### PR TITLE
[DPE-7584] Bump version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "postgresql-charms-single-kernel"
 description = "Shared and reusable code for PostgreSQL-related charms"
-version = "16.0.1"
+version = "16.0.2"
 readme = "README.md"
 license = "Apache-2.0"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -305,7 +305,7 @@ wheels = [
 
 [[package]]
 name = "postgresql-charms-single-kernel"
-version = "16.0.1"
+version = "16.0.2"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Issue
I forgot to bump the version on https://github.com/canonical/postgresql-single-kernel-library/pull/17 to allow the publishing of the library

## Solution
Bump the version.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
