### PR TITLE
[DPE-8997] Handle parameters with hyphen

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "postgresql-charms-single-kernel"
 description = "Shared and reusable code for PostgreSQL-related charms"
-version = "16.1.3"
+version = "16.1.4"
 readme = "README.md"
 license = {file = "LICENSE"}
 authors = [

--- a/single_kernel_postgresql/utils/postgresql.py
+++ b/single_kernel_postgresql/utils/postgresql.py
@@ -1731,9 +1731,15 @@ $$ LANGUAGE plpgsql security definer;"""  # noqa: S608
                 "vacuum",
             )):
                 continue
-            parameter = "_".join(config.split("_")[1:])
+			if "-" in config:
+            	parameter = "_".join(config.split("-")[1:])
+			else:
+				parameter = "_".join(config.split("_")[1:])
             if parameter in ["date_style", "time_zone"]:
-                parameter = "".join(x.capitalize() for x in parameter.split("_"))
+				if "-" in config:
+                	parameter = "".join(x.capitalize() for x in parameter.split("-"))
+				else:
+					parameter = "".join(x.capitalize() for x in parameter.split("_"))
             parameters[parameter] = value
         shared_buffers_max_value_in_mb = int(available_memory * 0.4 / 10**6)
         shared_buffers_max_value = int(shared_buffers_max_value_in_mb * 10**3 / 8)

--- a/single_kernel_postgresql/utils/postgresql.py
+++ b/single_kernel_postgresql/utils/postgresql.py
@@ -1731,15 +1731,15 @@ $$ LANGUAGE plpgsql security definer;"""  # noqa: S608
                 "vacuum",
             )):
                 continue
-			if "-" in config:
-            	parameter = "_".join(config.split("-")[1:])
-			else:
-				parameter = "_".join(config.split("_")[1:])
+            if "-" in config:
+                parameter = "_".join(config.split("-")[1:])
+            else:
+                parameter = "_".join(config.split("_")[1:])
             if parameter in ["date_style", "time_zone"]:
-				if "-" in config:
-                	parameter = "".join(x.capitalize() for x in parameter.split("-"))
-				else:
-					parameter = "".join(x.capitalize() for x in parameter.split("_"))
+                if "-" in config:
+                    parameter = "".join(x.capitalize() for x in parameter.split("-"))
+                else:
+                    parameter = "".join(x.capitalize() for x in parameter.split("_"))
             parameters[parameter] = value
         shared_buffers_max_value_in_mb = int(available_memory * 0.4 / 10**6)
         shared_buffers_max_value = int(shared_buffers_max_value_in_mb * 10**3 / 8)

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "postgresql-charms-single-kernel"
-version = "16.1.3"
+version = "16.1.4"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Issue
We forgot that we need to split parameters by a hyphen when the config option follows the new format

## Solution
Add the split by a hyphen logic.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
