### PR TITLE
[MISC] Reset role during user deletion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "postgresql-charms-single-kernel"
 description = "Shared and reusable code for PostgreSQL-related charms"
-version = "16.1.5"
+version = "16.1.6"
 readme = "README.md"
 license = {file = "LICENSE"}
 authors = [

--- a/single_kernel_postgresql/utils/postgresql.py
+++ b/single_kernel_postgresql/utils/postgresql.py
@@ -654,6 +654,7 @@ class PostgreSQL:
 
             # Delete the user.
             with self._connect_to_database() as connection, connection.cursor() as cursor:
+                cursor.execute(SQL("RESET ROLE;"))
                 cursor.execute(SQL("DROP ROLE {};").format(Identifier(user)))
         except psycopg2.Error as e:
             logger.error(f"Failed to delete user: {e}")

--- a/single_kernel_postgresql/utils/postgresql.py
+++ b/single_kernel_postgresql/utils/postgresql.py
@@ -644,6 +644,7 @@ class PostgreSQL:
                 with self._connect_to_database(
                     database
                 ) as connection, connection.cursor() as cursor:
+                    cursor.execute(SQL("RESET ROLE;"))
                     cursor.execute(
                         SQL("REASSIGN OWNED BY {} TO {};").format(
                             Identifier(user), Identifier(self.user)


### PR DESCRIPTION
PGB k8s was failing to reassign objects and delete users when breaking a relation with a PG 16 charm

Tested on https://github.com/canonical/pgbouncer-k8s-operator/pull/658

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
