### PR TITLE
[DPE-9451] Don't pass roles to alter user

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "postgresql-charms-single-kernel"
 description = "Shared and reusable code for PostgreSQL-related charms"
-version = "16.1.8"
+version = "16.1.9"
 readme = "README.md"
 license = {file = "LICENSE"}
 authors = [

--- a/single_kernel_postgresql/utils/postgresql.py
+++ b/single_kernel_postgresql/utils/postgresql.py
@@ -412,16 +412,22 @@ class PostgreSQL:
                 )
                 if cursor.fetchone() is not None:
                     user_definition = "ALTER ROLE {} "
+                    altering = True
                 else:
                     user_definition = "CREATE ROLE {} "
+                    altering = False
                 user_definition += f"WITH LOGIN{' SUPERUSER' if admin else ''}{' REPLICATION' if replication else ''} ENCRYPTED PASSWORD '{password}'"
-                user_definition, connect_statements = self._adjust_user_definition(
-                    user, roles, database, user_definition
-                )
-                if can_create_database:
-                    user_definition += " CREATEDB"
-                if privileges:
-                    user_definition += f" {' '.join(privileges)}"
+                if not altering:
+                    user_definition, connect_statements = self._adjust_user_definition(
+                        user, roles, database, user_definition
+                    )
+                    if can_create_database:
+                        user_definition += " CREATEDB"
+                    if privileges:
+                        user_definition += f" {' '.join(privileges)}"
+                else:
+                    db_roles, connect_statements = self._adjust_user_roles(user, roles, database)
+                    roles = [*db_roles, *roles]
                 cursor.execute(SQL("RESET ROLE;"))
                 cursor.execute(SQL("BEGIN;"))
                 cursor.execute(SQL("SET LOCAL log_statement = 'none';"))

--- a/tests/unit/test_postgresql.py
+++ b/tests/unit/test_postgresql.py
@@ -752,7 +752,7 @@ def test_create_user():
         pg.create_user("username", "password", True, True, ["role3"], "db1", True)
 
         _process_extra_user_roles.assert_called_once_with("username", ["role3"])
-        assert _cursor.execute.call_count == 8
+        assert _cursor.execute.call_count == 10
         _cursor.execute.assert_any_call(
             Composed([
                 SQL("SELECT TRUE FROM pg_roles WHERE rolname="),
@@ -767,12 +767,28 @@ def test_create_user():
             Composed([
                 SQL("ALTER ROLE "),
                 Identifier("username"),
-                SQL(
-                    ' WITH LOGIN SUPERUSER REPLICATION ENCRYPTED PASSWORD \'password\' IN ROLE "charmed_db1_admin", "charmed_db1_dml" CREATEDB priv1 priv2;'
-                ),
+                SQL(" WITH LOGIN SUPERUSER REPLICATION ENCRYPTED PASSWORD 'password';"),
             ])
         )
         _cursor.execute.assert_any_call(SQL("COMMIT;"))
+        _cursor.execute.assert_any_call(
+            Composed([
+                SQL("GRANT "),
+                Identifier("charmed_db1_admin"),
+                SQL(" TO "),
+                Identifier("username"),
+                SQL(";"),
+            ])
+        )
+        _cursor.execute.assert_any_call(
+            Composed([
+                SQL("GRANT "),
+                Identifier("charmed_db1_dml"),
+                SQL(" TO "),
+                Identifier("username"),
+                SQL(";"),
+            ])
+        )
         _cursor.execute.assert_any_call(
             Composed([
                 SQL("GRANT "),

--- a/uv.lock
+++ b/uv.lock
@@ -286,7 +286,7 @@ wheels = [
 
 [[package]]
 name = "postgresql-charms-single-kernel"
-version = "16.1.8"
+version = "16.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "ops", version = "2.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Issue
Repeated calls to `create_user` will fail due to wrong `ALTER ROLE` syntax

## Solution
Remove `IN ROLE` when altering a user and move additional roles to `GRANT`

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
