### PR TITLE
[DPE-10416] feat: migrate architecture guard to single kernel

### DIFF
--- a/single_kernel_postgresql/utils/arch.py
+++ b/single_kernel_postgresql/utils/arch.py
@@ -1,0 +1,46 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Utilities for catching and raising architecture errors."""
+
+import logging
+import os
+import sys
+
+from ops.charm import CharmBase
+from ops.model import BlockedStatus
+
+logger = logging.getLogger(__name__)
+
+
+class WrongArchitectureWarningCharm(CharmBase):
+    """A fake charm class that only signals a wrong architecture deploy."""
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.unit.status = BlockedStatus(
+            f"Error: Charm version incompatible with {os.uname().machine} architecture"
+        )
+        sys.exit(0)
+
+
+def is_wrong_architecture() -> bool:
+    """Checks if charm was deployed on wrong architecture."""
+    manifest_file_path = f"{os.environ.get('CHARM_DIR')}/manifest.yaml"
+    if not os.path.exists(manifest_file_path):
+        logger.error(
+            "Cannot check architecture: manifest file not found in %s", manifest_file_path
+        )
+        return False
+
+    with open(manifest_file_path) as file:
+        manifest = file.read()
+    hw_arch = os.uname().machine
+    if ("amd64" in manifest and hw_arch == "x86_64") or (
+        "arm64" in manifest and hw_arch == "aarch64"
+    ):
+        logger.info("Charm architecture matches")
+        return False
+
+    logger.error("Charm architecture does not match")
+    return True

--- a/tests/unit/test_arch.py
+++ b/tests/unit/test_arch.py
@@ -1,0 +1,43 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+import unittest.mock as mock
+from unittest.mock import patch
+
+from single_kernel_postgresql.utils.arch import is_wrong_architecture
+
+
+def test_wrong_architecture_file_not_found():
+    """Returns False when the manifest file does not exist."""
+    with (
+        patch("single_kernel_postgresql.utils.arch.os.environ.get", return_value="/tmp"),
+        patch("single_kernel_postgresql.utils.arch.os.path.exists", return_value=False),
+    ):
+        assert not is_wrong_architecture()
+
+
+def test_wrong_architecture_amd64():
+    """Correctly identifies architecture when the charm is AMD."""
+    with (
+        patch("single_kernel_postgresql.utils.arch.os.environ.get", return_value="/tmp"),
+        patch("single_kernel_postgresql.utils.arch.os.path.exists", return_value=True),
+        patch("builtins.open", mock.mock_open(read_data="amd64\n")),
+        patch("single_kernel_postgresql.utils.arch.os.uname") as _uname,
+    ):
+        _uname.return_value = mock.Mock(machine="x86_64")
+        assert not is_wrong_architecture()
+        _uname.return_value = mock.Mock(machine="aarch64")
+        assert is_wrong_architecture()
+
+
+def test_wrong_architecture_arm64():
+    """Correctly identifies architecture when the charm is ARM."""
+    with (
+        patch("single_kernel_postgresql.utils.arch.os.environ.get", return_value="/tmp"),
+        patch("single_kernel_postgresql.utils.arch.os.path.exists", return_value=True),
+        patch("builtins.open", mock.mock_open(read_data="arm64\n")),
+        patch("single_kernel_postgresql.utils.arch.os.uname") as _uname,
+    ):
+        _uname.return_value = mock.Mock(machine="x86_64")
+        assert is_wrong_architecture()
+        _uname.return_value = mock.Mock(machine="aarch64")
+        assert not is_wrong_architecture()


### PR DESCRIPTION
## Issue

The architecture guard — `is_wrong_architecture()` and `WrongArchitectureWarningCharm` — lived only in the K8s charm (`src/arch_utils.py`); the VM charm handled architecture inline. There was no shared home for it.

## Solution

Migrate the guard into the library as substrate-neutral `single_kernel_postgresql/utils/arch.py`, with unit tests for the pure functions. Both charms can then import it (the VM charm wires it into its entrypoint); the import-time guard behaviour stays exercised in the charms.

Tested on https://github.com/canonical/postgresql-k8s-operator/pull/1589 and https://github.com/canonical/postgresql-operator/pull/1784.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.