### PR TITLE
[DPE-10418] feat: add K8s locale superset to single kernel

### DIFF
--- a/single_kernel_postgresql/config/locales.py
+++ b/single_kernel_postgresql/config/locales.py
@@ -1,7 +1,12 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""List of locales available in the snap."""
+"""Locales accepted by the PostgreSQL ``response_lc_*`` config options.
+
+``SNAP_LOCALES`` is the set the VM snap ships (it stages ``locales-all``). The
+K8s rock additionally ships ``C.utf8`` and ``POSIX`` (from the Ubuntu base's
+``libc-bin``), so ``K8S_LOCALES`` extends ``SNAP_LOCALES`` with those two.
+"""
 
 from typing import Literal
 
@@ -516,3 +521,7 @@ SNAP_LOCALES = Literal[
     "zu_ZA",
     "zu_ZA.utf8",
 ]
+
+
+# The K8s rock additionally ships these (from libc-bin); the VM snap does not.
+K8S_LOCALES = Literal[SNAP_LOCALES, "C.utf8", "POSIX"]

--- a/tests/unit/test_locales.py
+++ b/tests/unit/test_locales.py
@@ -1,0 +1,19 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+from typing import get_args
+
+from single_kernel_postgresql.config.locales import K8S_LOCALES, SNAP_LOCALES
+
+
+def test_snap_locales_exclude_k8s_only_entries():
+    members = get_args(SNAP_LOCALES)
+    assert "C" in members
+    assert "C.utf8" not in members
+    assert "POSIX" not in members
+
+
+def test_k8s_locales_extend_snap_with_rock_only_entries():
+    snap = set(get_args(SNAP_LOCALES))
+    k8s = set(get_args(K8S_LOCALES))
+    assert k8s - snap == {"C.utf8", "POSIX"}
+    assert snap - k8s == set()


### PR DESCRIPTION
## Issue

The `response_lc_monetary` / `response_lc_numeric` / `response_lc_time` config options validate against a locale allow-list. #137 added `SNAP_LOCALES` — the set the VM snap ships (it stages `locales-all`) — and used it for `CharmConfig`. But the K8s rock additionally ships two locales the snap does not, so a single list rejects otherwise-valid K8s values.

## Solution

Keep #137's `SNAP_LOCALES` and add `K8S_LOCALES = Literal[SNAP_LOCALES, "C.utf8", "POSIX"]` (with a unit test), extending it **by reference** (no list duplication) with the two rock-only entries:

- `C.utf8` is a compiled locale shipped by Ubuntu's essential `libc-bin`. The K8s rock has it via its `ubuntu@24.04` base; the snap stages `locales-all` (which omits `C.utf8`), not `libc-bin`, so the VM workload genuinely lacks it.
- `POSIX` is a glibc built-in (an alias for `C`) with no `/usr/lib/locale` directory. `locale -a` (K8s) always reports it; `ls /usr/lib/locale` (VM) cannot, so the VM only has `C`.

That difference needs to be investigated separately in the snap and rock.

`K8SCharmConfig` (#150) validates against `K8S_LOCALES`, while the VM `CharmConfig` keeps `SNAP_LOCALES` — so each substrate validates against exactly what its workload provides.

Tested on https://github.com/canonical/postgresql-k8s-operator/pull/1589 and https://github.com/canonical/postgresql-operator/pull/1769.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.