### PR TITLE
[DPE-10608] Operator-cert manager, events handler + release (3/4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "postgresql-charms-single-kernel"
 description = "Shared and reusable code for PostgreSQL-related charms"
-version = "16.3.2"
+version = "16.3.3"
 readme = "README.md"
 license = {file = "LICENSE"}
 authors = [

--- a/single_kernel_postgresql/charms/abstract_charm.py
+++ b/single_kernel_postgresql/charms/abstract_charm.py
@@ -9,6 +9,7 @@ from ops.charm import CharmBase
 
 from single_kernel_postgresql.core.state import CharmState
 from single_kernel_postgresql.events.postgresql import PostgreSQLEventsHandler
+from single_kernel_postgresql.events.tls import TLS
 from single_kernel_postgresql.managers.cluster import ClusterManager
 from single_kernel_postgresql.managers.config import ConfigManager
 from single_kernel_postgresql.managers.patroni import PatroniManager
@@ -28,8 +29,17 @@ class AbstractPostgreSQLCharm(CharmBase, ABC):
         # State
         self.state = CharmState(charm=self, substrate=self.substrate)
 
+        # TLS events handler owns the two certificate requirers; build it before the
+        # TLS manager so the manager can constructor-inject them for its live-fetch getters.
+        self.tls = TLS(self, self.state)
+
         # Managers
-        self.tls_manager = TLSManager(state=self.state, workload=self.workload)
+        self.tls_manager = TLSManager(
+            state=self.state,
+            workload=self.workload,
+            client_certificate=self.tls.client_certificate,
+            peer_certificate=self.tls.peer_certificate,
+        )
         self.patroni_manager = PatroniManager(state=self.state, workload=self.workload)
         self.cluster_manager = ClusterManager(state=self.state, workload=self.workload)
         self.config_manager = ConfigManager(state=self.state, workload=self.workload)

--- a/single_kernel_postgresql/core/state.py
+++ b/single_kernel_postgresql/core/state.py
@@ -8,11 +8,12 @@ import re
 import socket
 from contextlib import suppress
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, get_args
+from typing import Any, get_args
 
 from data_platform_helpers.advanced_statuses import StatusesState, StatusObject
 from data_platform_helpers.advanced_statuses.types import Scope as AdvancedStatusesScope
 from ops import (
+    CharmBase,
     ConfigData,
     JujuVersion,
     ModelError,
@@ -43,16 +44,13 @@ from single_kernel_postgresql.utils import unit_name_to_pod_name
 from single_kernel_postgresql.utils.secret import translate_field_to_secret_key
 from single_kernel_postgresql.utils.status import format_status
 
-if TYPE_CHECKING:
-    from single_kernel_postgresql.charms.abstract_charm import AbstractPostgreSQLCharm
-
 
 class CharmState(Object):
     """The global PostgreSQL Charm State."""
 
     def __init__(
         self,
-        charm: "AbstractPostgreSQLCharm",
+        charm: CharmBase,
         substrate: Substrates,
     ) -> None:
         """Initialize the CharmState object."""
@@ -245,12 +243,63 @@ class CharmState(Object):
     @property
     def common_hosts(self) -> set[str]:
         """Common hosts to be used in TLS certificate SANs."""
-        return {self.host, self.fqdn} if self.fqdn else {self.host}
+        hosts = {self.host, self.fqdn} if self.fqdn else {self.host}
+        if self.substrate == Substrates.K8S:
+            namespace = self.model.name
+            hosts |= {
+                f"{self.model.app.name}-primary.{namespace}.svc.cluster.local",
+                f"{self.model.app.name}-replicas.{namespace}.svc.cluster.local",
+                # the original K8s charm also included the resolved per-pod FQDN.
+                socket.getfqdn(),
+            }
+        return hosts
 
     @property
     def peer_common_name(self) -> str:
         """Return the common name for the internally generated peer certificate."""
+        if self.substrate == Substrates.K8S:
+            return self._k8s_cert_common_name
         return self.peer.database_peers_address or self.host
+
+    @property
+    def client_addresses(self) -> set[str]:
+        """Client-facing addresses for the operator client certificate SANs."""
+        addrs: set[str] = set()
+        if addr := self.peer.database_address:
+            addrs.add(addr)
+        return addrs
+
+    @property
+    def client_common_name(self) -> str:
+        """Common name for the operator client certificate."""
+        if self.substrate == Substrates.K8S:
+            return self._k8s_cert_common_name
+        return self.peer.database_address or self.host
+
+    @property
+    def _k8s_cert_common_name(self) -> str:
+        """K8s operator-cert CN: the unit endpoints FQDN, wildcarded if too long.
+
+        Matches the original K8s charm: ``<app>-<unit_id>.<app>-endpoints``, collapsing to
+        ``*.<app>-endpoints`` when the full FQDN exceeds the 64-char CN limit. The
+        migration had switched this to the VM-style ``database_address/peers_address or
+        host``; restore the endpoints-FQDN CN for K8s parity.
+        """
+        full = self._get_hostname_from_unit(unit_name_to_pod_name(self.model.unit.name))
+        if len(full) > 64:
+            return f"*.{self.model.app.name}-endpoints"
+        return full
+
+    @property
+    def peer_addresses(self) -> set[str]:
+        """Peer addresses for the operator peer certificate SANs (substrate-aware).
+
+        K8s excludes the ``ip`` databag key (original K8s charm never added an ``ip`` SAN);
+        VM keeps it (unchanged from pre-migration behavior).
+        """
+        if self.substrate == Substrates.K8S:
+            return self.peer.peer_addresses_no_ip
+        return self.peer.peer_addresses
 
     @property
     def listen_ips(self) -> list[str]:

--- a/single_kernel_postgresql/core/state.py
+++ b/single_kernel_postgresql/core/state.py
@@ -281,9 +281,7 @@ class CharmState(Object):
         """K8s operator-cert CN: the unit endpoints FQDN, wildcarded if too long.
 
         Matches the original K8s charm: ``<app>-<unit_id>.<app>-endpoints``, collapsing to
-        ``*.<app>-endpoints`` when the full FQDN exceeds the 64-char CN limit. The
-        migration had switched this to the VM-style ``database_address/peers_address or
-        host``; restore the endpoints-FQDN CN for K8s parity.
+        ``*.<app>-endpoints`` when the full FQDN exceeds the 64-char CN limit.
         """
         full = self._get_hostname_from_unit(unit_name_to_pod_name(self.model.unit.name))
         if len(full) > 64:

--- a/single_kernel_postgresql/events/tls.py
+++ b/single_kernel_postgresql/events/tls.py
@@ -1,0 +1,151 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""TLS events handler — owns the operator-certificate requirers, delegates to TLSManager."""
+
+import logging
+
+from charmlibs.interfaces.tls_certificates import (
+    CertificateRequestAttributes,
+    TLSCertificatesRequiresV4,
+)
+from ops import EventSource
+from ops.framework import EventBase, Object
+
+from single_kernel_postgresql.config.exceptions import PostgreSQLFileOperationError
+from single_kernel_postgresql.config.literals import (
+    PEER_RELATION,
+    TLS_CLIENT_RELATION,
+    TLS_PEER_RELATION,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class RefreshTLSCertificatesEvent(EventBase):
+    """Event emitted to trigger a re-request of TLS certificates with updated SANs."""
+
+
+class TLS(Object):
+    """Owns the client/peer certificate requirers and pushes assigned certs to the workload.
+
+    Operator-certificate handler: observes certificate_available and triggers a
+    file-push via TLSManager. Also owns the refresh_tls_certificates_event that
+    re-requests certificates whenever SANs change (emitted on peer relation_changed).
+
+    Design notes
+    ------------
+    1. **Live-fetch model.** Operator cert/key are read live from the requirers
+       (TLSManager.get_*_tls_files call get_assigned_certificates() on demand) and are
+       never persisted — matching the pre-port charm. Only the peer CA is tracked in
+       state (``current-ca`` / ``old-ca``) so the CA bundle can include the previous CA
+       across a rotation; the requirer holds only the current cert. The manager is
+       constructor-injected with these requirers and reads from them at call time.
+
+    2. **CA bundle terminology.** The ``current_ca`` term used in state mirrors the
+       charm's live operator-CA term. It refers to the most recent peer CA from the TLS
+       operator, not the internal self-signed CA.
+
+    3. **SANs and the relation_changed trigger.** The ``relation_changed``-driven
+       ``refresh_tls_certificates_event`` is a stand-in for the charm's IP-change
+       trigger.  The client/peer SANs in the certificate requests remain inert until
+       the cluster (address-writer) code migrates and starts writing
+       ``database-address`` / ``database-peers-address`` keys into the peer databag.
+    """
+
+    refresh_tls_certificates_event = EventSource(RefreshTLSCertificatesEvent)
+
+    def __init__(self, charm, state):
+        super().__init__(charm, key="tls")
+        self.charm = charm
+        self.state = state
+
+        client_addresses = self.state.client_addresses
+        peer_addresses = self.state.peer_addresses
+
+        self.client_certificate = TLSCertificatesRequiresV4(
+            self.charm,
+            TLS_CLIENT_RELATION,
+            certificate_requests=[
+                CertificateRequestAttributes(
+                    common_name=self.state.client_common_name,
+                    sans_ip=frozenset(client_addresses),
+                    sans_dns=frozenset({*self.state.common_hosts, *client_addresses}),
+                ),
+            ],
+            refresh_events=[self.refresh_tls_certificates_event],
+        )
+        self.peer_certificate = TLSCertificatesRequiresV4(
+            self.charm,
+            TLS_PEER_RELATION,
+            certificate_requests=[
+                CertificateRequestAttributes(
+                    common_name=self.state.peer_common_name,
+                    sans_ip=frozenset(peer_addresses),
+                    sans_dns=frozenset({*self.state.common_hosts, *peer_addresses}),
+                ),
+            ],
+            refresh_events=[self.refresh_tls_certificates_event],
+        )
+
+        # The TLS manager is constructor-injected with these requirers (built in
+        # AbstractPostgreSQLCharm right after this handler); its live-fetch getters
+        # read cert/key from them. This handler reaches the manager via self.charm.
+
+        self.framework.observe(
+            self.client_certificate.on.certificate_available, self._on_certificate_available
+        )
+        self.framework.observe(
+            self.peer_certificate.on.certificate_available, self._on_peer_certificate_available
+        )
+        self.framework.observe(
+            self.charm.on[TLS_CLIENT_RELATION].relation_broken, self._on_certificate_available
+        )
+        self.framework.observe(
+            self.charm.on[TLS_PEER_RELATION].relation_broken, self._on_peer_certificate_available
+        )
+        self.framework.observe(
+            self.charm.on[PEER_RELATION].relation_changed, self._on_peer_relation_changed
+        )
+
+    def _on_peer_relation_changed(self, event) -> None:
+        """Re-request certificates when peer addresses change.
+
+        Fires on any peer-databag change: the address keys this should key on
+        (``database-address`` / ``database-peers-address``) are only written once
+        the cluster address-writer code migrates (see design note 3 above), and
+        the requirer no-ops when the resulting SANs are unchanged.
+        """
+        self.refresh_tls_certificates_event.emit()
+
+    def _push_tls_files(self, event) -> None:
+        """Guard-then-push helper: defer if the workload is not yet ready.
+
+        Two conditions must hold before files can be written:
+        1. The internal CA secret must exist — it is written by the leader on
+           leader-elected, so non-leaders and early hooks may see it absent.
+        2. The workload must accept file writes — on K8s the Pebble container
+           may not be ready yet, causing PostgreSQLFileOperationError.
+        """
+        if not self.state.application.internal_ca:
+            logger.debug("Internal CA not yet present; deferring TLS file push.")
+            event.defer()
+            return
+        try:
+            self.charm.tls_manager.push_tls_files()
+        except PostgreSQLFileOperationError:
+            logger.debug("Workload not ready for TLS file write; deferring.")
+            event.defer()
+
+    def _on_certificate_available(self, event) -> None:
+        """Push TLS files; the operator client cert/key is read live at push time."""
+        self._push_tls_files(event)
+
+    def _on_peer_certificate_available(self, event) -> None:
+        """Rotate the peer CA if it changed, then push (cert/key read live at push time)."""
+        certs, _ = self.peer_certificate.get_assigned_certificates()
+        new_ca = str(certs[0].ca) if certs else None
+        if new_ca is not None:
+            self.charm.tls_manager.rotate_peer_ca(new_ca)
+        else:
+            self.charm.tls_manager.clear_peer_ca()
+        self._push_tls_files(event)

--- a/single_kernel_postgresql/managers/tls.py
+++ b/single_kernel_postgresql/managers/tls.py
@@ -13,6 +13,7 @@ from datetime import timedelta
 from charmlibs.interfaces.tls_certificates import (
     Certificate,
     PrivateKey,
+    TLSCertificatesRequiresV4,
     generate_ca,
     generate_certificate,
     generate_csr,
@@ -21,9 +22,13 @@ from charmlibs.interfaces.tls_certificates import (
 from data_platform_helpers.advanced_statuses import StatusObject
 from data_platform_helpers.advanced_statuses.types import Scope as AdvancedStatusesScope
 
-from single_kernel_postgresql.config.exceptions import TlsError
+from single_kernel_postgresql.config.exceptions import PostgreSQLFileOperationError, TlsError
 from single_kernel_postgresql.config.literals import (
     APP_SCOPE,
+    TLS_CA_BUNDLE_FILE,
+    TLS_CA_FILE,
+    TLS_CERT_FILE,
+    TLS_KEY_FILE,
 )
 from single_kernel_postgresql.config.statuses import GeneralStatuses
 from single_kernel_postgresql.core.state import CharmState
@@ -39,8 +44,20 @@ class TLSManager(BaseManager):
     This manager is responsible for handling TLS configuration operations.
     """
 
-    def __init__(self, state: CharmState, workload: BaseWorkload):
+    def __init__(
+        self,
+        state: CharmState,
+        workload: BaseWorkload,
+        client_certificate: TLSCertificatesRequiresV4,
+        peer_certificate: TLSCertificatesRequiresV4,
+    ) -> None:
         super().__init__(state, workload, "tls_manager")
+        # Operator-certificate requirers, constructor-injected by events.tls.TLS.
+        # The getters below fetch cert/key LIVE from the durable relation databag — no
+        # operator cert/key is persisted to state (matches the pre-port charm). Only the
+        # peer CA is tracked in state (current-ca / old-ca), for rotation.
+        self.client_certificate = client_certificate
+        self.peer_certificate = peer_certificate
 
     def configure_internal_peer_ca(self) -> None:
         """Configure TLS internal peer CA."""
@@ -64,19 +81,22 @@ class TLSManager(BaseManager):
         csr = generate_csr(
             private_key,
             common_name=self.state.peer_common_name,
-            sans_ip=frozenset(self.state.peer.peer_addresses),
+            # substrate-aware: K8s excludes the ip SAN (matches the original charm).
+            sans_ip=frozenset(self.state.peer_addresses),
             sans_dns=frozenset({
                 *self.state.common_hosts,
                 # IP address need to be part of the DNS SANs list due to
                 # https://github.com/pgbackrest/pgbackrest/issues/1977.
-                *self.state.peer.peer_addresses,
+                *self.state.peer_addresses,
             }),
         )
         cert = generate_certificate(csr, ca, ca_key, validity=timedelta(days=7300))
         self.state.peer.internal_cert = str(cert)
         self.state.peer.internal_key = str(private_key)
 
-        # self.charm.push_tls_files_to_workload()
+        # NOTE: pushing the internal-peer cert/CA to disk is owned by the config
+        # subsystem (not yet migrated); operator certs are pushed via
+        # TLSManager.push_tls_files from the events.tls handler.
         logger.info(
             "Internal peer certificate generated. Please use a proper TLS operator if possible."
         )
@@ -92,6 +112,136 @@ class TLSManager(BaseManager):
         logger.warning("Internal peer CA generated. Please use a proper TLS operator if possible.")
         self.state.set_secret(APP_SCOPE, "internal-ca-key", str(private_key))
         self.state.set_secret(APP_SCOPE, "internal-ca", str(ca))
+
+    def rotate_peer_ca(self, ca: str) -> None:
+        """Track the operator peer CA for rotation (current-ca -> old-ca).
+
+        Only the CA is tracked in state; the operator cert/key are fetched live
+        from the requirer.
+        """
+        if ca != self.state.peer.current_ca:
+            if self.state.peer.current_ca:
+                self.state.peer.old_ca = self.state.peer.current_ca
+            else:
+                # Re-enabling after a disable cleared current-ca: nothing is being
+                # rotated out, so drop any stale old CA left from before the disable.
+                self.state.peer.remove_secret("old-ca")
+            self.state.peer.current_ca = ca
+
+    def clear_peer_ca(self) -> None:
+        """Retire the operator peer CA into old-ca on relation removal."""
+        current = self.state.peer.current_ca
+        if current:
+            self.state.peer.old_ca = current
+        self.state.peer.remove_secret("current-ca")
+
+    def get_client_tls_files(self) -> tuple[str | None, str | None, str | None]:
+        """Return (key, ca, cert) for the operator client cert, fetched live.
+
+        Reads from the requirer's assigned certificate (the durable relation
+        databag) rather than persisted state — matches the pre-port charm.
+        """
+        key = ca = cert = None
+        if self.client_certificate is not None:
+            certs, private_key = self.client_certificate.get_assigned_certificates()
+            if private_key:
+                key = str(private_key)
+            if certs:
+                cert = str(certs[0].certificate)
+                ca = str(certs[0].ca)
+        return key, ca, cert
+
+    def client_tls_files_on_disk(self) -> bool:
+        """Whether the client TLS files this unit serves are present on disk.
+
+        The reload bridge checks this before enabling TLS in the config so it never
+        renders ssl:on against files the push has not yet written: on K8s the Pebble
+        push can defer while the local config render would still succeed. A workload
+        that cannot be read (container down) counts as not-on-disk, so the caller defers.
+        """
+        tls = self.workload.paths.tls
+        try:
+            return all(
+                self.workload.exists(tls / f) for f in (TLS_KEY_FILE, TLS_CERT_FILE, TLS_CA_FILE)
+            )
+        except PostgreSQLFileOperationError:
+            return False
+
+    def get_peer_ca_bundle(self) -> str:
+        """Compose the peer CA bundle: live operator CA, old CA, internal CA.
+
+        The current operator CA is read live from the requirer (pre-port style);
+        the old CA and internal CA come from state.
+        """
+        operator_ca = ""
+        if self.peer_certificate is not None:
+            certs, _ = self.peer_certificate.get_assigned_certificates()
+            operator_ca = str(certs[0].ca) if certs else ""
+        cas = [
+            operator_ca,
+            self.state.peer.old_ca,
+            self.state.get_secret(APP_SCOPE, "internal-ca"),
+        ]
+        return "\n".join(ca for ca in cas if ca).strip()
+
+    def get_peer_tls_files(self) -> tuple[str | None, str | None, str | None]:
+        """Return (key, ca, cert) for the peer certificate, operator cert fetched live.
+
+        Prefers the operator-provided peer material (read live from the requirer,
+        with the composed CA bundle); falls back to the internally generated peer
+        material.
+        """
+        key = cert = None
+        if self.peer_certificate is not None:
+            certs, private_key = self.peer_certificate.get_assigned_certificates()
+            if private_key:
+                key = str(private_key)
+            if certs:
+                cert = str(certs[0].certificate)
+        if not all((key, cert)):
+            return (
+                self.state.peer.internal_key,
+                self.state.get_secret(APP_SCOPE, "internal-ca"),
+                self.state.peer.internal_cert,
+            )
+        return key, self.get_peer_ca_bundle(), cert
+
+    def _write_tls_file(self, content: str, path) -> None:
+        """Write a TLS file with substrate-specific permissions and ownership.
+
+        The mode comes from the workload (VM 0o600, K8s 0o400, matching the
+        pre-migration charms). Ownership is forwarded through pathops so it works
+        on both VM (LocalPath uses os.chown) and K8s (ContainerPath uses Pebble push).
+        """
+        self.workload.write_text(
+            content,
+            path,
+            self.workload.tls_file_mode,
+            user=self.workload.user,
+            group=self.workload.group,
+        )
+
+    def push_tls_files(self) -> None:
+        """Write the client, peer, and CA-bundle TLS files to the workload."""
+        tls = self.workload.paths.tls
+
+        key, ca, cert = self.get_client_tls_files()
+        if key is not None:
+            self._write_tls_file(key, tls / TLS_KEY_FILE)
+        if ca is not None:
+            self._write_tls_file(ca, tls / TLS_CA_FILE)
+        if cert is not None:
+            self._write_tls_file(cert, tls / TLS_CERT_FILE)
+
+        key, ca, cert = self.get_peer_tls_files()
+        if key is not None:
+            self._write_tls_file(key, tls / f"peer_{TLS_KEY_FILE}")
+        if ca is not None:
+            self._write_tls_file(ca, tls / f"peer_{TLS_CA_FILE}")
+        if cert is not None:
+            self._write_tls_file(cert, tls / f"peer_{TLS_CERT_FILE}")
+
+        self._write_tls_file(self.get_peer_ca_bundle(), tls / TLS_CA_BUNDLE_FILE)
 
     def get_statuses(
         self, scope: AdvancedStatusesScope, recompute: bool = False

--- a/tests/unit/test_tls_client_addrs.py
+++ b/tests/unit/test_tls_client_addrs.py
@@ -1,0 +1,50 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Tests for TLS client address and common-name state accessors."""
+
+
+def _set_unit_db(harness, key, value):
+    rel_id = harness.model.get_relation("database-peers").id
+    harness.update_relation_data(rel_id, harness.charm.unit.name, {key: value})
+
+
+def test_database_address_reads_unit_databag(harness):
+    _set_unit_db(harness, "database-address", "10.1.2.3")
+    assert harness.charm.state.peer.database_address == "10.1.2.3"
+
+
+def test_database_address_none_when_unset(harness):
+    assert harness.charm.state.peer.database_address is None
+
+
+def test_client_addresses_set(harness):
+    _set_unit_db(harness, "database-address", "10.1.2.3")
+    assert harness.charm.state.client_addresses == {"10.1.2.3"}
+
+
+def test_client_addresses_empty_when_unset(harness):
+    assert harness.charm.state.client_addresses == set()
+
+
+def test_client_common_name_prefers_database_address(substrate, harness):
+    _set_unit_db(harness, "database-address", "10.1.2.3")
+    state = harness.charm.state
+    if substrate == "vm":
+        # VM: CN follows the database-address databag value.
+        assert state.client_common_name == "10.1.2.3"
+    else:
+        # K8s: CN is the endpoints FQDN, not the databag address.
+        app = state.model.app.name
+        assert state.client_common_name == f"{app}-0.{app}-endpoints"
+
+
+def test_client_common_name_falls_back_to_host(substrate, harness):
+    state = harness.charm.state
+    if substrate == "vm":
+        # VM: falls back to host when no databag address is set.
+        assert state.client_common_name == state.host
+    else:
+        # K8s: no fallback — always the endpoints FQDN.
+        app = state.model.app.name
+        assert state.client_common_name == f"{app}-0.{app}-endpoints"

--- a/tests/unit/test_tls_state.py
+++ b/tests/unit/test_tls_state.py
@@ -1,0 +1,138 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Tests for TLS state accessors on PostgreSQLPeer.
+
+Operator cert/key are fetched live from the requirer and are NOT held in peer
+state; only the peer CA rotation slots (current-ca / old-ca) and the internal
+peer material live here.
+"""
+
+import socket
+from unittest.mock import patch
+
+from single_kernel_postgresql.config.enums import Substrates  # noqa: F401  (substrate fixture)
+
+
+def _set_unit_db(harness, key, value):
+    rel_id = harness.model.get_relation("database-peers").id
+    harness.update_relation_data(rel_id, harness.charm.unit.name, {key: value})
+
+
+def test_common_hosts_k8s_includes_service_endpoints(substrate, harness):
+    """On K8s the cert-SAN source must carry the primary/replicas Service DNS."""
+    state = harness.charm.state
+    app = state.model.app.name
+    namespace = state.model.name
+    hosts = state.common_hosts
+
+    if substrate == "k8s":
+        assert f"{app}-primary.{namespace}.svc.cluster.local" in hosts
+        assert f"{app}-replicas.{namespace}.svc.cluster.local" in hosts
+        # host/fqdn still present
+        assert state.host in hosts
+        assert state.fqdn in hosts
+        # the resolved per-pod FQDN is also included (parity with the original charm)
+        assert socket.getfqdn() in hosts
+    else:
+        # VM: only host/fqdn — no k8s service DNS leaks in
+        assert not any(h.endswith(".svc.cluster.local") for h in hosts)
+        assert hosts == {state.host, state.fqdn}
+
+
+def test_ca_rotation_slots_roundtrip(harness):
+    peer = harness.charm.state.peer
+    peer.current_ca = "CA-1"
+    peer.old_ca = "CA-0"
+
+    assert peer.current_ca == "CA-1"
+    assert peer.old_ca == "CA-0"
+
+
+def test_unset_ca_slots_are_none(harness):
+    peer = harness.charm.state.peer
+    assert peer.current_ca is None
+    assert peer.old_ca is None
+
+
+# -- G1: substrate-aware cert common name (parity with the original charm) ----
+
+
+def test_cert_common_name_is_endpoints_fqdn_on_k8s(substrate, harness):
+    """K8s operator-cert CN must be `<app>-<unit_id>.<app>-endpoints` (original charm parity)."""
+    state = harness.charm.state
+    app = state.model.app.name
+    expected = f"{app}-0.{app}-endpoints"
+
+    if substrate == "k8s":
+        assert state.client_common_name == expected
+        assert state.peer_common_name == expected
+    else:
+        # VM unchanged: host-derived, not the endpoints FQDN.
+        assert state.client_common_name != expected
+        assert state.peer_common_name != expected
+
+
+def test_cert_common_name_wildcards_when_too_long_on_k8s(substrate, harness):
+    """K8s CN collapses to `*.<app>-endpoints` when the endpoints FQDN exceeds 64 chars."""
+    if substrate != "k8s":
+        return  # wildcard rule is K8s-only
+
+    state = harness.charm.state
+    app = state.model.app.name
+    # Force the endpoints FQDN past the 64-char CN limit; the suffix stays app-derived.
+    long_fqdn = "x" * 80
+    with patch.object(state, "_get_hostname_from_unit", return_value=long_fqdn):
+        assert state._k8s_cert_common_name == f"*.{app}-endpoints"
+
+
+def test_cert_common_name_vm_unchanged(substrate, harness):
+    """VM CN stays host-derived: client reads database-address, peer reads database-peers-address."""
+    if substrate != "vm":
+        return
+
+    _set_unit_db(harness, "database-address", "10.1.2.3")
+    _set_unit_db(harness, "database-peers-address", "10.4.5.6")
+    state = harness.charm.state
+    assert state.client_common_name == "10.1.2.3"
+    assert state.peer_common_name == "10.4.5.6"
+
+
+# -- G2: substrate-aware peer_addresses (no `ip` SAN on K8s) -----------------
+
+
+def test_peer_addresses_excludes_ip_on_k8s(substrate, harness):
+    """K8s peer SAN set must omit the `ip` databag key (original K8s charm never added it)."""
+    _set_unit_db(harness, "ip", "10.0.0.1")
+    _set_unit_db(harness, "private-address", "10.0.0.2")
+    _set_unit_db(harness, "database-peers-address", "10.0.0.3")
+
+    addrs = harness.charm.state.peer_addresses
+
+    if substrate == "k8s":
+        assert "10.0.0.1" not in addrs  # `ip` excluded
+        assert "10.0.0.2" in addrs  # private-address kept
+        assert "10.0.0.3" in addrs  # database-peers-address kept
+    else:
+        assert "10.0.0.1" in addrs  # VM keeps `ip`
+
+
+def test_peer_addresses_includes_ip_on_vm(substrate, harness):
+    """VM peer SAN set keeps `ip` (unchanged from pre-migration behavior)."""
+    if substrate != "vm":
+        return
+
+    _set_unit_db(harness, "ip", "10.0.0.1")
+    addrs = harness.charm.state.peer_addresses
+    assert "10.0.0.1" in addrs  # `ip` retained on VM (the G2 regression was K8s-only)
+
+
+def test_charmstate_accepts_plain_charmbase():
+    """CharmState must accept any ops.CharmBase, not only AbstractPostgreSQLCharm."""
+    import inspect
+
+    import ops
+    from single_kernel_postgresql.core.state import CharmState
+
+    ann = inspect.signature(CharmState.__init__).parameters["charm"].annotation
+    assert ann is ops.CharmBase

--- a/uv.lock
+++ b/uv.lock
@@ -982,7 +982,7 @@ wheels = [
 
 [[package]]
 name = "postgresql-charms-single-kernel"
-version = "16.3.2"
+version = "16.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "ops", version = "2.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
Part 3/4, stacked on tls-2-state-accessors. Wires the **operator-certificate manager + events handler** into the lib charm — the core of the live-fetch TLS subsystem — and bumps the library version.

## What's here
- `managers/tls.py` (`TLSManager`): live-fetch getters (`get_client_tls_files` / `get_peer_tls_files` / `get_peer_ca_bundle` call `get_assigned_certificates()` on demand — operator cert/key are **never persisted**), `push_tls_files`, `rotate_peer_ca` / `clear_peer_ca` (only the peer CA is tracked in state, for the rotation bundle), internal-peer CA/cert generation, and `client_tls_files_on_disk`.
- `events/tls.py` (`TLS`): owns the two `TLSCertificatesRequiresV4` requirers, observes `certificate_available` + `relation_broken`, defers the file-push until the workload is ready, re-requests certs on SAN changes. Reaches the manager via `self.charm.tls_manager`.
- `charms/abstract_charm.py`: builds `TLS` first, then `TLSManager` with the handler's requirers injected.
- `pyproject.toml` + `uv.lock`: bump to `16.3.3`.

