### PR TITLE
[DPE-10663] fix(patroni): handle unreachable cluster in get_member_status

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "postgresql-charms-single-kernel"
 description = "Shared and reusable code for PostgreSQL-related charms"
-version = "16.3.3"
+version = "16.3.4"
 readme = "README.md"
 license = {file = "LICENSE"}
 authors = [

--- a/single_kernel_postgresql/managers/patroni.py
+++ b/single_kernel_postgresql/managers/patroni.py
@@ -251,7 +251,11 @@ class PatroniManager(BaseManager):
                 couldn't be retrieved yet.
         """
         # Request info from cluster endpoint (which returns all members of the cluster).
-        cluster_status = self.cluster_status()
+        try:
+            cluster_status = self.cluster_status()
+        except RetryError:
+            logger.debug("Unable to get member status. Cluster status unreachable")
+            return ""
         if cluster_status:
             for member in cluster_status:
                 if member["name"] == member_name:

--- a/tests/unit/test_patroni_manager.py
+++ b/tests/unit/test_patroni_manager.py
@@ -105,6 +105,46 @@ def test_get_member_ip(patroni):
         assert patroni.get_member_ip("postgresql-0") == "1.1.1.1"
 
 
+def test_get_member_status(patroni):
+    with (
+        patch(
+            "single_kernel_postgresql.managers.patroni.parallel_patroni_get_request",
+            return_value=None,
+        ) as _parallel_patroni_get_request,
+        patch(
+            "single_kernel_postgresql.core.peer_relation.PostgreSQLApplication.patroni_password",
+            new_callable=PropertyMock,
+            return_value="test-pass",
+        ),
+        patch(
+            "single_kernel_postgresql.core.peer_relation.PostgreSQLApplication.endpoints",
+            new_callable=PropertyMock,
+            return_value=["endpoint1", "endpoint2", "endpoint3"],
+        ),
+        patch(
+            "single_kernel_postgresql.core.peer_relation.PostgreSQLApplication.members_ips",
+            new_callable=PropertyMock,
+            return_value=["ip1", "ip2", "ip3"],
+        ),
+        patch(
+            "single_kernel_postgresql.core.state.CharmState.endpoint",
+            new_callable=PropertyMock,
+            return_value="endpoint",
+        ),
+    ):
+        # An unreachable cluster (cluster_status raises RetryError) yields an empty
+        # status instead of propagating the exception.
+        assert patroni.get_member_status("postgresql-0") == ""
+
+        _parallel_patroni_get_request.return_value = {
+            "members": [
+                {"name": "postgresql-1", "state": "running"},
+                {"name": "postgresql-0", "state": "streaming"},
+            ]
+        }
+        assert patroni.get_member_status("postgresql-0") == "streaming"
+
+
 def test_get_patroni_health(patroni):
     with (
         patch(

--- a/uv.lock
+++ b/uv.lock
@@ -982,7 +982,7 @@ wheels = [
 
 [[package]]
 name = "postgresql-charms-single-kernel"
-version = "16.3.3"
+version = "16.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "ops", version = "2.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Issue

`test_backups_pitr_{aws,gcp}` integration tests fail intermittently (and the same signature recurs on base `16/edge`, so it is a pre-existing flake, not tied to a specific charm PR). The failure trace is:

```
File ".../charm.py", in _was_restore_successful
    if "failed" in self.patroni_manager.get_member_status(self._member_name):
File ".../single_kernel_postgresql/managers/patroni.py", line 254, in get_member_status
    cluster_status = self.cluster_status()
File ".../single_kernel_postgresql/managers/patroni.py", line 221, in cluster_status
    raise RetryError(
tenacity.RetryError: RetryError[...]
```

`get_member_status()` calls `cluster_status()` with no try/except, unlike its siblings `get_member_ip` / `get_primary` / `cluster_members`, which all catch the `RetryError` that `cluster_status()` raises when no Patroni endpoint responds. During a PITR restore, Patroni is intentionally stopped; the deferred `database-peers-relation-changed` is re-emitted inside the restore action hook and calls `_was_restore_successful() -> get_member_status() -> cluster_status()`, raising `RetryError`. The exception propagates uncaught and crashes the restore action hook with a non-zero exit, discarding the staged `restore-status` result and exhausting the integration test's 10x retry loop.

## Solution

Catch the `RetryError` in `get_member_status` and return `""` — the value the method's docstring already promises when the status cannot be retrieved — so callers see a clean early-exit instead of a hook crash. This mirrors the established `get_member_ip` pattern and fixes every caller of `get_member_status`, not just the restore path.

Added `test_get_member_status` (mirrors `test_get_member_ip`): asserts an unreachable cluster yields `""` (fails without this fix with the exact `RetryError`, passes with it) plus the normal member-state path.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.