### PR TITLE
[DPE-10735] feat(config): add peer-state config/user hash + tls unit accessors (1/6)

### DIFF
--- a/single_kernel_postgresql/core/peer_relation.py
+++ b/single_kernel_postgresql/core/peer_relation.py
@@ -225,6 +225,48 @@ class PostgreSQLPeer(RelationState):
             return True
         return self.relation.data[self.unit].get("connectivity", "on") == "on"
 
+    @property
+    def config_hash(self) -> str | None:
+        """Get the last-applied PostgreSQL config hash from the peer relation data."""
+        if not self.relation:
+            return None
+        return self.relation.data[self.unit].get("config_hash")
+
+    @config_hash.setter
+    def config_hash(self, value: str) -> None:
+        """Set the last-applied PostgreSQL config hash in the peer relation data."""
+        if not self.relation:
+            return
+        self.relation.data[self.unit]["config_hash"] = value
+
+    @property
+    def user_hash(self) -> str | None:
+        """Get the last-applied users hash from the peer relation data."""
+        if not self.relation:
+            return None
+        return self.relation.data[self.unit].get("user_hash")
+
+    @user_hash.setter
+    def user_hash(self, value: str) -> None:
+        """Set the last-applied users hash in the peer relation data."""
+        if not self.relation:
+            return
+        self.relation.data[self.unit]["user_hash"] = value
+
+    @property
+    def tls(self) -> bool:
+        """Get the last-rendered TLS flag from the peer relation data."""
+        if not self.relation:
+            return False
+        return self.relation.data[self.unit].get("tls") == "enabled"
+
+    @tls.setter
+    def tls(self, value: bool) -> None:
+        """Set the last-rendered TLS flag in the peer relation data."""
+        if not self.relation:
+            return
+        self.relation.data[self.unit]["tls"] = "enabled" if value else ""
+
     @cached_property
     def data(self) -> MutableMapping[str, str]:
         """Escape hatch method to access the peer data directly."""
@@ -417,6 +459,20 @@ class PostgreSQLApplication(RelationState):
     def is_ldap_enabled(self) -> bool:
         """Return whether this unit has LDAP enabled."""
         return self.is_ldap_charm_related and self.is_cluster_initialised
+
+    @property
+    def user_hash(self) -> str | None:
+        """Get the last-applied users hash from the peer relation data."""
+        if not self.relation:
+            return None
+        return self.relation.data[self.app].get("user_hash")
+
+    @user_hash.setter
+    def user_hash(self, value: str) -> None:
+        """Set the last-applied users hash in the peer relation data."""
+        if not self.relation:
+            return
+        self.relation.data[self.app]["user_hash"] = value
 
     def get_secret(self, key: str) -> str | None:
         """Get the secret value for 'key' from the peer relation data."""


### PR DESCRIPTION
## Issue

The `update_config` migration needs the config/user hash and the TLS flag to round-trip through the peer databag, as they do in both charms. This first step adds those accessors so later steps in the stack can read and persist them.

## Solution

Add plain-databag accessors on the peer-relation state, mirroring the existing `ip` / `is_connectivity_enabled` pattern:

- `PostgreSQLPeer.config_hash` / `user_hash` (`str | None`) and `PostgreSQLApplication.user_hash`.
- `PostgreSQLPeer.tls` (`bool`) — getter reads `"enabled"`, setter writes `"enabled"` / `""`.

First (code-only) PR in the update_config stack. Its unit tests land with the rest in the stack's test PR (#188).

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
