### PR TITLE
fix(utils): swallow ssl.SSLError from empty/corrupt CA bundle

### DIFF
--- a/single_kernel_postgresql/utils/__init__.py
+++ b/single_kernel_postgresql/utils/__init__.py
@@ -9,8 +9,7 @@ import re
 import secrets
 import string
 from asyncio import as_completed, create_task, run, wait
-from contextlib import suppress
-from ssl import CERT_NONE, create_default_context
+from ssl import CERT_NONE, SSLError, create_default_context
 from typing import Any
 
 from httpx import AsyncClient, BasicAuth, HTTPError
@@ -172,8 +171,15 @@ async def _httpx_get_request(
 ) -> dict[str, Any] | None:
     ssl_ctx = create_default_context()
     if verify:
-        with suppress(FileNotFoundError):
+        # A missing OR empty/corrupt CA bundle must not crash the caller:
+        # load_verify_locations raises FileNotFoundError when the file is
+        # absent, but ssl.SSLError (NO_CERTIFICATE_OR_CRL_FOUND) when it exists
+        # yet holds no certificates. Both mean "cannot verify this endpoint",
+        # so degrade to an unreachable request instead of propagating.
+        try:
             ssl_ctx.load_verify_locations(cafile=cafile)
+        except (FileNotFoundError, SSLError):
+            pass
     else:
         ssl_ctx.check_hostname = False
         ssl_ctx.verify_mode = CERT_NONE

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -4,6 +4,8 @@
 import re
 from unittest.mock import mock_open, patch
 
+from httpx import BasicAuth
+
 from single_kernel_postgresql.config.enums import Substrates
 from single_kernel_postgresql.utils import (
     any_cpu_to_cores,
@@ -11,6 +13,7 @@ from single_kernel_postgresql.utils import (
     create_directory,
     label2name,
     new_password,
+    parallel_patroni_get_request,
     render_file,
 )
 
@@ -105,3 +108,36 @@ def test_create_directory():
         _chmod.assert_called_once_with("test", 0o640)
         _chown.assert_called_once_with("test", uid=35, gid=35)
         _pwnam.assert_called_with("postgres")
+
+
+def test_parallel_patroni_get_request_empty_ca_bundle_does_not_crash(tmp_path):
+    # An empty (or corrupt) CA bundle file must not crash the request:
+    # load_verify_locations raises ssl.SSLError (NO_CERTIFICATE_OR_CRL_FOUND)
+    # for an existing-but-certless file, which the old suppress(FileNotFoundError)
+    # did not catch — propagating up and failing the storage-detaching hook.
+    # With the fix it degrades to an unreachable endpoint and returns None.
+    empty_ca = tmp_path / "ca.pem"
+    empty_ca.write_text("")
+    auth = BasicAuth("patroni", password="unused")
+
+    assert (
+        parallel_patroni_get_request(
+            "/cluster", ["127.0.0.1"], str(empty_ca), auth, verify=True
+        )
+        is None
+    )
+
+
+def test_parallel_patroni_get_request_missing_ca_bundle_does_not_crash():
+    # A missing CA bundle is already swallowed (FileNotFoundError); this guards
+    # against a regression that narrows the suppression back to FileNotFoundError only.
+    assert (
+        parallel_patroni_get_request(
+            "/cluster",
+            ["127.0.0.1"],
+            "/tmp/does-not-exist-ca-bundle.pem",
+            BasicAuth("patroni", password="unused"),
+            verify=True,
+        )
+        is None
+    )


### PR DESCRIPTION
## Issue

Scaling down a `postgresql-k8s` unit fails the `storage-detaching` hook with an uncaught exception:

```
File ".../single_kernel_postgresql/utils/__init__.py", line 163, in _httpx_get_request
    ssl_ctx.load_verify_locations(cafile=cafile)
ssl.SSLError: [X509: NO_CERTIFICATE_OR_CRL_FOUND] no certificate or crl found (_ssl.c:4146)
```

The unit is left in `error` and the `data` storage stays attached.

## Solution

`load_verify_locations` raises `FileNotFoundError` when the CA bundle file is missing (already suppressed), but `ssl.SSLError` (`NO_CERTIFICATE_OR_CRL_FOUND`) when the file exists yet holds no certificates. The `suppress(FileNotFoundError)` guard did not catch the latter, so the error escaped `parallel_patroni_get_request` → `cluster_status` → `get_primary` (which only catches `RetryError`) and crashed the `storage-detaching` hook.

An empty CA bundle can arise at storage-detaching time: the charm touches an empty `/tmp/peer_ca_bundle.pem` on `_on_start` and rewrites it from `get_peer_ca_bundle()`, which returns `""` while the unit's TLS material is being torn down.

Broaden the guard to also swallow `ssl.SSLError`, so a missing OR certless bundle degrades to an unreachable request (returns `None`) instead of propagating — matching the degradation the original `suppress` was reaching for. Adds a regression test asserting an empty CA bundle no longer crashes `parallel_patroni_get_request`.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.