### PR TITLE
fix(utils): floor a sub-core CPU limit at one core

### DIFF
--- a/single_kernel_postgresql/utils/__init__.py
+++ b/single_kernel_postgresql/utils/__init__.py
@@ -91,8 +91,8 @@ def any_cpu_to_cores(cpu_str) -> int:
         cpu_str: a string representing a CPU value, as integer or millis
     """
     if cpu_str.endswith("m"):
-        # convert millis to cores, undercommited
-        return int(cpu_str[:-1]) // 1000
+        # convert millis to cores, undercommited but never below a single core
+        return max(1, int(cpu_str[:-1]) // 1000)
     return int(cpu_str)
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -34,6 +34,8 @@ def test_label2name():
 def test_any_cpu_to_cores():
     assert any_cpu_to_cores("12") == 12
     assert any_cpu_to_cores("1000m") == 1
+    # A sub-core limit still leaves a core's worth of workload to configure.
+    assert any_cpu_to_cores("500m") == 1
 
 
 def test_new_password():


### PR DESCRIPTION
## Issue

Juju's Kubernetes provider maps a `cpu-power=N` application constraint straight to an `Nm` millicore CPU value ([`constraints.go#L38`](https://github.com/juju/juju/blob/a850259476d8fd7ea95618089b1e670249bac938/internal/provider/kubernetes/application/constraints.go#L38)) and writes it into every container's `Resources.Limits` ([`#L339`](https://github.com/juju/juju/blob/a850259476d8fd7ea95618089b1e670249bac938/internal/provider/kubernetes/application/constraints.go#L339)). `any_cpu_to_cores` truncates millicores with integer division, so any sub-core constraint — `cpu-power=500` → `"500m"` — reports **zero** available cores to `K8sManager.get_available_resources`.

Zero cores then drives the whole worker-process sizing in `ConfigManager`: the `auto` values collapse to `"0"` (`min(8, 2 * 0)`), and every explicitly configured `cpu-max-*` value is rejected against a `10 * vCores` ceiling of zero with `value N exceeds maximum allowed of 0`. The unit ends up impossible to configure.

## Solution

Floor the millicore conversion at a single core. A container allowed a fraction of a CPU still runs one PostgreSQL, so one core's worth of configuration is the smallest meaningful answer; whole-core values (`"12"`, `"1000m"`, `"1500m"`) are unaffected.

Split out of #180, where it rode along with the `update_config` migration and left that PR reading as a behaviour change rather than a parity port.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
