### PR TITLE
feat(backups): workload service control, pgBackRest paths and backup state accessors

### DIFF
--- a/single_kernel_postgresql/config/literals.py
+++ b/single_kernel_postgresql/config/literals.py
@@ -183,3 +183,5 @@ VM_PATRONI_SERVICE_DEFAULT_PATH = f"/etc/systemd/system/{VM_PATRONI_SERVICE_NAME
 ## Snap services backing the backup domain.
 VM_PGBACKREST_SERVICE_NAME = "pgbackrest-service"
 VM_PGBACKREST_EXPORTER_SERVICE_NAME = "pgbackrest-exporter"
+## The snap exposes pgBackRest only under an alias, never as a bare binary.
+VM_PGBACKREST_EXECUTABLE = "charmed-postgresql.pgbackrest"

--- a/single_kernel_postgresql/config/literals.py
+++ b/single_kernel_postgresql/config/literals.py
@@ -34,9 +34,11 @@ VM_DATA_PATH = "var/lib/postgresql"
 VM_ARCHIVE_PATH = "data/archive"
 VM_DATA_LOGS_PATH = "data/logs"
 VM_TEMP_PATH = "data/temp"
+VM_PGBACKREST_LOGS_PATH = "var/log/pgbackrest"
 
 ## K8s Paths
 K8S_DATA_PATH = "var/lib/pg/data"
+K8S_PGBACKREST_LOGS_DIR = "pgbackrest_logs"
 
 ## Shared Paths
 # NOTE: The paths don't have leading slahes since pathops
@@ -178,3 +180,6 @@ RAFT_PARTNER_PREFIX = "partner_node_status_server_"
 # VM services
 VM_PATRONI_SERVICE_NAME = "snap.charmed-postgresql.patroni.service"
 VM_PATRONI_SERVICE_DEFAULT_PATH = f"/etc/systemd/system/{VM_PATRONI_SERVICE_NAME}"
+## Snap services backing the backup domain.
+VM_PGBACKREST_SERVICE_NAME = "pgbackrest-service"
+VM_PGBACKREST_EXPORTER_SERVICE_NAME = "pgbackrest-exporter"

--- a/single_kernel_postgresql/core/peer_relation.py
+++ b/single_kernel_postgresql/core/peer_relation.py
@@ -62,6 +62,18 @@ class PostgreSQLPeer(RelationState):
             return
         self.data_interface.delete_relation_data(self.relation.id, [key])
 
+    def _get_unit_field(self, key: str) -> str | None:
+        """Get a plain (non-secret) field from this unit's databag."""
+        if not self.relation:
+            return None
+        return self.relation.data[self.unit].get(key)
+
+    def _set_unit_field(self, key: str, value: str) -> None:
+        """Set a plain (non-secret) field in this unit's databag."""
+        if not self.relation:
+            return
+        self.relation.data[self.unit][key] = value
+
     @property
     def is_app_leader(self) -> bool:
         """Check if the current unit is the leader of the application."""
@@ -224,6 +236,60 @@ class PostgreSQLPeer(RelationState):
         if not self.relation:
             return True
         return self.relation.data[self.unit].get("connectivity", "on") == "on"
+
+    @property
+    def stanza(self) -> str | None:
+        """Get the pgBackRest stanza name set by this unit when it is the primary.
+
+        The leader publishes the stanza on the application databag; a primary that
+        is not the leader publishes it here until the leader copies it across.
+        """
+        return self._get_unit_field("stanza")
+
+    @stanza.setter
+    def stanza(self, value: str) -> None:
+        """Set the pgBackRest stanza name in the peer relation data."""
+        self._set_unit_field("stanza", value)
+
+    @property
+    def s3_initialization_done(self) -> str | None:
+        """Get the flag marking this unit as done with the S3 initialization sequence."""
+        return self._get_unit_field("s3-initialization-done")
+
+    @s3_initialization_done.setter
+    def s3_initialization_done(self, value: str) -> None:
+        """Set the S3 initialization completion flag in the peer relation data."""
+        self._set_unit_field("s3-initialization-done", value)
+
+    @property
+    def s3_initialization_block_message(self) -> str | None:
+        """Get the block message the S3 initialization sequence failed with on this unit."""
+        return self._get_unit_field("s3-initialization-block-message")
+
+    @s3_initialization_block_message.setter
+    def s3_initialization_block_message(self, value: str) -> None:
+        """Set the S3 initialization block message in the peer relation data."""
+        self._set_unit_field("s3-initialization-block-message", value)
+
+    @property
+    def last_pitr_fail_id(self) -> str | None:
+        """Get the last Patroni PITR failure seen, used to detect a repeated failure."""
+        return self._get_unit_field("last_pitr_fail_id")
+
+    @last_pitr_fail_id.setter
+    def last_pitr_fail_id(self, value: str) -> None:
+        """Set the last Patroni PITR failure in the peer relation data."""
+        self._set_unit_field("last_pitr_fail_id", value)
+
+    @property
+    def rotate_logs_pid(self) -> str | None:
+        """Get the PID of the log-rotation process this unit spawned (machines only)."""
+        return self._get_unit_field("rotate-logs-pid")
+
+    @rotate_logs_pid.setter
+    def rotate_logs_pid(self, value: str) -> None:
+        """Set the PID of the log-rotation process in the peer relation data."""
+        self._set_unit_field("rotate-logs-pid", value)
 
     @property
     def config_hash(self) -> str | None:
@@ -437,16 +503,12 @@ class PostgreSQLApplication(RelationState):
     @property
     def is_cluster_restoring_backup(self) -> bool:
         """Returns whether the cluster is restoring a backup."""
-        if not self.relation:
-            return False
-        return "restoring-backup" in self.relation.data[self.app]
+        return self.restoring_backup is not None
 
     @property
     def is_cluster_restoring_to_time(self) -> bool:
         """Returns whether the cluster is restoring a backup to a specific time."""
-        if not self.relation:
-            return False
-        return "restore-to-time" in self.relation.data[self.app]
+        return self.restore_to_time is not None
 
     @property
     def is_ldap_charm_related(self) -> bool:
@@ -473,6 +535,102 @@ class PostgreSQLApplication(RelationState):
         if not self.relation:
             return
         self.relation.data[self.app]["user_hash"] = value
+
+    @property
+    def stanza(self) -> str | None:
+        """Get the pgBackRest stanza name published by the leader."""
+        return self._get_app_field("stanza")
+
+    @stanza.setter
+    def stanza(self, value: str) -> None:
+        """Set the pgBackRest stanza name in the peer relation data."""
+        self._set_app_field("stanza", value)
+
+    @property
+    def restore_stanza(self) -> str | None:
+        """Get the stanza a restore reads the backup from.
+
+        A restore may point at a stanza belonging to a different cluster, so this
+        is tracked separately from the stanza the cluster archives to.
+        """
+        return self._get_app_field("restore-stanza")
+
+    @restore_stanza.setter
+    def restore_stanza(self, value: str) -> None:
+        """Set the stanza a restore reads the backup from."""
+        self._set_app_field("restore-stanza", value)
+
+    @property
+    def restoring_backup(self) -> str | None:
+        """Get the pgBackRest label of the backup being restored."""
+        return self._get_app_field("restoring-backup")
+
+    @restoring_backup.setter
+    def restoring_backup(self, value: str) -> None:
+        """Set the pgBackRest label of the backup being restored."""
+        self._set_app_field("restoring-backup", value)
+
+    @property
+    def restore_to_time(self) -> str | None:
+        """Get the point-in-time-recovery target, or ``latest`` to replay every WAL."""
+        return self._get_app_field("restore-to-time")
+
+    @restore_to_time.setter
+    def restore_to_time(self, value: str) -> None:
+        """Set the point-in-time-recovery target."""
+        self._set_app_field("restore-to-time", value)
+
+    @property
+    def restore_timeline(self) -> str | None:
+        """Get the timeline a point-in-time restore recovers along."""
+        return self._get_app_field("restore-timeline")
+
+    @restore_timeline.setter
+    def restore_timeline(self, value: str) -> None:
+        """Set the timeline a point-in-time restore recovers along."""
+        self._set_app_field("restore-timeline", value)
+
+    @property
+    def s3_initialization_start(self) -> str | None:
+        """Get the timestamp at which the leader started the S3 initialization sequence."""
+        return self._get_app_field("s3-initialization-start")
+
+    @s3_initialization_start.setter
+    def s3_initialization_start(self, value: str) -> None:
+        """Set the timestamp at which the leader started the S3 initialization sequence."""
+        self._set_app_field("s3-initialization-start", value)
+
+    @property
+    def s3_initialization_done(self) -> str | None:
+        """Get the flag the leader raises once it has adopted the primary's stanza fields."""
+        return self._get_app_field("s3-initialization-done")
+
+    @s3_initialization_done.setter
+    def s3_initialization_done(self, value: str) -> None:
+        """Set the S3 initialization completion flag in the peer relation data."""
+        self._set_app_field("s3-initialization-done", value)
+
+    @property
+    def s3_initialization_block_message(self) -> str | None:
+        """Get the block message the S3 initialization sequence failed with."""
+        return self._get_app_field("s3-initialization-block-message")
+
+    @s3_initialization_block_message.setter
+    def s3_initialization_block_message(self, value: str) -> None:
+        """Set the S3 initialization block message in the peer relation data."""
+        self._set_app_field("s3-initialization-block-message", value)
+
+    def _get_app_field(self, key: str) -> str | None:
+        """Get a plain (non-secret) field from the application databag."""
+        if not self.relation:
+            return None
+        return self.relation.data[self.app].get(key)
+
+    def _set_app_field(self, key: str, value: str) -> None:
+        """Set a plain (non-secret) field in the application databag."""
+        if not self.relation:
+            return
+        self.relation.data[self.app][key] = value
 
     def get_secret(self, key: str) -> str | None:
         """Get the secret value for 'key' from the peer relation data."""

--- a/single_kernel_postgresql/core/state.py
+++ b/single_kernel_postgresql/core/state.py
@@ -531,6 +531,16 @@ class CharmState(Object):
             and self.synchronous_node_count > 0,
         }
 
+    @property
+    def stanza(self) -> str | None:
+        """The pgBackRest stanza this unit archives to, or None before initialisation.
+
+        A primary that is not the leader publishes the stanza on its own databag
+        first; the leader adopts it onto the application databag afterwards, so a
+        reader has to consult both.
+        """
+        return self.application.stanza or self.peer.stanza
+
     def _build_service_name(self, service: str) -> str:
         """Build a full k8s service name based on the service name."""
         return f"{self.application.app.name}-{service}.{self.model_name}.svc.cluster.local"

--- a/single_kernel_postgresql/workload/base.py
+++ b/single_kernel_postgresql/workload/base.py
@@ -71,6 +71,12 @@ class BaseWorkload(ABC):
         """
         return 0o600
 
+    @property
+    @abstractmethod
+    def pgbackrest_executable(self) -> str:
+        """Name of the pgBackRest binary to invoke on this substrate."""
+        pass
+
     @abstractmethod
     def install(self) -> None:
         """Install the workload."""
@@ -264,8 +270,28 @@ class BaseWorkload(ABC):
         pass
 
     @abstractmethod
-    def start_service(self):
-        """Start the PostgreSQL service."""
+    def start_service(self, service_name: str) -> None:
+        """Start a workload service by name (snap service on VM, Pebble service on K8s)."""
+        pass
+
+    @abstractmethod
+    def stop_service(self, service_name: str) -> None:
+        """Stop a workload service by name."""
+        pass
+
+    @abstractmethod
+    def restart_service(self, service_name: str) -> None:
+        """Restart a workload service by name."""
+        pass
+
+    @abstractmethod
+    def reload_service(self, service_name: str) -> None:
+        """Make a running workload service re-read its configuration."""
+        pass
+
+    @abstractmethod
+    def is_service_running(self, service_name: str) -> bool:
+        """Whether the named workload service is currently active."""
         pass
 
     @abstractmethod

--- a/single_kernel_postgresql/workload/k8s.py
+++ b/single_kernel_postgresql/workload/k8s.py
@@ -4,6 +4,7 @@
 """Kubernetes Workload."""
 
 import logging
+import signal
 import uuid
 from collections.abc import Generator
 from contextlib import contextmanager
@@ -105,9 +106,33 @@ class K8sWorkload(BaseWorkload):
         """Stop the PostgreSQL service."""
         ...
 
-    def start_service(self):
-        """Start the PostgreSQL service."""
-        ...
+    def start_service(self, service_name: str) -> None:
+        """Start a Pebble service."""
+        self.container.start(service_name)
+
+    def stop_service(self, service_name: str) -> None:
+        """Stop a Pebble service."""
+        self.container.stop(service_name)
+
+    def restart_service(self, service_name: str) -> None:
+        """Restart a Pebble service."""
+        self.container.restart(service_name)
+
+    def reload_service(self, service_name: str) -> None:
+        """Signal a Pebble service to re-read its configuration without dropping state."""
+        self.container.pebble.send_signal(signal.SIGHUP, services=[service_name])
+
+    def is_service_running(self, service_name: str) -> bool:
+        """Whether the named Pebble service is active.
+
+        An unknown service reads as not running, which is how a workload container
+        that has not had the layer applied yet presents.
+        """
+        if not self.container.can_connect():
+            return False
+
+        services = self.container.pebble.get_services(names=[service_name])
+        return len(services) > 0 and services[0].current == ServiceStatus.ACTIVE
 
     def get_workload_version(self) -> str:
         """Get the workload version."""
@@ -166,6 +191,11 @@ class K8sWorkload(BaseWorkload):
                     self.unlink(file_path, missing_ok=True)
                 except PostgreSQLFileOperationError as e:
                     logger.warning(f"Failed to delete temporary file {file_path}: {e}")
+
+    @property
+    def pgbackrest_executable(self) -> str:
+        """The pgBackRest binary, on PATH inside the workload container."""
+        return "pgbackrest"
 
     @property
     def user(self) -> str:

--- a/single_kernel_postgresql/workload/paths/base.py
+++ b/single_kernel_postgresql/workload/paths/base.py
@@ -85,6 +85,12 @@ class Paths(ABC):
 
     @property
     @abstractmethod
+    def pgbackrest_logs(self) -> PathProtocol:
+        """Path to the pgBackRest logs, the directory logrotate is pointed at."""
+        pass
+
+    @property
+    @abstractmethod
     def tls(self) -> PathProtocol:
         """Directory where TLS files are written for this substrate."""
         pass

--- a/single_kernel_postgresql/workload/paths/k8s.py
+++ b/single_kernel_postgresql/workload/paths/k8s.py
@@ -6,6 +6,7 @@ from charmlibs.pathops import PathProtocol
 
 from single_kernel_postgresql.config.literals import (
     K8S_DATA_PATH,
+    K8S_PGBACKREST_LOGS_DIR,
     PATRONI_LOGS_PATH,
     PGBACKREST_CONF_PATH,
     POSTGRESQL_CONF_FILE,
@@ -87,3 +88,12 @@ class K8sPaths(Paths):
     def pgbackrest_conf(self) -> PathProtocol:
         """Path to the pgbackrest config."""
         return self.conf / PGBACKREST_CONF_PATH
+
+    @property
+    def pgbackrest_logs(self) -> PathProtocol:
+        """Path to the pgBackRest logs.
+
+        These sit on the mounted logs storage under the version-scoped subtree, so
+        that a workload upgrade does not mix log generations.
+        """
+        return self.logs / self.versioned_path / K8S_PGBACKREST_LOGS_DIR

--- a/single_kernel_postgresql/workload/paths/vm.py
+++ b/single_kernel_postgresql/workload/paths/vm.py
@@ -17,6 +17,7 @@ from single_kernel_postgresql.config.literals import (
     VM_DATA_LOGS_PATH,
     VM_DATA_PATH,
     VM_LOGS_PATH,
+    VM_PGBACKREST_LOGS_PATH,
     VM_TEMP_PATH,
 )
 from single_kernel_postgresql.workload.paths.base import Paths
@@ -108,3 +109,11 @@ class VMPaths(Paths):
     def pgbackrest_conf(self) -> PathProtocol:
         """Path to the pgbackrest configuration."""
         return self.snap_current / PGBACKREST_CONF_PATH
+
+    @property
+    def pgbackrest_logs(self) -> PathProtocol:
+        """Path to the pgBackRest logs.
+
+        The snap writes them next to the other workload logs, unversioned.
+        """
+        return self.snap_common / VM_PGBACKREST_LOGS_PATH

--- a/single_kernel_postgresql/workload/vm.py
+++ b/single_kernel_postgresql/workload/vm.py
@@ -19,6 +19,7 @@ import tomli
 from charmlibs import pathops, snap
 from charmlibs.pathops import PathProtocol
 
+from single_kernel_postgresql.config.literals import VM_PGBACKREST_EXECUTABLE
 from single_kernel_postgresql.workload.base import BaseWorkload
 from single_kernel_postgresql.workload.paths.base import Paths as BasePaths
 from single_kernel_postgresql.workload.paths.vm import VMPaths
@@ -149,9 +150,42 @@ class VMWorkload(BaseWorkload):
         """Stop the PostgreSQL service."""
         ...
 
-    def start_service(self):
-        """Start the PostgreSQL service."""
-        ...
+    def start_service(self, service_name: str) -> None:
+        """Start a snap service."""
+        self._snap.start(services=[service_name])
+
+    def stop_service(self, service_name: str) -> None:
+        """Stop a snap service."""
+        self._snap.stop(services=[service_name])
+
+    def restart_service(self, service_name: str) -> None:
+        """Restart a snap service."""
+        self._snap.restart(services=[service_name])
+
+    def reload_service(self, service_name: str) -> None:
+        """Restart a snap service so it re-reads its configuration.
+
+        The snap layer offers no way to signal a service, so a restart is the only
+        available reload.
+        """
+        self.restart_service(service_name)
+
+    def is_service_running(self, service_name: str) -> bool:
+        """Whether the named snap service is active.
+
+        A service the installed snap revision does not declare is absent from the
+        services mapping, so it reads as not running rather than raising.
+        """
+        try:
+            return self._snap.services[service_name]["active"]
+        except (snap.SnapError, KeyError) as e:
+            logger.debug(f"Failed to check {service_name} service: {e}")
+            return False
+
+    @property
+    def _snap(self) -> snap.Snap:
+        """The charmed-postgresql snap package."""
+        return snap.SnapCache()["charmed-postgresql"]
 
     def get_workload_version(self) -> str:
         """Get the workload version."""
@@ -195,6 +229,11 @@ class VMWorkload(BaseWorkload):
                     file_path.unlink()
                 except OSError as e:
                     raise e
+
+    @property
+    def pgbackrest_executable(self) -> str:
+        """The pgBackRest binary, reachable on VM only through the snap alias."""
+        return VM_PGBACKREST_EXECUTABLE
 
     @property
     def user(self) -> str:


### PR DESCRIPTION
## Issue

Unit 04 of the charm-to-library migration ports the backup and restore subsystem into the library. That port cannot start yet: the workload layer has no way to address a service by name (the abstract `start_service` took no argument and neither substrate implemented it), `Paths` does not expose the pgBackRest log directory, and every backup/restore coordination field is read through the untyped databag escape hatch with the key spelled out at each call site.

## Solution

Lay the scaffolding the backup port lands on. No backup logic moves in this PR.

- pgBackRest log directory and the two machine-charm snap service names become literals, one constant per substrate rather than one shared string: the snap keeps the log directory unversioned beside the other workload logs, while the Kubernetes charm scopes it under the version subtree of the mounted logs storage.
- The log directory resolves through `Paths`, keeping that divergence out of the backup manager, which would otherwise have to branch on the substrate to build a path.
- Typed stanza and restore-state accessors name each key once on the state object, so a rename or a scope mistake is one edit rather than a search. The stanza needs a cross-scope reader because it is published by whichever unit is primary and only later adopted by the leader, so consulting one databag alone is not enough. Field names are left exactly as the charms write them, so a cluster mid-restore survives the adoption.
- Workload services are addressed by name — start, stop, restart, reload and query — so the manager can express the pgBackRest lifecycle without knowing whether it is talking to snapd or Pebble. `reload_service` is the one primitive whose meaning differs: Pebble can signal a running service to re-read its configuration, the snap layer offers no signal channel, so on machines the only available reload is a restart, which is what the machine charm already does today. Querying a service has to answer for names the substrate may not know — a snap revision predating a service omits it from its services mapping, and Pebble cannot be asked before the container is up; both read as not running rather than raising.

Unit tests follow in a separate PR, matching the code-then-tests split used for the earlier migration units.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
