### PR TITLE
test(backups): unit tests for the unit-04 scaffolding

### DIFF
--- a/tests/unit/test_backup_state.py
+++ b/tests/unit/test_backup_state.py
@@ -1,0 +1,158 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Tests for the pgBackRest stanza and restore/PITR state accessors.
+
+The stanza is coordinated between the leader (app databag) and the primary
+(unit databag), so the same key name lives in both scopes and the read side has
+to fall back from app to unit.
+"""
+
+import pytest
+
+
+def _set_app_db(harness, values):
+    rel_id = harness.model.get_relation("database-peers").id
+    harness.update_relation_data(rel_id, harness.charm.app.name, values)
+
+
+def _set_unit_db(harness, values):
+    rel_id = harness.model.get_relation("database-peers").id
+    harness.update_relation_data(rel_id, harness.charm.unit.name, values)
+
+
+# -- app scope ---------------------------------------------------------------
+
+APP_FIELDS = [
+    ("stanza", "stanza", "test-model.postgresql"),
+    ("restore_stanza", "restore-stanza", "old-model.postgresql"),
+    ("restoring_backup", "restoring-backup", "20260814-101112F"),
+    ("restore_to_time", "restore-to-time", "2026-08-14 10:11:12"),
+    ("restore_timeline", "restore-timeline", "3"),
+    ("s3_initialization_start", "s3-initialization-start", "Thu Aug 14 10:11:12 2026"),
+    ("s3_initialization_done", "s3-initialization-done", "True"),
+    ("s3_initialization_block_message", "s3-initialization-block-message", "bad bucket"),
+]
+
+
+@pytest.mark.parametrize(("attribute", "key", "value"), APP_FIELDS)
+def test_app_backup_field_defaults_to_none(harness, attribute, key, value):
+    assert getattr(harness.charm.state.application, attribute) is None
+
+
+@pytest.mark.parametrize(("attribute", "key", "value"), APP_FIELDS)
+def test_app_backup_field_reads_its_own_key(harness, attribute, key, value):
+    _set_app_db(harness, {key: value})
+
+    assert getattr(harness.charm.state.application, attribute) == value
+
+
+@pytest.mark.parametrize(("attribute", "key", "value"), APP_FIELDS)
+def test_app_backup_field_writes_only_its_own_key(harness, attribute, key, value):
+    """The setter must touch its own key and leave every sibling key alone."""
+    with harness.hooks_disabled():
+        harness.set_leader(True)
+    app = harness.charm.state.application
+    before = dict(app.data)
+
+    setattr(app, attribute, value)
+
+    assert dict(app.data) == before | {key: value}
+
+
+def test_app_backup_fields_are_independent(harness):
+    """Every app accessor must read a distinct key, not share one."""
+    _set_app_db(harness, {key: value for _, key, value in APP_FIELDS})
+    app = harness.charm.state.application
+
+    assert [getattr(app, attribute) for attribute, _, _ in APP_FIELDS] == [
+        value for _, _, value in APP_FIELDS
+    ]
+
+
+# -- unit scope --------------------------------------------------------------
+
+UNIT_FIELDS = [
+    ("stanza", "stanza", "test-model.postgresql"),
+    ("s3_initialization_done", "s3-initialization-done", "True"),
+    ("s3_initialization_block_message", "s3-initialization-block-message", "bad stanza"),
+    ("last_pitr_fail_id", "last_pitr_fail_id", "2026-08-14 10:11:12 UTC"),
+    ("rotate_logs_pid", "rotate-logs-pid", "4242"),
+]
+
+
+@pytest.mark.parametrize(("attribute", "key", "value"), UNIT_FIELDS)
+def test_unit_backup_field_defaults_to_none(harness, attribute, key, value):
+    assert getattr(harness.charm.state.peer, attribute) is None
+
+
+@pytest.mark.parametrize(("attribute", "key", "value"), UNIT_FIELDS)
+def test_unit_backup_field_reads_its_own_key(harness, attribute, key, value):
+    _set_unit_db(harness, {key: value})
+
+    assert getattr(harness.charm.state.peer, attribute) == value
+
+
+@pytest.mark.parametrize(("attribute", "key", "value"), UNIT_FIELDS)
+def test_unit_backup_field_writes_only_its_own_key(harness, attribute, key, value):
+    """The setter must touch its own key and leave every sibling key alone."""
+    peer = harness.charm.state.peer
+    before = dict(peer.data)
+
+    setattr(peer, attribute, value)
+
+    assert dict(peer.data) == before | {key: value}
+
+
+def test_unit_backup_fields_are_independent(harness):
+    """Every unit accessor must read a distinct key, not share one."""
+    _set_unit_db(harness, {key: value for _, key, value in UNIT_FIELDS})
+    peer = harness.charm.state.peer
+
+    assert [getattr(peer, attribute) for attribute, _, _ in UNIT_FIELDS] == [
+        value for _, _, value in UNIT_FIELDS
+    ]
+
+
+# -- restore-in-progress views -----------------------------------------------
+
+RESTORE_VIEWS = [
+    ("is_cluster_restoring_backup", "restoring-backup"),
+    ("is_cluster_restoring_to_time", "restore-to-time"),
+]
+
+
+@pytest.mark.parametrize(("view", "key"), RESTORE_VIEWS)
+def test_restore_view_is_false_without_its_key(harness, view, key):
+    assert getattr(harness.charm.state.application, view) is False
+
+
+@pytest.mark.parametrize(("view", "key"), RESTORE_VIEWS)
+def test_restore_view_tracks_only_its_own_key(harness, view, key):
+    """Each view must answer for its own key, not for whichever restore field is set."""
+    _set_app_db(harness, {key: "set"})
+    app = harness.charm.state.application
+
+    assert [getattr(app, name) for name, _ in RESTORE_VIEWS] == [
+        name == view for name, _ in RESTORE_VIEWS
+    ]
+
+
+# -- cross-scope stanza view -------------------------------------------------
+
+
+def test_stanza_prefers_the_app_databag(harness):
+    _set_app_db(harness, {"stanza": "from-leader"})
+    _set_unit_db(harness, {"stanza": "from-primary"})
+
+    assert harness.charm.state.stanza == "from-leader"
+
+
+def test_stanza_falls_back_to_the_unit_databag(harness):
+    _set_unit_db(harness, {"stanza": "from-primary"})
+
+    assert harness.charm.state.stanza == "from-primary"
+
+
+def test_stanza_is_none_when_neither_scope_has_it(harness):
+    assert harness.charm.state.stanza is None

--- a/tests/unit/test_workload_services.py
+++ b/tests/unit/test_workload_services.py
@@ -1,0 +1,227 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Tests for the generic workload service primitives and pgBackRest paths.
+
+pgBackRest runs as a snap service on VM and as a Pebble service on K8s, so the
+backup domain drives them through one name-taking interface. Every service test
+runs against two distinct names per substrate: with a single name, an
+implementation that hardcoded its own constant would be indistinguishable from
+one that honours the argument.
+"""
+
+import signal
+from unittest.mock import MagicMock, patch
+
+import pytest
+from charmlibs import snap
+from ops.pebble import ServiceStatus
+from single_kernel_postgresql.config.literals import (
+    K8S_PGBACK_REST_SERVER_SERVICE_NAME,
+    K8S_PGBACKREST_METRICS_SERVER_SERVICE_NAME,
+    VM_PGBACKREST_EXECUTABLE,
+    VM_PGBACKREST_EXPORTER_SERVICE_NAME,
+    VM_PGBACKREST_SERVICE_NAME,
+)
+
+VM_SERVICE_NAMES = [VM_PGBACKREST_SERVICE_NAME, VM_PGBACKREST_EXPORTER_SERVICE_NAME]
+K8S_SERVICE_NAMES = [
+    K8S_PGBACK_REST_SERVER_SERVICE_NAME,
+    K8S_PGBACKREST_METRICS_SERVER_SERVICE_NAME,
+]
+
+
+@pytest.fixture
+def workload(harness):
+    return harness.charm.workload
+
+
+@pytest.fixture
+def snap_package():
+    """Patch charmlibs.snap.SnapCache and yield the charmed-postgresql package mock."""
+    package = MagicMock()
+    with patch(
+        "single_kernel_postgresql.workload.vm.snap.SnapCache",
+        return_value={"charmed-postgresql": package},
+    ):
+        yield package
+
+
+def _pebble_service(status):
+    service = MagicMock()
+    service.current = status
+    return service
+
+
+# -- literals ----------------------------------------------------------------
+
+
+def test_pgbackrest_service_literals():
+    assert VM_PGBACKREST_SERVICE_NAME == "pgbackrest-service"
+    assert VM_PGBACKREST_EXPORTER_SERVICE_NAME == "pgbackrest-exporter"
+    assert K8S_PGBACK_REST_SERVER_SERVICE_NAME == "pgbackrest server"
+    assert VM_PGBACKREST_EXECUTABLE == "charmed-postgresql.pgbackrest"
+
+
+# -- pgbackrest executable ---------------------------------------------------
+
+
+def test_pgbackrest_executable_is_substrate_specific(substrate, workload):
+    if substrate == "vm":
+        assert workload.pgbackrest_executable == "charmed-postgresql.pgbackrest"
+    else:
+        assert workload.pgbackrest_executable == "pgbackrest"
+
+
+# -- pgbackrest log directory ------------------------------------------------
+
+
+def test_pgbackrest_logs_path(substrate, workload):
+    if substrate == "vm":
+        assert (
+            str(workload.paths.pgbackrest_logs)
+            == "/var/snap/charmed-postgresql/common/var/log/pgbackrest"
+        )
+    else:
+        assert str(workload.paths.pgbackrest_logs) == "/var/lib/pg/logs/16/main/pgbackrest_logs"
+
+
+# -- VM: snap-backed service actions -----------------------------------------
+
+
+@pytest.mark.parametrize("service_name", VM_SERVICE_NAMES)
+@pytest.mark.parametrize(
+    ("method", "snap_action"),
+    [("start_service", "start"), ("stop_service", "stop"), ("restart_service", "restart")],
+)
+def test_vm_service_actions_drive_the_snap(
+    substrate, workload, snap_package, method, snap_action, service_name
+):
+    if substrate != "vm":
+        pytest.skip("VM only")
+
+    getattr(workload, method)(service_name)
+
+    getattr(snap_package, snap_action).assert_called_once_with(services=[service_name])
+
+
+@pytest.mark.parametrize("service_name", VM_SERVICE_NAMES)
+def test_vm_reload_service_restarts_the_snap_service(
+    substrate, workload, snap_package, service_name
+):
+    """The snap layer exposes no signal channel, so reload degrades to a restart."""
+    if substrate != "vm":
+        pytest.skip("VM only")
+
+    workload.reload_service(service_name)
+
+    snap_package.restart.assert_called_once_with(services=[service_name])
+
+
+@pytest.mark.parametrize("service_name", VM_SERVICE_NAMES)
+@pytest.mark.parametrize("active", [True, False])
+def test_vm_is_service_running_reads_the_snap_service_state(
+    substrate, workload, snap_package, active, service_name
+):
+    if substrate != "vm":
+        pytest.skip("VM only")
+    # The other service carries the opposite state, so a lookup that ignores the
+    # requested name answers for the wrong service.
+    snap_package.services = {
+        name: {"active": active if name == service_name else not active}
+        for name in VM_SERVICE_NAMES
+    }
+
+    assert workload.is_service_running(service_name) is active
+
+
+def test_vm_is_service_running_is_false_for_an_unknown_service(substrate, workload, snap_package):
+    """A snap revision predating a service omits it, which must not raise KeyError."""
+    if substrate != "vm":
+        pytest.skip("VM only")
+    snap_package.services = {VM_PGBACKREST_SERVICE_NAME: {"active": True}}
+
+    assert workload.is_service_running(VM_PGBACKREST_EXPORTER_SERVICE_NAME) is False
+
+
+def test_vm_is_service_running_is_false_when_the_snap_errors(substrate, workload):
+    if substrate != "vm":
+        pytest.skip("VM only")
+
+    with patch(
+        "single_kernel_postgresql.workload.vm.snap.SnapCache", side_effect=snap.SnapError("boom")
+    ):
+        assert workload.is_service_running(VM_PGBACKREST_SERVICE_NAME) is False
+
+
+# -- K8s: pebble-backed service actions --------------------------------------
+
+
+@pytest.mark.parametrize("service_name", K8S_SERVICE_NAMES)
+@pytest.mark.parametrize(
+    ("method", "container_action"),
+    [("start_service", "start"), ("stop_service", "stop"), ("restart_service", "restart")],
+)
+def test_k8s_service_actions_drive_the_container(
+    substrate, workload, method, container_action, service_name
+):
+    if substrate != "k8s":
+        pytest.skip("K8s only")
+
+    with patch.object(workload, "container") as container:
+        getattr(workload, method)(service_name)
+
+    getattr(container, container_action).assert_called_once_with(service_name)
+
+
+@pytest.mark.parametrize("service_name", K8S_SERVICE_NAMES)
+def test_k8s_reload_service_sends_sighup(substrate, workload, service_name):
+    if substrate != "k8s":
+        pytest.skip("K8s only")
+
+    with patch.object(workload, "container") as container:
+        workload.reload_service(service_name)
+
+    container.pebble.send_signal.assert_called_once_with(signal.SIGHUP, services=[service_name])
+
+
+@pytest.mark.parametrize("service_name", K8S_SERVICE_NAMES)
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [(ServiceStatus.ACTIVE, True), (ServiceStatus.INACTIVE, False)],
+)
+def test_k8s_is_service_running_reads_the_pebble_status(
+    substrate, workload, status, expected, service_name
+):
+    if substrate != "k8s":
+        pytest.skip("K8s only")
+
+    with patch.object(workload, "container") as container:
+        container.pebble.get_services.return_value = [_pebble_service(status)]
+        running = workload.is_service_running(service_name)
+
+    container.pebble.get_services.assert_called_once_with(names=[service_name])
+    assert running is expected
+
+
+def test_k8s_is_service_running_is_false_for_an_unknown_service(substrate, workload):
+    if substrate != "k8s":
+        pytest.skip("K8s only")
+
+    with patch.object(workload, "container") as container:
+        container.pebble.get_services.return_value = []
+
+        assert workload.is_service_running(K8S_PGBACK_REST_SERVER_SERVICE_NAME) is False
+
+
+def test_k8s_is_service_running_is_false_when_the_container_is_unreachable(substrate, workload):
+    """Pebble is not answerable before the container is up, as for is_patroni_running."""
+    if substrate != "k8s":
+        pytest.skip("K8s only")
+
+    with patch.object(workload, "container") as container:
+        container.can_connect.return_value = False
+
+        assert workload.is_service_running(K8S_PGBACK_REST_SERVER_SERVICE_NAME) is False
+
+    container.pebble.get_services.assert_not_called()


### PR DESCRIPTION
## Issue

The unit 04 scaffolding in #207 ships without unit tests, following the code-then-tests split used for the earlier migration units.

## Solution

Cover every accessor and workload primitive #207 adds.

Each accessor is asserted against its own key, service name and path, so a copy-paste slip between two neighbouring fields fails rather than passing on a value the fields happen to share. Every service primitive is driven with two distinct names per substrate, because with a single name an implementation that ignored the argument and reached for its own constant would pass unchallenged. Setters are asserted to leave every sibling key untouched, and the cross-scope stanza reader is covered for both precedence and fallback, since a restore that reads the wrong databag silently archives to the wrong repository.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
