### PR TITLE
[DPE-10875] refactor(config): inject the resource provider instead of routing via state

### DIFF
--- a/single_kernel_postgresql/charms/abstract_charm.py
+++ b/single_kernel_postgresql/charms/abstract_charm.py
@@ -14,7 +14,7 @@ from single_kernel_postgresql.managers.cluster import ClusterManager
 from single_kernel_postgresql.managers.config import ConfigManager
 from single_kernel_postgresql.managers.patroni import PatroniManager
 from single_kernel_postgresql.managers.tls import TLSManager
-from single_kernel_postgresql.workload.base import BaseWorkload
+from single_kernel_postgresql.workload.base import BaseWorkload, ResourceProvider
 
 from ..config.enums import Substrates
 from ..utils.postgresql import PostgreSQL
@@ -47,6 +47,7 @@ class AbstractPostgreSQLCharm(CharmBase, ABC):
             workload=self.workload,
             tls_manager=self.tls_manager,
             patroni_manager=self.patroni_manager,
+            resource_provider=self.get_resource_provider,
             request_restart=self.request_restart,
             refresh_endpoints=self.refresh_endpoints,
             restart_services=self.restart_services,
@@ -96,6 +97,11 @@ class AbstractPostgreSQLCharm(CharmBase, ABC):
     # Config-update bridges: charm-side callables the ConfigManager invokes for the
     # substrate-tangled restart trigger, endpoint refresh and monitoring/ldap service
     # restarts. They stay in the charm until their own migration phases.
+    @abstractmethod
+    def get_resource_provider(self) -> ResourceProvider:
+        """Return the substrate's (cpu_cores, memory_bytes) introspector."""
+        pass
+
     @abstractmethod
     def request_restart(self) -> None:
         """Run the substrate pre-restart side effect and acquire the restart lock."""

--- a/single_kernel_postgresql/charms/k8s_charm.py
+++ b/single_kernel_postgresql/charms/k8s_charm.py
@@ -26,7 +26,6 @@ class PostgreSQLK8sCharm(AbstractPostgreSQLCharm):
             "Workload must be an instance of K8sWorkload"
         )
         self.k8s_manager = K8sManager(self.state, self.workload)
-        self.state.resource_provider = self.k8s_manager
 
     @property
     def postgresql(self) -> PostgreSQL:
@@ -69,6 +68,10 @@ class PostgreSQLK8sCharm(AbstractPostgreSQLCharm):
     # The concrete production charm owns these bridges (update_scrape_job_spec +
     # acquire_lock, update_endpoints, pebble metrics/ldap restarts), so they default to
     # no-ops here.
+    def get_resource_provider(self) -> K8sManager:
+        """Return the substrate's (cpu_cores, memory_bytes) introspector."""
+        return self.k8s_manager
+
     def request_restart(self) -> None:
         """Run the substrate pre-restart side effect and acquire the restart lock."""
 

--- a/single_kernel_postgresql/charms/vm_charm.py
+++ b/single_kernel_postgresql/charms/vm_charm.py
@@ -20,7 +20,6 @@ class PostgreSQLVMCharm(AbstractPostgreSQLCharm):
     def __init__(self, *args):
         """Initialize the PostgreSQL VM Charm."""
         super().__init__(*args)
-        self.state.resource_provider = self.workload
 
     @property
     def postgresql(self) -> PostgreSQL:
@@ -60,6 +59,10 @@ class PostgreSQLVMCharm(AbstractPostgreSQLCharm):
     # The concrete production charm owns these bridges (pops postgresql_restarted +
     # acquire_lock, update_endpoints, snap metrics/ldap restarts), so they default to
     # no-ops here.
+    def get_resource_provider(self) -> VMWorkload:
+        """Return the substrate's (cpu_cores, memory_bytes) introspector."""
+        return self.workload
+
     def request_restart(self) -> None:
         """Run the substrate pre-restart side effect and acquire the restart lock."""
 

--- a/single_kernel_postgresql/core/state.py
+++ b/single_kernel_postgresql/core/state.py
@@ -8,7 +8,7 @@ import re
 import socket
 from contextlib import suppress
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, get_args
+from typing import Any, get_args
 
 from data_platform_helpers.advanced_statuses import StatusesState, StatusObject
 from data_platform_helpers.advanced_statuses.types import Scope as AdvancedStatusesScope
@@ -44,9 +44,6 @@ from single_kernel_postgresql.utils import unit_name_to_pod_name
 from single_kernel_postgresql.utils.secret import translate_field_to_secret_key
 from single_kernel_postgresql.utils.status import format_status
 
-if TYPE_CHECKING:
-    from single_kernel_postgresql.workload.base import ResourceProvider
-
 
 class CharmState(Object):
     """The global PostgreSQL Charm State."""
@@ -63,16 +60,6 @@ class CharmState(Object):
         self.peer_unit_interface = DataPeerUnitData(model=charm.model, relation_name=PEER_RELATION)
 
         self.statuses = StatusesState(self, STATUS_PEERS_RELATION)
-
-        # Set by the charm to the substrate's resource introspector (VM workload / K8s manager).
-        self.resource_provider: ResourceProvider | None = None
-
-    @property
-    def available_resources(self) -> tuple[int, int]:
-        """(cpu_cores, memory_bytes) for this unit, via the substrate's provider."""
-        if self.resource_provider is None:
-            raise RuntimeError("resource_provider was not set by the charm")
-        return self.resource_provider.get_available_resources()
 
     # -- Charm Config
     @cached_property

--- a/single_kernel_postgresql/managers/config.py
+++ b/single_kernel_postgresql/managers/config.py
@@ -36,7 +36,7 @@ from single_kernel_postgresql.managers.patroni import PatroniManager
 from single_kernel_postgresql.managers.tls import TLSManager
 from single_kernel_postgresql.utils import _change_owner, render_file
 from single_kernel_postgresql.utils.postgresql import PostgreSQL as PostgreSQLClient
-from single_kernel_postgresql.workload.base import BaseWorkload
+from single_kernel_postgresql.workload.base import BaseWorkload, ResourceProvider
 
 if TYPE_CHECKING:
     # Import-time only: the VM workload pulls the snap charm lib, which K8s does not ship.
@@ -57,6 +57,7 @@ class ConfigManager(BaseManager):
         workload: BaseWorkload,
         tls_manager: TLSManager,
         patroni_manager: PatroniManager,
+        resource_provider: Callable[[], ResourceProvider],
         request_restart: Callable[[], None],
         refresh_endpoints: Callable[[], None],
         restart_services: Callable[[], None],
@@ -64,6 +65,9 @@ class ConfigManager(BaseManager):
         super().__init__(state, workload, "config_manager")
         self.tls_manager = tls_manager
         self.patroni_manager = patroni_manager
+        # Resolved on use, not at construction: the K8s manager that provides it is built
+        # after this manager in the charm's __init__.
+        self.resource_provider = resource_provider
         # Charm-side bridges: the substrate-tangled restart trigger, endpoint refresh and
         # monitoring/ldap service restarts stay in the charm until their own migration phases.
         self.request_restart = request_restart
@@ -468,7 +472,7 @@ class ConfigManager(BaseManager):
         # Snapshot resources once so parameter-building and the API patch agree. On K8s
         # these are lightkube reads; re-fetching per callee doubled the API calls and
         # could disagree mid-scaling.
-        cpu_cores, available_memory = self.state.available_resources
+        cpu_cores, available_memory = self.resource_provider().get_available_resources()
 
         # Build PostgreSQL parameters
         pg_parameters = self._build_postgresql_parameters(

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -25,6 +25,7 @@ def config(substrate):
             workload=workload,
             tls_manager=Mock(),
             patroni_manager=Mock(),
+            resource_provider=Mock(),
             request_restart=Mock(),
             refresh_endpoints=Mock(),
             restart_services=Mock(),
@@ -718,10 +719,9 @@ def orchestrate(config, postgresql_client):
         patch.object(config, "_can_connect_to_postgresql", return_value=True),
         patch.object(config.workload, "is_patroni_running", return_value=True),
         patch.object(
-            type(config.state),
-            "available_resources",
-            new_callable=PropertyMock,
-            return_value=(4, 8_000_000_000),
+            config,
+            "resource_provider",
+            return_value=Mock(get_available_resources=Mock(return_value=(4, 8_000_000_000))),
         ),
         # render_patroni_yml_file is mocked, but its kwargs are still eagerly evaluated
         # against the state — patch the accessors they read so they don't hit the Mock relation.


### PR DESCRIPTION
## Issue

`CharmState` carries a `resource_provider` slot that the charm assigns after construction, and an `available_resources` property that raises `RuntimeError` when nobody set it. `ConfigManager` is the only consumer, so the state class is acting as a service locator for a single manager's dependency. Raised by @akram09 in review on #182 and again on #183.

## Solution

Hand the provider to `ConfigManager` directly and drop both the slot and the property, so the "not set" failure mode stops being representable. Each charm exposes it through a `get_resource_provider()` method (abstract on the base charm, returning the K8s manager or the VM workload), and the manager resolves the getter on use.

It is injected as a getter rather than an instance because the K8s manager that supplies it is constructed after `ConfigManager` in the charm's `__init__` — the same late binding the existing charm bridges already use, so no construction reordering is needed. The injected type is the existing `ResourceProvider` protocol rather than a K8s client, since the VM charm satisfies it through its workload and `K8sManager` is not importable on VM.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.

