### PR TITLE
[DPE-10879] feat(database): client-relation manager and its mapping caches (1/7)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "postgresql-charms-single-kernel"
 description = "Shared and reusable code for PostgreSQL-related charms"
-version = "16.3.5"
+version = "16.3.6"
 readme = "README.md"
 license = {file = "LICENSE"}
 authors = [

--- a/single_kernel_postgresql/charms/abstract_charm.py
+++ b/single_kernel_postgresql/charms/abstract_charm.py
@@ -12,13 +12,18 @@ from single_kernel_postgresql.core.state import CharmState
 from single_kernel_postgresql.events.database import DatabaseEventsHandler
 from single_kernel_postgresql.events.postgresql import PostgreSQLEventsHandler
 from single_kernel_postgresql.events.tls import TLS
+from single_kernel_postgresql.lib.charms.data_platform_libs.v0.data_interfaces import (
+    DatabaseProvides,
+)
 from single_kernel_postgresql.managers.cluster import ClusterManager
 from single_kernel_postgresql.managers.config import ConfigManager
+from single_kernel_postgresql.managers.database import DatabaseManager
 from single_kernel_postgresql.managers.patroni import PatroniManager
 from single_kernel_postgresql.managers.tls import TLSManager
 from single_kernel_postgresql.workload.base import BaseWorkload, ResourceProvider
 
 from ..config.enums import Substrates
+from ..config.literals import DATABASE
 from ..utils.postgresql import PostgreSQL
 
 
@@ -45,12 +50,17 @@ class AbstractPostgreSQLCharm(CharmBase, ABC):
         self.patroni_manager = PatroniManager(state=self.state, workload=self.workload)
         self.cluster_manager = ClusterManager(state=self.state, workload=self.workload)
 
-        # Client-relation handler owns DatabaseProvides and builds the DatabaseManager the
-        # config manager refreshes endpoints and reads the user hash through.
-        self.database = DatabaseEventsHandler(
-            self, self.state, self.patroni_manager, self.tls_manager
+        # Client-relation subsystem: the charm is the composition root, as with the
+        # other managers; the handler owns only the observers and guard/defer decisions.
+        self.database_manager = DatabaseManager(
+            state=self.state,
+            workload=self.workload,
+            database_provides=DatabaseProvides(self, relation_name=DATABASE),
+            set_unit_status=self.set_unit_status,
         )
-        self.database_manager = self.database.manager
+        self.database = DatabaseEventsHandler(
+            self, self.state, self.database_manager, self.patroni_manager, self.tls_manager
+        )
 
         self.config_manager = ConfigManager(
             state=self.state,

--- a/single_kernel_postgresql/charms/abstract_charm.py
+++ b/single_kernel_postgresql/charms/abstract_charm.py
@@ -107,8 +107,9 @@ class AbstractPostgreSQLCharm(CharmBase, ABC):
     # Charm-side bridges the lib calls back into. request_restart/restart_services are
     # substrate-tangled and stay until their own migration phases; update_config still
     # supplies the ldap/async/watcher values those phases own; primary_endpoint is the
-    # VM's Patroni-derived primary lookup. set_unit_status is permanent: it gates status
-    # writes on charm_refresh priority, and charm_refresh is not a migration target.
+    # VM's Patroni-derived primary lookup. set_unit_status routes status writes through
+    # the charm_refresh priority gate and stays until the refresh logic itself migrates
+    # into the library, at which point the managers own their status writes.
     @abstractmethod
     def get_resource_provider(self) -> ResourceProvider:
         """Return the substrate's (cpu_cores, memory_bytes) introspector."""

--- a/single_kernel_postgresql/charms/abstract_charm.py
+++ b/single_kernel_postgresql/charms/abstract_charm.py
@@ -5,9 +5,11 @@
 from abc import ABC, abstractmethod
 
 from data_platform_helpers.advanced_statuses import StatusHandler
+from ops import StatusBase
 from ops.charm import CharmBase
 
 from single_kernel_postgresql.core.state import CharmState
+from single_kernel_postgresql.events.database import DatabaseEventsHandler
 from single_kernel_postgresql.events.postgresql import PostgreSQLEventsHandler
 from single_kernel_postgresql.events.tls import TLS
 from single_kernel_postgresql.managers.cluster import ClusterManager
@@ -42,14 +44,22 @@ class AbstractPostgreSQLCharm(CharmBase, ABC):
         )
         self.patroni_manager = PatroniManager(state=self.state, workload=self.workload)
         self.cluster_manager = ClusterManager(state=self.state, workload=self.workload)
+
+        # Client-relation handler owns DatabaseProvides and builds the DatabaseManager the
+        # config manager refreshes endpoints and reads the user hash through.
+        self.database = DatabaseEventsHandler(
+            self, self.state, self.patroni_manager, self.tls_manager
+        )
+        self.database_manager = self.database.manager
+
         self.config_manager = ConfigManager(
             state=self.state,
             workload=self.workload,
             tls_manager=self.tls_manager,
             patroni_manager=self.patroni_manager,
+            database_manager=self.database_manager,
             resource_provider=self.get_resource_provider,
             request_restart=self.request_restart,
-            refresh_endpoints=self.refresh_endpoints,
             restart_services=self.restart_services,
         )
 
@@ -94,9 +104,11 @@ class AbstractPostgreSQLCharm(CharmBase, ABC):
         """Access current substrate."""
         pass
 
-    # Config-update bridges: charm-side callables the ConfigManager invokes for the
-    # substrate-tangled restart trigger, endpoint refresh and monitoring/ldap service
-    # restarts. They stay in the charm until their own migration phases.
+    # Charm-side bridges the lib calls back into. request_restart/restart_services are
+    # substrate-tangled and stay until their own migration phases; update_config still
+    # supplies the ldap/async/watcher values those phases own; primary_endpoint is the
+    # VM's Patroni-derived primary lookup. set_unit_status is permanent: it gates status
+    # writes on charm_refresh priority, and charm_refresh is not a migration target.
     @abstractmethod
     def get_resource_provider(self) -> ResourceProvider:
         """Return the substrate's (cpu_cores, memory_bytes) introspector."""
@@ -108,11 +120,22 @@ class AbstractPostgreSQLCharm(CharmBase, ABC):
         pass
 
     @abstractmethod
-    def refresh_endpoints(self) -> None:
-        """Refresh the client relation endpoints."""
+    def restart_services(self) -> None:
+        """Restart the monitoring and LDAP-sync sidecar services."""
         pass
 
     @abstractmethod
-    def restart_services(self) -> None:
-        """Restart the monitoring and LDAP-sync sidecar services."""
+    def set_unit_status(self, status: StatusBase) -> None:
+        """Set the unit status without overriding a higher-priority refresh status."""
+        pass
+
+    @abstractmethod
+    def update_config(self) -> bool:
+        """Re-render the Patroni configuration and apply it."""
+        pass
+
+    @property
+    @abstractmethod
+    def primary_endpoint(self) -> str | None:
+        """Address of the cluster primary, or None when there is not one."""
         pass

--- a/single_kernel_postgresql/charms/k8s_charm.py
+++ b/single_kernel_postgresql/charms/k8s_charm.py
@@ -6,6 +6,8 @@
 
 import logging
 
+from ops import StatusBase
+
 from single_kernel_postgresql.charms.abstract_charm import AbstractPostgreSQLCharm, PostgreSQL
 from single_kernel_postgresql.config.enums import Substrates
 from single_kernel_postgresql.config.literals import CONTAINER_NAME, SYSTEM_USERS, USER
@@ -66,8 +68,8 @@ class PostgreSQLK8sCharm(AbstractPostgreSQLCharm):
         return Substrates.K8S
 
     # The concrete production charm owns these bridges (update_scrape_job_spec +
-    # acquire_lock, update_endpoints, pebble metrics/ldap restarts), so they default to
-    # no-ops here.
+    # acquire_lock, pebble metrics/ldap restarts, the refresh-aware status write and the
+    # config re-render), so they are minimal here.
     def get_resource_provider(self) -> K8sManager:
         """Return the substrate's (cpu_cores, memory_bytes) introspector."""
         return self.k8s_manager
@@ -75,8 +77,18 @@ class PostgreSQLK8sCharm(AbstractPostgreSQLCharm):
     def request_restart(self) -> None:
         """Run the substrate pre-restart side effect and acquire the restart lock."""
 
-    def refresh_endpoints(self) -> None:
-        """Refresh the client relation endpoints."""
-
     def restart_services(self) -> None:
         """Restart the monitoring and LDAP-sync sidecar services."""
+
+    def set_unit_status(self, status: StatusBase) -> None:
+        """Set the unit status without overriding a higher-priority refresh status."""
+        self.unit.status = status
+
+    def update_config(self) -> bool:
+        """Re-render the Patroni configuration and apply it."""
+        return self.config_manager.update_config(self.postgresql)
+
+    @property
+    def primary_endpoint(self) -> str | None:
+        """Address of the cluster primary's Service."""
+        return self.state.primary_endpoint

--- a/single_kernel_postgresql/charms/vm_charm.py
+++ b/single_kernel_postgresql/charms/vm_charm.py
@@ -6,6 +6,8 @@
 
 import logging
 
+from ops import StatusBase
+
 from single_kernel_postgresql.charms.abstract_charm import AbstractPostgreSQLCharm, PostgreSQL
 from single_kernel_postgresql.config.enums import Substrates
 from single_kernel_postgresql.config.literals import SYSTEM_USERS, USER
@@ -57,8 +59,8 @@ class PostgreSQLVMCharm(AbstractPostgreSQLCharm):
         return Substrates.VM
 
     # The concrete production charm owns these bridges (pops postgresql_restarted +
-    # acquire_lock, update_endpoints, snap metrics/ldap restarts), so they default to
-    # no-ops here.
+    # acquire_lock, snap metrics/ldap restarts, the refresh-aware status write, the
+    # Patroni-derived primary lookup and the config re-render), so they are minimal here.
     def get_resource_provider(self) -> VMWorkload:
         """Return the substrate's (cpu_cores, memory_bytes) introspector."""
         return self.workload
@@ -66,8 +68,19 @@ class PostgreSQLVMCharm(AbstractPostgreSQLCharm):
     def request_restart(self) -> None:
         """Run the substrate pre-restart side effect and acquire the restart lock."""
 
-    def refresh_endpoints(self) -> None:
-        """Refresh the client relation endpoints."""
-
     def restart_services(self) -> None:
         """Restart the monitoring and LDAP-sync sidecar services."""
+
+    def set_unit_status(self, status: StatusBase) -> None:
+        """Set the unit status without overriding a higher-priority refresh status."""
+        self.unit.status = status
+
+    def update_config(self) -> bool:
+        """Re-render the Patroni configuration and apply it."""
+        return self.config_manager.update_config(self.postgresql)
+
+    @property
+    def primary_endpoint(self) -> str | None:
+        """Address of the cluster primary, or None when there is not one."""
+        primary = self.patroni_manager.get_primary()
+        return self.patroni_manager.get_member_ip(primary) if primary else None

--- a/single_kernel_postgresql/core/state.py
+++ b/single_kernel_postgresql/core/state.py
@@ -235,6 +235,13 @@ class CharmState(Object):
             addresses.remove(current_unit_ip)
         return addresses
 
+    def unit_database_address(self, unit: Unit, relation_name: str = DATABASE) -> str | None:
+        """The client-facing address a peer unit published for the given relation."""
+        if not (peer_relation := self.peer_relation):
+            return None
+        with suppress(KeyError):
+            return peer_relation.data[unit].get(f"{relation_name}-address")
+
     @property
     def host(self) -> str:
         """Current unit host."""

--- a/single_kernel_postgresql/core/state.py
+++ b/single_kernel_postgresql/core/state.py
@@ -526,3 +526,8 @@ class CharmState(Object):
     def primary_endpoint(self) -> str:
         """Returns the endpoint of the primary instance's service."""
         return self._build_service_name("primary")
+
+    @property
+    def replicas_endpoint(self) -> str:
+        """Returns the endpoint of the replicas instances' service."""
+        return self._build_service_name("replicas")

--- a/single_kernel_postgresql/events/database.py
+++ b/single_kernel_postgresql/events/database.py
@@ -62,7 +62,7 @@ class DatabaseEventsHandler(Object):
         self.manager = database_manager
         self.database_provides = database_manager.database_provides
         # Held for the readiness guards and the endpoint-input gathers: the manager
-        # takes no peer-manager references (akram09's review on the mappings PR).
+        # takes no peer-manager references.
         self.patroni_manager = patroni_manager
         self.tls_manager = tls_manager
 

--- a/single_kernel_postgresql/events/database.py
+++ b/single_kernel_postgresql/events/database.py
@@ -102,8 +102,10 @@ class DatabaseEventsHandler(Object):
 
         if not self._ready_for_request():
             logger.debug(
-                "Deferring on_database_requested: cluster not initialized, Patroni not started "
-                "or primary endpoint not available"
+                "Deferring on_database_requested: %s",
+                "Cluster must be initialized before database can be requested"
+                if self.state.substrate == Substrates.K8S
+                else "cluster not initialized, Patroni not started or primary endpoint not available",
             )
             event.defer()
             return
@@ -144,7 +146,11 @@ class DatabaseEventsHandler(Object):
                 event.relation.id, postgresql.get_postgresql_version()
             )
             self.database_provides.set_database(event.relation.id, database)
-            self.manager.update_endpoints(event.relation.id)
+            if self.state.substrate == Substrates.K8S:
+                # K8s refreshed every relation from the request handler.
+                self.manager.update_endpoints()
+            else:
+                self.manager.update_endpoints(event.relation.id)
             self.manager.update_unit_status(postgresql, event.relation)
             self.charm.update_config()
         except self.manager.request_errors as e:
@@ -195,8 +201,10 @@ class DatabaseEventsHandler(Object):
         """Remove the user created for this relation."""
         if not self.state.peer_relation or not self._ready_for_removal():
             logger.debug(
-                "Deferring on_relation_broken: Cluster must be initialized and primary "
-                "available before user can be deleted"
+                "Deferring on_relation_broken: %s",
+                "Cluster must be initialized before user can be deleted"
+                if self.state.substrate == Substrates.K8S
+                else "Cluster must be initialized and primary available before user can be deleted",
             )
             event.defer()
             return

--- a/single_kernel_postgresql/events/database.py
+++ b/single_kernel_postgresql/events/database.py
@@ -5,7 +5,7 @@
 
 import logging
 
-from ops import BlockedStatus, Object, RelationBrokenEvent, RelationDepartedEvent
+from ops import BlockedStatus, ModelError, Object, RelationBrokenEvent, RelationDepartedEvent
 
 from single_kernel_postgresql.config.enums import Substrates
 from single_kernel_postgresql.config.literals import DATABASE, DATABASE_PORT
@@ -14,7 +14,11 @@ from single_kernel_postgresql.lib.charms.data_platform_libs.v0.data_interfaces i
     DatabaseProvides,
     DatabaseRequestedEvent,
 )
-from single_kernel_postgresql.managers.database import DatabaseManager, DatabaseRequest
+from single_kernel_postgresql.managers.database import (
+    NO_ACCESS_TO_SECRET_MSG,
+    DatabaseManager,
+    DatabaseRequest,
+)
 from single_kernel_postgresql.managers.patroni import PatroniManager
 from single_kernel_postgresql.managers.tls import TLSManager
 from single_kernel_postgresql.utils.postgresql import (
@@ -110,12 +114,20 @@ class DatabaseEventsHandler(Object):
             event.defer()
             return
 
+        # The vendored property resolves the secret on access: until the grant lands it
+        # raises ModelError, which the manager's own guard can no longer see.
+        try:
+            requested_entity_secret_content = event.requested_entity_secret_content
+        except ModelError:
+            self.charm.set_unit_status(BlockedStatus(NO_ACCESS_TO_SECRET_MSG))
+            return
+
         request = DatabaseRequest(
             relation_id=event.relation.id,
             database=event.database or "",
             extra_user_roles=event.extra_user_roles,
             prefix_matching=event.prefix_matching,
-            requested_entity_secret_content=event.requested_entity_secret_content,
+            requested_entity_secret_content=requested_entity_secret_content,
         )
         postgresql = self.charm.postgresql
 

--- a/single_kernel_postgresql/events/database.py
+++ b/single_kernel_postgresql/events/database.py
@@ -54,14 +54,16 @@ class DatabaseEventsHandler(Object):
         self.charm = charm
         self.state = state
         self.relation_name = relation_name
+        # Held for the readiness guards and the endpoint-input gathers: the manager
+        # takes no peer-manager references (akram09's review on the mappings PR).
+        self.patroni_manager = patroni_manager
+        self.tls_manager = tls_manager
 
         self.database_provides = DatabaseProvides(charm, relation_name=relation_name)
         self.manager = DatabaseManager(
             state=state,
             workload=charm.workload,
             database_provides=self.database_provides,
-            patroni_manager=patroni_manager,
-            tls_manager=tls_manager,
             set_unit_status=charm.set_unit_status,
             relation_name=relation_name,
         )
@@ -79,8 +81,8 @@ class DatabaseEventsHandler(Object):
         if not self.state.application.is_cluster_initialised:
             return False
         if self.state.substrate == Substrates.K8S:
-            return self.manager.patroni_manager.primary_endpoint_ready
-        return bool(self.manager.patroni_manager.member_started and self.charm.primary_endpoint)
+            return self.patroni_manager.primary_endpoint_ready
+        return bool(self.patroni_manager.member_started and self.charm.primary_endpoint)
 
     def _ready_for_removal(self) -> bool:
         """Whether the cluster can serve a relation removal right now.
@@ -91,8 +93,8 @@ class DatabaseEventsHandler(Object):
         if not self.state.application.is_cluster_initialised:
             return False
         if self.state.substrate == Substrates.K8S:
-            return self.manager.patroni_manager.member_started
-        return bool(self.manager.patroni_manager.member_started and self.charm.primary_endpoint)
+            return self.patroni_manager.member_started
+        return bool(self.patroni_manager.member_started and self.charm.primary_endpoint)
 
     def _on_database_requested(self, event: DatabaseRequestedEvent) -> None:
         """Generate password and handle user and database creation for the related app."""
@@ -148,9 +150,15 @@ class DatabaseEventsHandler(Object):
             self.database_provides.set_database(event.relation.id, database)
             if self.state.substrate == Substrates.K8S:
                 # K8s refreshed every relation from the request handler.
-                self.manager.update_endpoints()
+                self.manager.update_endpoints(
+                    client_tls_files=self.tls_manager.get_client_tls_files()
+                )
             else:
-                self.manager.update_endpoints(event.relation.id)
+                self.manager.update_endpoints(
+                    event.relation.id,
+                    online_members=self.patroni_manager.online_cluster_members(),
+                    client_tls_files=self.tls_manager.get_client_tls_files(),
+                )
             self.manager.update_unit_status(postgresql, event.relation)
             self.charm.update_config()
         except self.manager.request_errors as e:
@@ -182,12 +190,10 @@ class DatabaseEventsHandler(Object):
         self.database_provides.set_uris(
             relation_id, f"postgresql://{user}:{password}@{primary}/{database}"
         )
-        self.database_provides.set_tls(
-            relation_id, "True" if self.manager.is_tls_enabled else "False"
-        )
-        if self.manager.is_tls_enabled:
-            _, ca, _ = self.manager.tls_manager.get_client_tls_files()
-            self.database_provides.set_tls_ca(relation_id, ca or "")
+        client_tls_files = self.tls_manager.get_client_tls_files()
+        self.database_provides.set_tls(relation_id, "True" if all(client_tls_files) else "False")
+        if all(client_tls_files):
+            self.database_provides.set_tls_ca(relation_id, client_tls_files[1] or "")
 
     def _on_relation_departed(self, event: RelationDepartedEvent) -> None:
         """Set a flag to avoid deleting database users when not wanted."""

--- a/single_kernel_postgresql/events/database.py
+++ b/single_kernel_postgresql/events/database.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""Client-relation events handler — owns DatabaseProvides, delegates to DatabaseManager."""
+
+import logging
+
+from ops import BlockedStatus, Object, RelationBrokenEvent, RelationDepartedEvent
+
+from single_kernel_postgresql.config.enums import Substrates
+from single_kernel_postgresql.config.literals import DATABASE, DATABASE_PORT
+from single_kernel_postgresql.core.state import CharmState
+from single_kernel_postgresql.lib.charms.data_platform_libs.v0.data_interfaces import (
+    DatabaseProvides,
+    DatabaseRequestedEvent,
+)
+from single_kernel_postgresql.managers.database import DatabaseManager, DatabaseRequest
+from single_kernel_postgresql.managers.patroni import PatroniManager
+from single_kernel_postgresql.managers.tls import TLSManager
+from single_kernel_postgresql.utils.postgresql import (
+    PostgreSQLCreateDatabaseError,
+    PostgreSQLCreateUserError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class DatabaseEventsHandler(Object):
+    """Handles the ``database`` (``postgresql_client``) provider relation.
+
+    Owns the :class:`DatabaseProvides` interface and the three observers the client
+    relation needs, and constructor-injects the interface into
+    :class:`~single_kernel_postgresql.managers.database.DatabaseManager`, mirroring how
+    the TLS handler owns its requirers.
+
+    Each handler keeps its guard and its work in one observer: ``defer()`` is
+    per-observer, so splitting the readiness check from the action would let a deferred
+    action retry alone against state its guard never re-checked.
+
+    ``charm`` is deliberately untyped, as in the TLS handler: the production charms do
+    not derive from :class:`AbstractPostgreSQLCharm` until the cutover phase, and they
+    are the callers that construct this.
+    """
+
+    def __init__(
+        self,
+        charm,
+        state: CharmState,
+        patroni_manager: PatroniManager,
+        tls_manager: TLSManager,
+        relation_name: str = DATABASE,
+    ) -> None:
+        super().__init__(charm, key="database")
+        self.charm = charm
+        self.state = state
+        self.relation_name = relation_name
+
+        self.database_provides = DatabaseProvides(charm, relation_name=relation_name)
+        self.manager = DatabaseManager(
+            state=state,
+            workload=charm.workload,
+            database_provides=self.database_provides,
+            patroni_manager=patroni_manager,
+            tls_manager=tls_manager,
+            set_unit_status=charm.set_unit_status,
+            relation_name=relation_name,
+        )
+
+        self.framework.observe(
+            charm.on[relation_name].relation_departed, self._on_relation_departed
+        )
+        self.framework.observe(charm.on[relation_name].relation_broken, self._on_relation_broken)
+        self.framework.observe(
+            self.database_provides.on.database_requested, self._on_database_requested
+        )
+
+    def _ready_for_request(self) -> bool:
+        """Whether the cluster can serve a new client request right now."""
+        if not self.state.application.is_cluster_initialised:
+            return False
+        if self.state.substrate == Substrates.K8S:
+            return self.manager.patroni_manager.primary_endpoint_ready
+        return bool(self.manager.patroni_manager.member_started and self.charm.primary_endpoint)
+
+    def _ready_for_removal(self) -> bool:
+        """Whether the cluster can serve a relation removal right now.
+
+        K8s settles for a started member here where a request additionally waits on the
+        primary endpoint being reachable.
+        """
+        if not self.state.application.is_cluster_initialised:
+            return False
+        if self.state.substrate == Substrates.K8S:
+            return self.manager.patroni_manager.member_started
+        return bool(self.manager.patroni_manager.member_started and self.charm.primary_endpoint)
+
+    def _on_database_requested(self, event: DatabaseRequestedEvent) -> None:
+        """Generate password and handle user and database creation for the related app."""
+        # The provider library only emits this on the leader.
+        if not self.state.peer.is_app_leader:
+            return
+
+        if not self._ready_for_request():
+            logger.debug(
+                "Deferring on_database_requested: cluster not initialized, Patroni not started "
+                "or primary endpoint not available"
+            )
+            event.defer()
+            return
+
+        request = DatabaseRequest(
+            relation_id=event.relation.id,
+            database=event.database or "",
+            extra_user_roles=event.extra_user_roles,
+            prefix_matching=event.prefix_matching,
+            requested_entity_secret_content=event.requested_entity_secret_content,
+        )
+        postgresql = self.charm.postgresql
+
+        if not (creds := self.manager.get_credentials(postgresql, request)):
+            return
+        user, password = creds
+
+        if not (databases_setup := self.manager.collect_databases(postgresql, user, request)):
+            return
+        database, databases = databases_setup
+
+        self.manager.update_username_mapping(event.relation.id, user)
+        self.charm.update_config()
+        if not self.manager.are_units_in_sync():
+            logger.debug("Not all units have synced configuration")
+            event.defer()
+            return
+
+        extra_user_roles = self.manager.build_extra_user_roles(event.extra_user_roles)
+
+        try:
+            self.manager.create_relation_user_and_database(
+                postgresql, user, password, database, databases, extra_user_roles
+            )
+            self.database_provides.set_credentials(event.relation.id, user, password)
+            self._publish_k8s_inline_endpoints(event.relation.id, user, password, database)
+            self.database_provides.set_version(
+                event.relation.id, postgresql.get_postgresql_version()
+            )
+            self.database_provides.set_database(event.relation.id, database)
+            self.manager.update_endpoints(event.relation.id)
+            self.manager.update_unit_status(postgresql, event.relation)
+            self.charm.update_config()
+        except self.manager.request_errors as e:
+            if self.state.substrate == Substrates.K8S:
+                logger.exception(e)
+            self.charm.set_unit_status(
+                BlockedStatus(
+                    e.message
+                    if isinstance(e, PostgreSQLCreateDatabaseError | PostgreSQLCreateUserError)
+                    and e.message is not None
+                    # The clearer of the two charms' wordings, now shared by both.
+                    else f"Failed to initialize {self.relation_name} relation"
+                )
+            )
+            return
+
+    def _publish_k8s_inline_endpoints(
+        self, relation_id: int, user: str, password: str, database: str
+    ) -> None:
+        """Publish the endpoint/URI/TLS fields the K8s charm wrote inside the request handler.
+
+        ``update_endpoints`` writes the same values moments later, so this is redundant;
+        it is kept so the port does not change K8s databag write ordering.
+        """
+        if self.state.substrate != Substrates.K8S:
+            return
+        primary = f"{self.state.primary_endpoint}:{DATABASE_PORT}"
+        self.database_provides.set_endpoints(relation_id, primary)
+        self.database_provides.set_uris(
+            relation_id, f"postgresql://{user}:{password}@{primary}/{database}"
+        )
+        self.database_provides.set_tls(
+            relation_id, "True" if self.manager.is_tls_enabled else "False"
+        )
+        if self.manager.is_tls_enabled:
+            _, ca, _ = self.manager.tls_manager.get_client_tls_files()
+            self.database_provides.set_tls_ca(relation_id, ca or "")
+
+    def _on_relation_departed(self, event: RelationDepartedEvent) -> None:
+        """Set a flag to avoid deleting database users when not wanted."""
+        # Set a flag to avoid deleting database users when this unit
+        # is removed and receives relation broken events from related applications.
+        # This is needed because of https://bugs.launchpad.net/juju/+bug/1979811.
+        if event.departing_unit == self.state.model.unit and self.state.peer_relation:
+            self.state.peer.data.update({"departing": "True"})
+
+    def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
+        """Remove the user created for this relation."""
+        if not self.state.peer_relation or not self._ready_for_removal():
+            logger.debug(
+                "Deferring on_relation_broken: Cluster must be initialized and primary "
+                "available before user can be deleted"
+            )
+            event.defer()
+            return
+
+        postgresql = self.charm.postgresql
+        self.manager.update_unit_status(postgresql, event.relation)
+
+        if self.state.peer.is_unit_departing:
+            logger.debug("Early exit on_relation_broken: Skipping departing unit")
+            return
+
+        if not self.state.peer.is_app_leader:
+            user = self.manager.get_username_mapping().get(
+                str(event.relation.id), self.manager.relation_username(event.relation.id)
+            )
+            if user in postgresql.list_users():
+                logger.debug("Deferring on_relation_broken: user was not deleted yet")
+                event.defer()
+            else:
+                self.charm.update_config()
+            return
+
+        self.manager.delete_relation_user(postgresql, event.relation.id)
+        self.charm.update_config()

--- a/single_kernel_postgresql/events/database.py
+++ b/single_kernel_postgresql/events/database.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
-"""Client-relation events handler — owns DatabaseProvides, delegates to DatabaseManager."""
+"""Client-relation events handler — owns the client-relation observers."""
 
 import logging
 
@@ -11,7 +11,6 @@ from single_kernel_postgresql.config.enums import Substrates
 from single_kernel_postgresql.config.literals import DATABASE, DATABASE_PORT
 from single_kernel_postgresql.core.state import CharmState
 from single_kernel_postgresql.lib.charms.data_platform_libs.v0.data_interfaces import (
-    DatabaseProvides,
     DatabaseRequestedEvent,
 )
 from single_kernel_postgresql.managers.database import DatabaseManager, DatabaseRequest
@@ -28,10 +27,9 @@ logger = logging.getLogger(__name__)
 class DatabaseEventsHandler(Object):
     """Handles the ``database`` (``postgresql_client``) provider relation.
 
-    Owns the :class:`DatabaseProvides` interface and the three observers the client
-    relation needs, and constructor-injects the interface into
-    :class:`~single_kernel_postgresql.managers.database.DatabaseManager`, mirroring how
-    the TLS handler owns its requirers.
+    Owns the three observers the client relation needs and drives the
+    :class:`~single_kernel_postgresql.managers.database.DatabaseManager` the charm
+    constructs, mirroring how the postgresql events handler receives its managers.
 
     Each handler keeps its guard and its work in one observer: ``defer()`` is
     per-observer, so splitting the readiness check from the action would let a deferred
@@ -46,6 +44,7 @@ class DatabaseEventsHandler(Object):
         self,
         charm,
         state: CharmState,
+        database_manager: DatabaseManager,
         patroni_manager: PatroniManager,
         tls_manager: TLSManager,
         relation_name: str = DATABASE,
@@ -54,19 +53,14 @@ class DatabaseEventsHandler(Object):
         self.charm = charm
         self.state = state
         self.relation_name = relation_name
+        # The charm is the composition root: it constructs the manager and the provider
+        # interface; this handler owns the observers and the guard/defer decisions.
+        self.manager = database_manager
+        self.database_provides = database_manager.database_provides
         # Held for the readiness guards and the endpoint-input gathers: the manager
         # takes no peer-manager references (akram09's review on the mappings PR).
         self.patroni_manager = patroni_manager
         self.tls_manager = tls_manager
-
-        self.database_provides = DatabaseProvides(charm, relation_name=relation_name)
-        self.manager = DatabaseManager(
-            state=state,
-            workload=charm.workload,
-            database_provides=self.database_provides,
-            set_unit_status=charm.set_unit_status,
-            relation_name=relation_name,
-        )
 
         self.framework.observe(
             charm.on[relation_name].relation_departed, self._on_relation_departed

--- a/single_kernel_postgresql/managers/config.py
+++ b/single_kernel_postgresql/managers/config.py
@@ -309,6 +309,24 @@ class ConfigManager(BaseManager):
             self.tls_manager.client_tls_files_on_disk()
         )
 
+    def _client_relation_endpoint_inputs(self) -> dict:
+        """Gather the DatabaseManager.update_endpoints inputs this caller must supply.
+
+        The Patroni cluster-status query is a live REST call: gather it only where
+        update_endpoints would use it — on the leader (it returns early otherwise) and
+        on VM (K8s endpoints come from the Services state). The raw TLS files are
+        passed as-is: the endpoint publish uses the databag-only view, not this
+        manager's on-disk-augmented is_tls_enabled.
+        """
+        return {
+            "online_members": (
+                self.patroni_manager.online_cluster_members()
+                if self.state.peer.is_app_leader and self.state.substrate == Substrates.VM
+                else None
+            ),
+            "client_tls_files": self.tls_manager.get_client_tls_files(),
+        }
+
     @cached_property
     def generate_config_hash(self) -> str:
         """Generate current configuration hash."""
@@ -437,7 +455,7 @@ class ConfigManager(BaseManager):
                 pass
 
         self.state.peer.tls = self.is_tls_enabled
-        self.database_manager.update_endpoints()
+        self.database_manager.update_endpoints(**self._client_relation_endpoint_inputs())
 
         # Restart PostgreSQL if TLS configuration has changed
         # (so the both old and new connections use the configuration).
@@ -518,7 +536,7 @@ class ConfigManager(BaseManager):
             # in a bundle together with the TLS certificates operator. This flag is used to
             # know when to call the Patroni API using HTTP or HTTPS.
             self.state.peer.tls = self.is_tls_enabled
-            self.database_manager.update_endpoints()
+            self.database_manager.update_endpoints(**self._client_relation_endpoint_inputs())
             logger.debug("Early exit update_config: Workload not started yet")
             return True
 

--- a/single_kernel_postgresql/managers/config.py
+++ b/single_kernel_postgresql/managers/config.py
@@ -40,6 +40,7 @@ from single_kernel_postgresql.workload.base import BaseWorkload, ResourceProvide
 
 if TYPE_CHECKING:
     # Import-time only: the VM workload pulls the snap charm lib, which K8s does not ship.
+    from single_kernel_postgresql.managers.database import DatabaseManager
     from single_kernel_postgresql.workload.vm import VMWorkload
 
 logger = logging.getLogger(__name__)
@@ -57,21 +58,21 @@ class ConfigManager(BaseManager):
         workload: BaseWorkload,
         tls_manager: TLSManager,
         patroni_manager: PatroniManager,
+        database_manager: "DatabaseManager",
         resource_provider: Callable[[], ResourceProvider],
         request_restart: Callable[[], None],
-        refresh_endpoints: Callable[[], None],
         restart_services: Callable[[], None],
     ):
         super().__init__(state, workload, "config_manager")
         self.tls_manager = tls_manager
         self.patroni_manager = patroni_manager
+        self.database_manager = database_manager
         # Resolved on use, not at construction: the K8s manager that provides it is built
         # after this manager in the charm's __init__.
         self.resource_provider = resource_provider
-        # Charm-side bridges: the substrate-tangled restart trigger, endpoint refresh and
-        # monitoring/ldap service restarts stay in the charm until their own migration phases.
+        # Charm-side bridges: the substrate-tangled restart trigger and the monitoring/ldap
+        # service restarts stay in the charm until their own migration phases.
         self.request_restart = request_restart
-        self.refresh_endpoints = refresh_endpoints
         self.restart_services = restart_services
 
     @staticmethod
@@ -436,7 +437,7 @@ class ConfigManager(BaseManager):
                 pass
 
         self.state.peer.tls = self.is_tls_enabled
-        self.refresh_endpoints()
+        self.database_manager.update_endpoints()
 
         # Restart PostgreSQL if TLS configuration has changed
         # (so the both old and new connections use the configuration).
@@ -447,7 +448,6 @@ class ConfigManager(BaseManager):
     def update_config(
         self,
         postgresql_client: PostgreSQLClient,
-        user_hash: str,
         is_creating_backup: bool = False,
         # TODO add rel handler
         relations_user_databases_map: dict[str, Any] | None = None,
@@ -518,7 +518,7 @@ class ConfigManager(BaseManager):
             # in a bundle together with the TLS certificates operator. This flag is used to
             # know when to call the Patroni API using HTTP or HTTPS.
             self.state.peer.tls = self.is_tls_enabled
-            self.refresh_endpoints()
+            self.database_manager.update_endpoints()
             logger.debug("Early exit update_config: Workload not started yet")
             return True
 
@@ -567,6 +567,7 @@ class ConfigManager(BaseManager):
 
         self.restart_services()
 
+        user_hash = self.database_manager.user_hash
         self.state.peer.user_hash = user_hash
         self.state.peer.config_hash = self.generate_config_hash
         if self.state.peer.is_app_leader:

--- a/single_kernel_postgresql/managers/database.py
+++ b/single_kernel_postgresql/managers/database.py
@@ -16,7 +16,7 @@ from functools import cached_property
 from hashlib import shake_128
 from typing import TypedDict
 
-from ops import ActiveStatus, BlockedStatus, ModelError, Relation, StatusBase, Unit
+from ops import ActiveStatus, BlockedStatus, ModelError, Relation, StatusBase
 
 from single_kernel_postgresql.config.enums import Substrates
 from single_kernel_postgresql.config.literals import (
@@ -431,15 +431,6 @@ class DatabaseManager(BaseManager):
 
     # -- Endpoint publishing
 
-    def _unit_ip(self, unit: Unit) -> str | None:
-        """The client-facing address a peer unit published for this relation."""
-        if not self.state.peer_relation:
-            return None
-        try:
-            return self.state.peer_relation.data[unit].get(f"{self.relation_name}-address")
-        except KeyError:
-            return None
-
     def _vm_endpoints(self, online_members: list[dict]) -> tuple[str, str, str]:
         """(rw_endpoint, ro_endpoints, ro_hosts) from the online Patroni members."""
         members = [
@@ -452,10 +443,10 @@ class DatabaseManager(BaseManager):
             if member["role"] == "leader":
                 # A stale leader unit without a peer address publishes "None:5432",
                 # as the charm did.
-                primary_unit_ip = self._unit_ip(unit)
+                primary_unit_ip = self.state.unit_database_address(unit, self.relation_name)
                 rw_endpoint = f"{primary_unit_ip}:{DATABASE_PORT}"
             else:
-                replica_ip = self._unit_ip(unit)
+                replica_ip = self.state.unit_database_address(unit, self.relation_name)
                 if not replica_ip:
                     continue
                 if ro_hosts:

--- a/single_kernel_postgresql/managers/database.py
+++ b/single_kernel_postgresql/managers/database.py
@@ -16,8 +16,6 @@ from functools import cached_property
 from hashlib import shake_128
 from typing import TypedDict
 
-from data_platform_helpers.advanced_statuses import StatusObject
-from data_platform_helpers.advanced_statuses.types import Scope as AdvancedStatusesScope
 from ops import StatusBase
 
 from single_kernel_postgresql.config.enums import Substrates
@@ -29,7 +27,6 @@ from single_kernel_postgresql.config.literals import (
     SPI_MODULE,
     USERNAME_MAPPING_LABEL,
 )
-from single_kernel_postgresql.config.statuses import GeneralStatuses
 from single_kernel_postgresql.core.state import CharmState
 from single_kernel_postgresql.lib.charms.data_platform_libs.v0.data_interfaces import (
     DatabaseProvides,
@@ -54,7 +51,7 @@ class DatabaseManager(BaseManager):
     """PostgreSQL Database Manager.
 
     This manager is responsible for handling the client relation user and database
-    lifecycle. It owns no events; :class:`~single_kernel_postgresql.events.database`
+    lifecycle. It owns no events; :class:`~single_kernel_postgresql.events.database.DatabaseEventsHandler`
     drives it and maps its outcomes onto defer/status.
     """
 
@@ -248,13 +245,3 @@ class DatabaseManager(BaseManager):
             plugins.remove("spi")
             plugins.extend(SPI_MODULE)
         return plugins
-
-    def get_statuses(
-        self, scope: AdvancedStatusesScope, recompute: bool = False
-    ) -> list[StatusObject]:
-        """Compute the manager's statuses."""
-        if not recompute:
-            return self.state.statuses.get(scope, self.name).root or [
-                GeneralStatuses.ACTIVE_IDLE.value
-            ]
-        return [GeneralStatuses.ACTIVE_IDLE.value]

--- a/single_kernel_postgresql/managers/database.py
+++ b/single_kernel_postgresql/managers/database.py
@@ -11,12 +11,12 @@ map the Patroni config renders its pg_hba rules from.
 
 import json
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from functools import cached_property
 from hashlib import shake_128
 from typing import TypedDict
 
-from ops import StatusBase
+from ops import ActiveStatus, BlockedStatus, ModelError, Relation, StatusBase
 
 from single_kernel_postgresql.config.enums import Substrates
 from single_kernel_postgresql.config.literals import (
@@ -25,6 +25,7 @@ from single_kernel_postgresql.config.literals import (
     DATABASE_MAPPING_LABEL,
     PLUGIN_OVERRIDES,
     SPI_MODULE,
+    SYSTEM_USERS,
     USERNAME_MAPPING_LABEL,
 )
 from single_kernel_postgresql.core.state import CharmState
@@ -34,9 +35,31 @@ from single_kernel_postgresql.lib.charms.data_platform_libs.v0.data_interfaces i
 from single_kernel_postgresql.managers.base import BaseManager
 from single_kernel_postgresql.managers.patroni import PatroniManager
 from single_kernel_postgresql.managers.tls import TLSManager
+from single_kernel_postgresql.utils import new_password
+from single_kernel_postgresql.utils.postgresql import (
+    ACCESS_GROUP_RELATION,
+    ACCESS_GROUPS,
+    INVALID_DATABASE_NAME_BLOCKING_MESSAGE,
+    INVALID_DATABASE_NAMES,
+    INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE,
+    PostgreSQLBaseError,
+    PostgreSQLCreateDatabaseError,
+    PostgreSQLCreateUserError,
+    PostgreSQLDeleteUserError,
+    PostgreSQLGetPostgreSQLVersionError,
+)
+from single_kernel_postgresql.utils.postgresql import PostgreSQL as PostgreSQLClient
 from single_kernel_postgresql.workload.base import BaseWorkload
 
 logger = logging.getLogger(__name__)
+
+# Label not a secret
+NO_ACCESS_TO_SECRET_MSG = "Missing grant to requested entity secret"  # noqa: S105
+FORBIDDEN_USER_MSG = "Requesting an existing username"
+PREFIX_TOO_SHORT_MSG = "Prefix too short"
+
+# The shortest prefixed database request that is accepted: three characters plus the "*".
+MINIMUM_PREFIX_REQUEST_LENGTH = 4
 
 
 class PrefixDatabaseCacheType(TypedDict):
@@ -45,6 +68,16 @@ class PrefixDatabaseCacheType(TypedDict):
     username: str
     prefix: str
     databases: list[str]
+
+
+class DatabaseRequest(TypedDict):
+    """The parts of a database-requested event the manager acts on."""
+
+    relation_id: int
+    database: str
+    extra_user_roles: str | None
+    prefix_matching: str | None
+    requested_entity_secret_content: Mapping[str, str | None] | None
 
 
 class DatabaseManager(BaseManager):
@@ -245,3 +278,271 @@ class DatabaseManager(BaseManager):
             plugins.remove("spi")
             plugins.extend(SPI_MODULE)
         return plugins
+
+    # -- Request handling
+
+    @staticmethod
+    def sanitize_extra_roles(extra_roles: str | None) -> list[str]:
+        """Standardize and sanitize user extra-roles."""
+        if extra_roles is None:
+            return []
+
+        # Make sure the access-groups are not in the list
+        extra_roles_list = [role.lower() for role in extra_roles.split(",")]
+        return [role for role in extra_roles_list if role not in ACCESS_GROUPS]
+
+    def build_extra_user_roles(self, extra_roles: str | None) -> list[str]:
+        """Sanitize the requested roles and add the relation access-group."""
+        return [*self.sanitize_extra_roles(extra_roles), ACCESS_GROUP_RELATION]
+
+    def get_credentials(
+        self, postgresql_client: PostgreSQLClient, request: DatabaseRequest
+    ) -> tuple[str, str] | None:
+        """Resolve the user and password for a request, or block and return None."""
+        try:
+            if requested_entities := request["requested_entity_secret_content"]:
+                for key, val in requested_entities.items():
+                    if key in SYSTEM_USERS or key in postgresql_client.list_users():
+                        self.set_unit_status(BlockedStatus(FORBIDDEN_USER_MSG))
+                        return None
+                    return key, val or new_password()
+        except ModelError:
+            self.set_unit_status(BlockedStatus(NO_ACCESS_TO_SECRET_MSG))
+            return None
+        return self.relation_username(request["relation_id"]), new_password()
+
+    def collect_databases(
+        self, postgresql_client: PostgreSQLClient, user: str, request: DatabaseRequest
+    ) -> tuple[str, list[str]] | None:
+        """Resolve the requested database(s), or block and return None."""
+        database = request["database"] or ""
+        if database and database[-1] == "*":
+            if len(database) < MINIMUM_PREFIX_REQUEST_LENGTH:
+                self.set_unit_status(BlockedStatus(PREFIX_TOO_SHORT_MSG))
+                return None
+            prefix_matching = request["prefix_matching"]
+            if prefix_matching and prefix_matching != "all":
+                logger.warning("Only all prefix matching is supported")
+            databases = sorted(postgresql_client.list_databases(database[:-1]))
+            self.set_databases_prefix_mapping(
+                request["relation_id"], user, database[:-1], databases
+            )
+        else:
+            databases = [database]
+            # Add to cached field to be able to generate hba rules
+            self.add_database_to_prefix_mapping(database)
+        return database, databases
+
+    @property
+    def request_errors(self) -> tuple[type[PostgreSQLBaseError], ...]:
+        """The PostgreSQL errors a failed request blocks on, per substrate.
+
+        VM blocks on the whole hierarchy; K8s only on the three it named. Kept apart
+        because widening K8s would newly block requests that today raise through.
+        """
+        if self.state.substrate == Substrates.K8S:
+            return (
+                PostgreSQLCreateDatabaseError,
+                PostgreSQLCreateUserError,
+                PostgreSQLGetPostgreSQLVersionError,
+            )
+        return (PostgreSQLBaseError,)
+
+    def create_relation_user_and_database(
+        self,
+        postgresql_client: PostgreSQLClient,
+        user: str,
+        password: str,
+        database: str,
+        databases: list[str],
+        extra_user_roles: list[str],
+    ) -> None:
+        """Create the user and database backing one client relation."""
+        plugins = self.get_plugins()
+
+        if database[-1] != "*":
+            postgresql_client.create_database(database, plugins=plugins)
+            postgresql_client.create_user(
+                user, password, extra_user_roles=extra_user_roles, database=database
+            )
+            # Get the prefixed users again, to add db level grants
+            for prefixed_user in self.add_database_to_prefix_mapping(database):
+                postgresql_client.add_user_to_databases(prefixed_user, databases, extra_user_roles)
+        else:
+            postgresql_client.create_user(user, password, extra_user_roles=extra_user_roles)
+            postgresql_client.add_user_to_databases(user, databases, extra_user_roles)
+
+    def delete_relation_user(self, postgresql_client: PostgreSQLClient, relation_id: int) -> None:
+        """Delete the relation user and drop it from every mapping cache."""
+        user = self.get_username_mapping().get(
+            str(relation_id), self.relation_username(relation_id)
+        )
+        try:
+            postgresql_client.delete_user(user)
+        except PostgreSQLDeleteUserError as e:
+            logger.exception(e)
+            self.set_unit_status(
+                BlockedStatus(
+                    f"Failed to delete user during {self.relation_name} relation broken event"
+                )
+            )
+
+        self.update_username_mapping(relation_id, None)
+        self.set_databases_prefix_mapping(relation_id, None, None, None)
+        if (
+            (dbs := self.get_rel_to_db_mapping())
+            and (database := dbs.get(str(relation_id)))
+            and database[-1] != "*"
+        ):
+            for prefixed_user in self.remove_database_from_prefix_mapping(database):
+                postgresql_client.remove_user_from_databases(prefixed_user, [database])
+
+    def oversee_users(self, postgresql_client: PostgreSQLClient) -> None:
+        """Remove users from database if their relations were broken."""
+        if not self.state.peer.is_app_leader:
+            return
+
+        delete_user = "suppress-oversee-users" not in self.state.application.data
+
+        # Retrieve database users.
+        try:
+            database_users = {
+                user
+                for user in postgresql_client.list_users()
+                if user.startswith(self._username_prefix)
+            }
+        except PostgreSQLBaseError as e:
+            logger.error("Early-exit, failed to oversee users: %r", e)
+            return
+
+        # Retrieve the users from the active relations.
+        relation_users = {
+            self.relation_username(relation.id)
+            for relation in self.state.model.relations[self.relation_name]
+        }
+
+        # Delete that users that exist in the database but not in the active relations.
+        for user in database_users - relation_users:
+            if delete_user:
+                try:
+                    logger.info("Remove relation user: %s", user)
+                    self.state.set_secret(APP_SCOPE, user, None)
+                    self.state.set_secret(APP_SCOPE, f"{user}-database", None)
+                    postgresql_client.delete_user(user)
+                except PostgreSQLDeleteUserError:
+                    logger.error("Failed to delete user %s", user)
+            else:
+                logger.info("Stale relation user detected: %s", user)
+
+    # -- Blocking-status validation
+
+    def check_for_invalid_extra_user_roles(
+        self, postgresql_client: PostgreSQLClient, relation_id: int
+    ) -> bool:
+        """Checks if there are relations with invalid extra user roles.
+
+        Args:
+            postgresql_client: the PostgreSQL client to list valid privileges with.
+            relation_id: current relation to be skipped.
+        """
+        valid_privileges, valid_roles = postgresql_client.list_valid_privileges_and_roles()
+        # VM also accepts "createdb", which is not a privilege or role PostgreSQL reports.
+        extra_valid = {"createdb"} if self.state.substrate == Substrates.VM else set()
+        for relation in self.state.model.relations.get(self.relation_name, []):
+            if relation.id == relation_id:
+                continue
+            for data in relation.data.values():
+                for extra_user_role in self.sanitize_extra_roles(data.get("extra-user-roles")):
+                    if (
+                        extra_user_role not in valid_privileges
+                        and extra_user_role not in valid_roles
+                        and extra_user_role not in extra_valid
+                    ):
+                        return True
+        return False
+
+    def check_for_invalid_database_name(self, relation_id: int) -> bool:
+        """Checks if there are relations with invalid database names.
+
+        Args:
+            relation_id: current relation to be skipped.
+        """
+        for relation in self.state.model.relations.get(self.relation_name, []):
+            if relation.id == relation_id:
+                continue
+            for data in relation.data.values():
+                database = data.get("database")
+                if database is not None and (
+                    len(database) > 49 or database in INVALID_DATABASE_NAMES
+                ):
+                    return True
+        return False
+
+    def unblock_custom_user_errors(
+        self, postgresql_client: PostgreSQLClient, relation: Relation
+    ) -> None:
+        """Clear a custom-user blocking status once no relation still requests one."""
+        if self.check_for_invalid_extra_user_roles(postgresql_client, relation.id):
+            self.set_unit_status(BlockedStatus(INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE))
+            return
+        existing_users = postgresql_client.list_users()
+        for other in self.state.model.relations.get(self.relation_name, []):
+            try:
+                # Relation is not established and custom user was requested
+                if not self.database_provides.fetch_my_relation_field(
+                    other.id, "secret-user"
+                ) and (
+                    secret_uri := self.database_provides.fetch_relation_field(
+                        other.id, "requested-entity-secret"
+                    )
+                ):
+                    content = self.state.model.get_secret(id=secret_uri).get_content()
+                    for key in content:
+                        if key in SYSTEM_USERS or key in existing_users:
+                            logger.warning(
+                                f"Relation {other.id} is still requesting a forbidden user"
+                            )
+                            self.set_unit_status(BlockedStatus(FORBIDDEN_USER_MSG))
+                            return
+            except ModelError:
+                logger.warning(f"Relation {other.id} still cannot access the set secret")
+                self.set_unit_status(BlockedStatus(NO_ACCESS_TO_SECRET_MSG))
+                return
+        self.set_unit_status(ActiveStatus())
+
+    def update_unit_status(self, postgresql_client: PostgreSQLClient, relation: Relation) -> None:
+        """Clean up Blocked status if it's due to extensions request."""
+        unit = self.state.model.unit
+        if (
+            (
+                self.state.peer.is_blocked
+                and (
+                    unit.status.message == INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE
+                    or unit.status.message == INVALID_DATABASE_NAME_BLOCKING_MESSAGE
+                )
+            )
+            and not self.check_for_invalid_extra_user_roles(postgresql_client, relation.id)
+            and not self.check_for_invalid_database_name(relation.id)
+        ):
+            self.set_unit_status(ActiveStatus())
+        # Matches the handler's failed-init message; the charms' longer substring never
+        # matched their K8s wording, leaving the block unclearable there.
+        if self.state.peer.is_blocked and "Failed to initialize" in unit.status.message:
+            self.set_unit_status(ActiveStatus())
+        if self.state.peer.is_blocked and unit.status.message == PREFIX_TOO_SHORT_MSG:
+            for other in self.state.model.relations.get(self.relation_name, []):
+                # Relation is not established and custom user was requested
+                if (
+                    (database := self.database_provides.fetch_relation_field(other.id, "database"))
+                    and database[-1] == "*"
+                    and len(database) < MINIMUM_PREFIX_REQUEST_LENGTH
+                ):
+                    return
+                self.set_unit_status(ActiveStatus())
+                return
+        if self.state.peer.is_blocked and unit.status.message in [
+            INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE,
+            NO_ACCESS_TO_SECRET_MSG,
+            FORBIDDEN_USER_MSG,
+        ]:
+            self.unblock_custom_user_errors(postgresql_client, relation)

--- a/single_kernel_postgresql/managers/database.py
+++ b/single_kernel_postgresql/managers/database.py
@@ -458,7 +458,9 @@ class DatabaseManager(BaseManager):
         for member in online_members:
             unit = self.state.model.get_unit(label2name(member["name"]))
             if member["role"] == "leader":
-                primary_unit_ip = self._unit_ip(unit) or ""
+                # A stale leader unit without a peer address publishes "None:5432",
+                # as the charm did.
+                primary_unit_ip = self._unit_ip(unit)
                 rw_endpoint = f"{primary_unit_ip}:{DATABASE_PORT}"
             else:
                 replica_ip = self._unit_ip(unit)

--- a/single_kernel_postgresql/managers/database.py
+++ b/single_kernel_postgresql/managers/database.py
@@ -16,13 +16,14 @@ from functools import cached_property
 from hashlib import shake_128
 from typing import TypedDict
 
-from ops import ActiveStatus, BlockedStatus, ModelError, Relation, StatusBase
+from ops import ActiveStatus, BlockedStatus, ModelError, Relation, StatusBase, Unit
 
 from single_kernel_postgresql.config.enums import Substrates
 from single_kernel_postgresql.config.literals import (
     APP_SCOPE,
     DATABASE,
     DATABASE_MAPPING_LABEL,
+    DATABASE_PORT,
     PLUGIN_OVERRIDES,
     SPI_MODULE,
     SYSTEM_USERS,
@@ -35,7 +36,7 @@ from single_kernel_postgresql.lib.charms.data_platform_libs.v0.data_interfaces i
 from single_kernel_postgresql.managers.base import BaseManager
 from single_kernel_postgresql.managers.patroni import PatroniManager
 from single_kernel_postgresql.managers.tls import TLSManager
-from single_kernel_postgresql.utils import new_password
+from single_kernel_postgresql.utils import label2name, new_password
 from single_kernel_postgresql.utils.postgresql import (
     ACCESS_GROUP_RELATION,
     ACCESS_GROUPS,
@@ -433,6 +434,141 @@ class DatabaseManager(BaseManager):
                     logger.error("Failed to delete user %s", user)
             else:
                 logger.info("Stale relation user detected: %s", user)
+
+    # -- Endpoint publishing
+
+    def _unit_ip(self, unit: Unit) -> str | None:
+        """The client-facing address a peer unit published for this relation."""
+        if not self.state.peer_relation:
+            return None
+        try:
+            return self.state.peer_relation.data[unit].get(f"{self.relation_name}-address")
+        except KeyError:
+            return None
+
+    def _vm_endpoints(self) -> tuple[str, str, str]:
+        """(rw_endpoint, ro_endpoints, ro_hosts) from the online Patroni members."""
+        online_members = [
+            member
+            for member in self.patroni_manager.online_cluster_members()
+            if not member.get("tags", {}).get("nosync", False)
+        ]
+
+        primary_unit_ip, rw_endpoint, ro_hosts, ro_endpoints = "", "", "", ""
+        for member in online_members:
+            unit = self.state.model.get_unit(label2name(member["name"]))
+            if member["role"] == "leader":
+                primary_unit_ip = self._unit_ip(unit) or ""
+                rw_endpoint = f"{primary_unit_ip}:{DATABASE_PORT}"
+            else:
+                replica_ip = self._unit_ip(unit)
+                if not replica_ip:
+                    continue
+                if ro_hosts:
+                    ro_hosts = f"{ro_hosts},{replica_ip}"
+                    ro_endpoints = f"{ro_endpoints},{replica_ip}:{DATABASE_PORT}"
+                else:
+                    ro_hosts = replica_ip
+                    ro_endpoints = f"{replica_ip}:{DATABASE_PORT}"
+        if not ro_hosts and primary_unit_ip:
+            # If there are no replicas, fallback to primary
+            ro_endpoints = rw_endpoint
+            ro_hosts = primary_unit_ip
+        return rw_endpoint, ro_endpoints, ro_hosts
+
+    def _k8s_endpoints(self) -> tuple[str, str, str]:
+        """(rw_endpoint, ro_endpoints, ro_hosts) from the primary/replicas Services."""
+        peer_relation = self.state.peer_relation
+        ro_hosts = (
+            self.state.replicas_endpoint
+            if peer_relation and len(peer_relation.units) > 0
+            else self.state.primary_endpoint
+        )
+        return (
+            f"{self.state.primary_endpoint}:{DATABASE_PORT}",
+            f"{ro_hosts}:{DATABASE_PORT}",
+            ro_hosts,
+        )
+
+    def update_endpoints(self, relation_id: int | None = None) -> None:  # noqa: C901
+        """Set the read/write and read-only endpoints on the client relations.
+
+        Args:
+            relation_id: restrict the update to one relation; all of them when None.
+        """
+        if not self.state.peer.is_app_leader:
+            return
+
+        relations_ids = [relation_id] if relation_id is not None else None
+        rel_data = self.database_provides.fetch_relation_data(
+            relations_ids, ["external-node-connectivity", "database"]
+        )
+
+        # skip if no relation data
+        if not rel_data:
+            return
+
+        secret_data = (
+            self.database_provides.fetch_my_relation_data(relations_ids, ["username", "password"])
+            or {}
+        )
+
+        if self.state.substrate == Substrates.K8S:
+            rw_endpoint, ro_endpoints, ro_hosts = self._k8s_endpoints()
+        else:
+            rw_endpoint, ro_endpoints, ro_hosts = self._vm_endpoints()
+
+        tls = "True" if self.is_tls_enabled else "False"
+        ca = None
+        if tls == "True":
+            _, ca, _ = self.tls_manager.get_client_tls_files()
+        if not ca:
+            ca = ""
+
+        prefix_database_mapping = self.get_databases_prefix_mapping()
+
+        for current_id in rel_data:
+            database = rel_data[current_id].get("database")
+            databases = None
+            prefix_def = prefix_database_mapping.get(str(current_id))
+            if prefix_def is not None:
+                databases = prefix_def["databases"]
+                self.database_provides.set_prefix_databases(current_id, databases)
+                database = databases[0] if len(databases) else database
+            user = secret_data.get(current_id, {}).get("username")
+            password = secret_data.get(current_id, {}).get("password")
+            if not database or not password:
+                continue
+
+            self.database_provides.set_endpoints(current_id, rw_endpoint)
+            self.database_provides.set_read_only_endpoints(current_id, ro_endpoints)
+            self.database_provides.set_tls(current_id, tls)
+            self.database_provides.set_tls_ca(current_id, ca)
+            if databases is None or len(databases):
+                # Set connection string URI.
+                self.database_provides.set_uris(
+                    current_id,
+                    f"postgresql://{user}:{password}@{rw_endpoint}/{database}",
+                )
+                # Make sure that the URI will be a secret
+                if (
+                    secret_fields := self.database_provides.fetch_relation_field(
+                        current_id, "requested-secrets"
+                    )
+                ) and "read-only-uris" in secret_fields:
+                    self.database_provides.set_read_only_uris(
+                        current_id,
+                        f"postgresql://{user}:{password}@{ro_hosts}:{DATABASE_PORT}/{database}",
+                    )
+            else:
+                # No database matches prefix, no valid URI
+                self.database_provides.delete_relation_data(current_id, ["uris", "read-only-uris"])
+            self.set_rel_to_db_mapping()
+
+    @property
+    def is_tls_enabled(self) -> bool:
+        """Whether the client-facing TLS files have been issued."""
+        return all(self.tls_manager.get_client_tls_files())
 
     # -- Blocking-status validation
 

--- a/single_kernel_postgresql/managers/database.py
+++ b/single_kernel_postgresql/managers/database.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Database Manager.
+
+Responsible for the ``database`` (``postgresql_client``) client relation: the user and
+database lifecycle, the username/prefix-database mapping caches, and the user-databases
+map the Patroni config renders its pg_hba rules from.
+"""
+
+import json
+import logging
+from collections.abc import Callable
+from hashlib import shake_128
+from typing import TypedDict
+
+from data_platform_helpers.advanced_statuses import StatusObject
+from data_platform_helpers.advanced_statuses.types import Scope as AdvancedStatusesScope
+from ops import StatusBase
+
+from single_kernel_postgresql.config.enums import Substrates
+from single_kernel_postgresql.config.literals import (
+    APP_SCOPE,
+    DATABASE,
+    DATABASE_MAPPING_LABEL,
+    PLUGIN_OVERRIDES,
+    SPI_MODULE,
+    USERNAME_MAPPING_LABEL,
+)
+from single_kernel_postgresql.config.statuses import GeneralStatuses
+from single_kernel_postgresql.core.state import CharmState
+from single_kernel_postgresql.lib.charms.data_platform_libs.v0.data_interfaces import (
+    DatabaseProvides,
+)
+from single_kernel_postgresql.managers.base import BaseManager
+from single_kernel_postgresql.managers.patroni import PatroniManager
+from single_kernel_postgresql.managers.tls import TLSManager
+from single_kernel_postgresql.workload.base import BaseWorkload
+
+logger = logging.getLogger(__name__)
+
+
+class PrefixDatabaseCacheType(TypedDict):
+    """Type definition for the prefix database cached mapping."""
+
+    username: str
+    prefix: str
+    databases: list[str]
+
+
+class DatabaseManager(BaseManager):
+    """PostgreSQL Database Manager.
+
+    This manager is responsible for handling the client relation user and database
+    lifecycle. It owns no events; :class:`~single_kernel_postgresql.events.database`
+    drives it and maps its outcomes onto defer/status.
+    """
+
+    def __init__(
+        self,
+        state: CharmState,
+        workload: BaseWorkload,
+        database_provides: DatabaseProvides,
+        patroni_manager: PatroniManager,
+        tls_manager: TLSManager,
+        set_unit_status: Callable[[StatusBase], None],
+        relation_name: str = DATABASE,
+    ) -> None:
+        super().__init__(state, workload, "database_manager")
+        # Constructor-injected by events.database.DatabaseEventsHandler, which owns the
+        # provider interface and the ops observers.
+        self.database_provides = database_provides
+        self.patroni_manager = patroni_manager
+        self.tls_manager = tls_manager
+        # Injected only while the charm_refresh priority gate is still charm-side; once
+        # the refresh logic migrates into the library the manager owns its status writes.
+        self.set_unit_status = set_unit_status
+        self.relation_name = relation_name
+
+    # -- Relation user naming
+
+    @property
+    def _username_prefix(self) -> str:
+        """The prefix of the PostgreSQL role generated for a client relation.
+
+        The two substrates ship different live role names and deployed clusters hold
+        roles under whichever their charm created, so the name is substrate-derived
+        rather than converged. The SQL layer already matches both
+        (``utils.postgresql`` filters on ``relation-%`` OR ``relation_id_%``).
+        """
+        return "relation_id_" if self.state.substrate == Substrates.K8S else "relation-"
+
+    def relation_username(self, relation_id: int) -> str:
+        """Return the default PostgreSQL role name for a client relation."""
+        return f"{self._username_prefix}{relation_id}"
+
+    # -- Mapping caches (app peer secrets; labels are upgrade-compatible, do not rename)
+
+    def get_username_mapping(self) -> dict[str, str]:
+        """Get a mapping of custom usernames by a relation ID."""
+        if username_mapping := self.state.get_secret(APP_SCOPE, USERNAME_MAPPING_LABEL):
+            return json.loads(username_mapping)
+        return {}
+
+    def update_username_mapping(self, relation_id: int, username: str | None) -> None:
+        """Update a mapping of custom usernames in the application peer secret."""
+        if username == self.relation_username(relation_id):
+            return
+
+        username_mapping = self.get_username_mapping()
+        if username and username_mapping.get(str(relation_id)) != username:
+            username_mapping[str(relation_id)] = username
+        elif not username and str(relation_id) in username_mapping:
+            del username_mapping[str(relation_id)]
+        else:
+            # Cache is up to date
+            return
+        self.state.set_secret(APP_SCOPE, USERNAME_MAPPING_LABEL, json.dumps(username_mapping))
+
+    def get_databases_prefix_mapping(self) -> dict[str, PrefixDatabaseCacheType]:
+        """Get a mapping of prefixed databases by relation ID."""
+        if database_mapping := self.state.get_secret(APP_SCOPE, DATABASE_MAPPING_LABEL):
+            return json.loads(database_mapping)
+        return {}
+
+    def set_databases_prefix_mapping(
+        self,
+        relation_id: int,
+        username: str | None,
+        prefix: str | None,
+        databases: list[str] | None,
+    ) -> None:
+        """Set the initial mapping of prefix databases."""
+        database_mapping = self.get_databases_prefix_mapping()
+        # Empty databases is valid
+        if prefix and username and databases is not None:
+            database_mapping[str(relation_id)] = {
+                "prefix": prefix,
+                "username": username,
+                "databases": databases,
+            }
+        elif not prefix and str(relation_id) in database_mapping:
+            del database_mapping[str(relation_id)]
+        else:
+            # Cache is up to date
+            return
+        self.state.set_secret(APP_SCOPE, DATABASE_MAPPING_LABEL, json.dumps(database_mapping))
+
+    def add_database_to_prefix_mapping(self, database: str) -> list[str]:
+        """Add a new database to all fitting prefixes."""
+        usernames = []
+        dirty = False
+        database_mapping = self.get_databases_prefix_mapping()
+        for value in database_mapping.values():
+            if database.startswith(value["prefix"]):
+                if database not in value["databases"]:
+                    value["databases"].append(database)
+                    value["databases"].sort()
+                    dirty = True
+                usernames.append(value["username"])
+        if dirty:
+            self.state.set_secret(APP_SCOPE, DATABASE_MAPPING_LABEL, json.dumps(database_mapping))
+        return usernames
+
+    def remove_database_from_prefix_mapping(self, database: str) -> list[str]:
+        """Remove a database from all fitting prefixes."""
+        usernames = []
+        database_mapping = self.get_databases_prefix_mapping()
+        for value in database_mapping.values():
+            if database in value["databases"]:
+                value["databases"].remove(database)
+                usernames.append(value["username"])
+        if usernames:
+            self.state.set_secret(APP_SCOPE, DATABASE_MAPPING_LABEL, json.dumps(database_mapping))
+        return usernames
+
+    def set_rel_to_db_mapping(self) -> None:
+        """Set mapping between relation and database."""
+        if self.state.peer.is_app_leader:
+            self.state.application.data["rel_databases"] = json.dumps({
+                key: val["database"]
+                for key, val in self.database_provides.fetch_relation_data(
+                    None, ["database"]
+                ).items()
+                if val.get("database")
+            })
+
+    def get_rel_to_db_mapping(self) -> dict[str, str] | None:
+        """Get mapping between relation and database."""
+        if self.state.peer.is_app_leader:
+            return json.loads(self.state.application.data.get("rel_databases", "{}"))
+
+    # -- User/database map consumed by the Patroni pg_hba render
+
+    def collect_user_relations(self) -> dict[str, str]:
+        """Return the user->databases pairs the established client relations imply."""
+        user_db_pairs = {}
+        custom_username_mapping = self.get_username_mapping()
+        prefix_database_mapping = self.get_databases_prefix_mapping()
+
+        for relation in self.state.model.relations[self.relation_name]:
+            if database := self.database_provides.fetch_relation_field(relation.id, "database"):
+                user = custom_username_mapping.get(
+                    str(relation.id), self.relation_username(relation.id)
+                )
+                database = ",".join(prefix_database_mapping.get(str(relation.id), [database]))
+                user_db_pairs[user] = database
+        return user_db_pairs
+
+    @property
+    def user_hash(self) -> str:
+        """Hash of the expected users and databases, used to detect unsynced peers."""
+        return shake_128(str(self.collect_user_relations()).encode()).hexdigest(16)
+
+    def are_units_in_sync(self) -> bool:
+        """Whether every peer unit has applied the current user hash."""
+        expected = self.user_hash
+        if not self.state.peer_relation:
+            return True
+        for key in self.state.peer_relation.data:
+            # We skip the leader so we don't have to wait on the defer
+            if (
+                key != self.state.model.app
+                and key != self.state.model.unit
+                and self.state.peer_relation.data[key].get("user_hash", "") != expected
+            ):
+                return False
+        return True
+
+    # -- Plugins
+
+    def get_plugins(self) -> list[str]:
+        """Return a list of installed plugins."""
+        config = self.state.config
+        plugins = [
+            "_".join(plugin.split("_")[1:-1])
+            for plugin in config.plugin_keys()
+            if getattr(config, plugin)
+        ]
+        plugins = [PLUGIN_OVERRIDES.get(plugin, plugin) for plugin in plugins]
+        if "spi" in plugins:
+            plugins.remove("spi")
+            plugins.extend(SPI_MODULE)
+        return plugins
+
+    def get_statuses(
+        self, scope: AdvancedStatusesScope, recompute: bool = False
+    ) -> list[StatusObject]:
+        """Compute the manager's statuses."""
+        if not recompute:
+            return self.state.statuses.get(scope, self.name).root or [
+                GeneralStatuses.ACTIVE_IDLE.value
+            ]
+        return [GeneralStatuses.ACTIVE_IDLE.value]

--- a/single_kernel_postgresql/managers/database.py
+++ b/single_kernel_postgresql/managers/database.py
@@ -97,8 +97,8 @@ class DatabaseManager(BaseManager):
         relation_name: str = DATABASE,
     ) -> None:
         super().__init__(state, workload, "database_manager")
-        # Constructor-injected by events.database.DatabaseEventsHandler, which owns the
-        # provider interface and the ops observers.
+        # Constructor-injected by the charm, the composition root: it owns the provider
+        # interface and the ops observers live in the events handler.
         self.database_provides = database_provides
         # Injected only while the charm_refresh priority gate is still charm-side; once
         # the refresh logic migrates into the library the manager owns its status writes.

--- a/single_kernel_postgresql/managers/database.py
+++ b/single_kernel_postgresql/managers/database.py
@@ -32,8 +32,6 @@ from single_kernel_postgresql.lib.charms.data_platform_libs.v0.data_interfaces i
     DatabaseProvides,
 )
 from single_kernel_postgresql.managers.base import BaseManager
-from single_kernel_postgresql.managers.patroni import PatroniManager
-from single_kernel_postgresql.managers.tls import TLSManager
 from single_kernel_postgresql.workload.base import BaseWorkload
 
 logger = logging.getLogger(__name__)
@@ -60,8 +58,6 @@ class DatabaseManager(BaseManager):
         state: CharmState,
         workload: BaseWorkload,
         database_provides: DatabaseProvides,
-        patroni_manager: PatroniManager,
-        tls_manager: TLSManager,
         set_unit_status: Callable[[StatusBase], None],
         relation_name: str = DATABASE,
     ) -> None:
@@ -69,8 +65,6 @@ class DatabaseManager(BaseManager):
         # Constructor-injected by events.database.DatabaseEventsHandler, which owns the
         # provider interface and the ops observers.
         self.database_provides = database_provides
-        self.patroni_manager = patroni_manager
-        self.tls_manager = tls_manager
         # Injected only while the charm_refresh priority gate is still charm-side; once
         # the refresh logic migrates into the library the manager owns its status writes.
         self.set_unit_status = set_unit_status

--- a/single_kernel_postgresql/managers/database.py
+++ b/single_kernel_postgresql/managers/database.py
@@ -510,9 +510,8 @@ class DatabaseManager(BaseManager):
                 raise ValueError("online_members is required on the VM substrate")
             rw_endpoint, ro_endpoints, ro_hosts = self._vm_endpoints(online_members)
 
-        client_tls_files = client_tls_files or (None, None, None)
-        tls = "True" if all(client_tls_files) else "False"
-        ca = client_tls_files[1] or ""
+        tls = "True" if client_tls_files and all(client_tls_files) else "False"
+        ca = (client_tls_files[1] if client_tls_files else None) or ""
 
         prefix_database_mapping = self.get_databases_prefix_mapping()
 

--- a/single_kernel_postgresql/managers/database.py
+++ b/single_kernel_postgresql/managers/database.py
@@ -300,16 +300,12 @@ class DatabaseManager(BaseManager):
         self, postgresql_client: PostgreSQLClient, request: DatabaseRequest
     ) -> tuple[str, str] | None:
         """Resolve the user and password for a request, or block and return None."""
-        try:
-            if requested_entities := request["requested_entity_secret_content"]:
-                for key, val in requested_entities.items():
-                    if key in SYSTEM_USERS or key in postgresql_client.list_users():
-                        self.set_unit_status(BlockedStatus(FORBIDDEN_USER_MSG))
-                        return None
-                    return key, val or new_password()
-        except ModelError:
-            self.set_unit_status(BlockedStatus(NO_ACCESS_TO_SECRET_MSG))
-            return None
+        if requested_entities := request["requested_entity_secret_content"]:
+            for key, val in requested_entities.items():
+                if key in SYSTEM_USERS or key in postgresql_client.list_users():
+                    self.set_unit_status(BlockedStatus(FORBIDDEN_USER_MSG))
+                    return None
+                return key, val or new_password()
         return self.relation_username(request["relation_id"]), new_password()
 
     def collect_databases(

--- a/single_kernel_postgresql/managers/database.py
+++ b/single_kernel_postgresql/managers/database.py
@@ -12,6 +12,7 @@ map the Patroni config renders its pg_hba rules from.
 import json
 import logging
 from collections.abc import Callable
+from functools import cached_property
 from hashlib import shake_128
 from typing import TypedDict
 
@@ -208,9 +209,13 @@ class DatabaseManager(BaseManager):
                 user_db_pairs[user] = database
         return user_db_pairs
 
-    @property
+    @cached_property
     def user_hash(self) -> str:
-        """Hash of the expected users and databases, used to detect unsynced peers."""
+        """Hash of the expected users and databases, used to detect unsynced peers.
+
+        Frozen at first read for the manager's lifetime, as both charms cached it per
+        hook: the request flow's second update_config stores the same hash as the first.
+        """
         return shake_128(str(self.collect_user_relations()).encode()).hexdigest(16)
 
     def are_units_in_sync(self) -> bool:

--- a/single_kernel_postgresql/managers/database.py
+++ b/single_kernel_postgresql/managers/database.py
@@ -34,6 +34,7 @@ from single_kernel_postgresql.lib.charms.data_platform_libs.v0.data_interfaces i
     DatabaseProvides,
 )
 from single_kernel_postgresql.managers.base import BaseManager
+from single_kernel_postgresql.managers.patroni import ClusterMember
 from single_kernel_postgresql.utils import label2name, new_password
 from single_kernel_postgresql.utils.postgresql import (
     ACCESS_GROUP_RELATION,
@@ -431,7 +432,7 @@ class DatabaseManager(BaseManager):
 
     # -- Endpoint publishing
 
-    def _vm_endpoints(self, online_members: list[dict]) -> tuple[str, str, str]:
+    def _vm_endpoints(self, online_members: list[ClusterMember]) -> tuple[str, str, str]:
         """(rw_endpoint, ro_endpoints, ro_hosts) from the online Patroni members."""
         members = [
             member for member in online_members if not member.get("tags", {}).get("nosync", False)
@@ -478,7 +479,7 @@ class DatabaseManager(BaseManager):
     def update_endpoints(
         self,
         relation_id: int | None = None,
-        online_members: list[dict] | None = None,
+        online_members: list[ClusterMember] | None = None,
         client_tls_files: tuple[str | None, str | None, str | None] | None = None,
     ) -> None:
         """Set the read/write and read-only endpoints on the client relations.

--- a/single_kernel_postgresql/managers/database.py
+++ b/single_kernel_postgresql/managers/database.py
@@ -440,16 +440,14 @@ class DatabaseManager(BaseManager):
         except KeyError:
             return None
 
-    def _vm_endpoints(self) -> tuple[str, str, str]:
+    def _vm_endpoints(self, online_members: list[dict]) -> tuple[str, str, str]:
         """(rw_endpoint, ro_endpoints, ro_hosts) from the online Patroni members."""
-        online_members = [
-            member
-            for member in self.patroni_manager.online_cluster_members()
-            if not member.get("tags", {}).get("nosync", False)
+        members = [
+            member for member in online_members if not member.get("tags", {}).get("nosync", False)
         ]
 
         primary_unit_ip, rw_endpoint, ro_hosts, ro_endpoints = "", "", "", ""
-        for member in online_members:
+        for member in members:
             unit = self.state.model.get_unit(label2name(member["name"]))
             if member["role"] == "leader":
                 # A stale leader unit without a peer address publishes "None:5432",
@@ -486,11 +484,19 @@ class DatabaseManager(BaseManager):
             ro_hosts,
         )
 
-    def update_endpoints(self, relation_id: int | None = None) -> None:  # noqa: C901
+    def update_endpoints(
+        self,
+        relation_id: int | None = None,
+        online_members: list[dict] | None = None,
+        client_tls_files: tuple[str | None, str | None, str | None] | None = None,
+    ) -> None:
         """Set the read/write and read-only endpoints on the client relations.
 
         Args:
             relation_id: restrict the update to one relation; all of them when None.
+            online_members: the Patroni cluster members (VM only; gathered by the caller,
+                as the manager holds no peer-manager references).
+            client_tls_files: the (key, ca, cert) client TLS files, for the TLS flag and CA.
         """
         if not self.state.peer.is_app_leader:
             return
@@ -512,14 +518,13 @@ class DatabaseManager(BaseManager):
         if self.state.substrate == Substrates.K8S:
             rw_endpoint, ro_endpoints, ro_hosts = self._k8s_endpoints()
         else:
-            rw_endpoint, ro_endpoints, ro_hosts = self._vm_endpoints()
+            if online_members is None:
+                raise ValueError("online_members is required on the VM substrate")
+            rw_endpoint, ro_endpoints, ro_hosts = self._vm_endpoints(online_members)
 
-        tls = "True" if self.is_tls_enabled else "False"
-        ca = None
-        if tls == "True":
-            _, ca, _ = self.tls_manager.get_client_tls_files()
-        if not ca:
-            ca = ""
+        client_tls_files = client_tls_files or (None, None, None)
+        tls = "True" if all(client_tls_files) else "False"
+        ca = client_tls_files[1] or ""
 
         prefix_database_mapping = self.get_databases_prefix_mapping()
 
@@ -560,11 +565,6 @@ class DatabaseManager(BaseManager):
                 # No database matches prefix, no valid URI
                 self.database_provides.delete_relation_data(current_id, ["uris", "read-only-uris"])
             self.set_rel_to_db_mapping()
-
-    @property
-    def is_tls_enabled(self) -> bool:
-        """Whether the client-facing TLS files have been issued."""
-        return all(self.tls_manager.get_client_tls_files())
 
     # -- Blocking-status validation
 

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -27,7 +27,7 @@ def config(substrate):
             patroni_manager=Mock(),
             resource_provider=Mock(),
             request_restart=Mock(),
-            refresh_endpoints=Mock(),
+            database_manager=Mock(),
             restart_services=Mock(),
         )
     yield config
@@ -632,7 +632,7 @@ def test_handle_restart_need_persists_tls_flag_and_refreshes_endpoints(
     postgresql_client.is_tls_enabled.return_value = True
     restart_engine.handle_restart_need(postgresql_client, config_changed=False)
     restart_engine._peer_tls.assert_called_once_with(True)
-    restart_engine.refresh_endpoints.assert_called_once_with()
+    restart_engine.database_manager.update_endpoints.assert_called_once_with()
 
 
 def test_handle_restart_need_swallows_reload_patroni_error(restart_engine, postgresql_client):
@@ -768,6 +768,7 @@ def orchestrate(config, postgresql_client):
         # patroni_manager is a Mock; member_started / ensure_slots are plain attributes here.
         config.patroni_manager.member_started = True
         config.patroni_manager.ensure_slots_controller_by_patroni.return_value = True
+        config.database_manager.user_hash = "uh"
         config._is_tls = _is_tls
         config._hash = _hash
         config._peer_tls = _peer_tls
@@ -778,21 +779,21 @@ def orchestrate(config, postgresql_client):
 
 
 def test_update_config_no_peers_returns_true_early(orchestrate, postgresql_client):
-    assert orchestrate.update_config(postgresql_client, user_hash="uh", no_peers=True) is True
+    assert orchestrate.update_config(postgresql_client, no_peers=True) is True
     orchestrate.render_patroni_yml_file.assert_called_once()
-    orchestrate.refresh_endpoints.assert_not_called()
+    orchestrate.database_manager.update_endpoints.assert_not_called()
     orchestrate.handle_restart_need.assert_not_called()
 
 
 def test_update_config_threads_tls_flag_into_render(orchestrate, postgresql_client):
     """is_tls_enabled is what update_config passes as render_patroni_yml_file's enable_tls."""
     orchestrate._is_tls.return_value = True
-    orchestrate.update_config(postgresql_client, user_hash="uh", no_peers=True)
+    orchestrate.update_config(postgresql_client, no_peers=True)
     assert orchestrate.render_patroni_yml_file.call_args.kwargs["enable_tls"] is True
 
     orchestrate.render_patroni_yml_file.reset_mock()
     orchestrate._is_tls.return_value = False
-    orchestrate.update_config(postgresql_client, user_hash="uh", no_peers=True)
+    orchestrate.update_config(postgresql_client, no_peers=True)
     assert orchestrate.render_patroni_yml_file.call_args.kwargs["enable_tls"] is False
 
 
@@ -801,9 +802,9 @@ def test_update_config_workload_not_running_persists_tls_and_refreshes(
 ):
     orchestrate._is_tls.return_value = True
     with patch.object(orchestrate.workload, "is_patroni_running", return_value=False):
-        assert orchestrate.update_config(postgresql_client, user_hash="uh") is True
+        assert orchestrate.update_config(postgresql_client) is True
     orchestrate._peer_tls.assert_called_once_with(True)
-    orchestrate.refresh_endpoints.assert_called_once_with()
+    orchestrate.database_manager.update_endpoints.assert_called_once_with()
     orchestrate.handle_restart_need.assert_not_called()
 
 
@@ -812,14 +813,14 @@ def test_update_config_member_not_started_with_tls_forces_handle_restart_true(
 ):
     orchestrate._is_tls.return_value = True
     orchestrate.patroni_manager.member_started = False
-    assert orchestrate.update_config(postgresql_client, user_hash="uh") is True
+    assert orchestrate.update_config(postgresql_client) is True
     orchestrate.handle_restart_need.assert_called_once_with(postgresql_client, True)
 
 
 def test_update_config_member_not_started_no_tls_returns_false(orchestrate, postgresql_client):
     orchestrate._is_tls.return_value = False
     orchestrate.patroni_manager.member_started = False
-    assert orchestrate.update_config(postgresql_client, user_hash="uh") is False
+    assert orchestrate.update_config(postgresql_client) is False
     orchestrate.handle_restart_need.assert_not_called()
 
 
@@ -828,7 +829,7 @@ def test_update_config_cannot_connect_returns_false(substrate, orchestrate, post
     if substrate != Substrates.VM:
         pytest.skip("standalone connect gate is VM-only")
     with patch.object(orchestrate, "_can_connect_to_postgresql", return_value=False):
-        assert orchestrate.update_config(postgresql_client, user_hash="uh") is False
+        assert orchestrate.update_config(postgresql_client) is False
     orchestrate.apply_api_config.assert_not_called()
 
 
@@ -843,13 +844,13 @@ def test_update_config_k8s_proceeds_without_standalone_connect_gate(
     if substrate != Substrates.K8S:
         pytest.skip("this asserts the K8s-only no-gate behavior")
     with patch.object(orchestrate, "_can_connect_to_postgresql", return_value=False):
-        assert orchestrate.update_config(postgresql_client, user_hash="uh") is True
+        assert orchestrate.update_config(postgresql_client) is True
     orchestrate.apply_api_config.assert_called_once()
 
 
 def test_update_config_api_apply_fails_returns_false(orchestrate, postgresql_client):
     with patch.object(orchestrate, "apply_api_config", return_value=False):
-        assert orchestrate.update_config(postgresql_client, user_hash="uh") is False
+        assert orchestrate.update_config(postgresql_client) is False
     orchestrate.handle_restart_need.assert_not_called()
 
 
@@ -861,7 +862,7 @@ def test_update_config_happy_path_persists_hashes_and_calls_bridges(
         new_callable=PropertyMock,
         return_value=True,
     ):
-        assert orchestrate.update_config(postgresql_client, user_hash="uh") is True
+        assert orchestrate.update_config(postgresql_client) is True
     # config_hash change (old "oldhash" != new "newhash") drives handle_restart_need(True).
     orchestrate.handle_restart_need.assert_called_once_with(postgresql_client, True)
     orchestrate.restart_services.assert_called_once_with()
@@ -876,7 +877,7 @@ def test_update_config_ensure_slots_is_k8s_only(substrate, orchestrate, postgres
         new_callable=PropertyMock,
         return_value=False,
     ):
-        orchestrate.update_config(postgresql_client, user_hash="uh")
+        orchestrate.update_config(postgresql_client)
     if substrate == Substrates.K8S:
         orchestrate.patroni_manager.ensure_slots_controller_by_patroni.assert_called_once()
     else:
@@ -894,9 +895,7 @@ def test_update_config_vm_snap_gate_exits_before_restart_services(
     from unittest.mock import call
 
     with patch.object(orchestrate.workload, "get_snap_revision", return_value="123"):
-        assert (
-            orchestrate.update_config(postgresql_client, user_hash="uh", refresh=refresh) is True
-        )
+        assert orchestrate.update_config(postgresql_client, refresh=refresh) is True
     orchestrate.handle_restart_need.assert_called_once()
     orchestrate.restart_services.assert_not_called()
     # config_hash is read (getter, call()) for the restart decision but never PERSISTED

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -1,6 +1,6 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
-from unittest.mock import MagicMock, Mock, PropertyMock, patch, sentinel
+from unittest.mock import ANY, MagicMock, Mock, PropertyMock, patch, sentinel
 
 import pytest
 from single_kernel_postgresql.config.enums import Substrates
@@ -632,7 +632,9 @@ def test_handle_restart_need_persists_tls_flag_and_refreshes_endpoints(
     postgresql_client.is_tls_enabled.return_value = True
     restart_engine.handle_restart_need(postgresql_client, config_changed=False)
     restart_engine._peer_tls.assert_called_once_with(True)
-    restart_engine.database_manager.update_endpoints.assert_called_once_with()
+    restart_engine.database_manager.update_endpoints.assert_called_once_with(
+        online_members=ANY, client_tls_files=ANY
+    )
 
 
 def test_handle_restart_need_swallows_reload_patroni_error(restart_engine, postgresql_client):
@@ -804,7 +806,9 @@ def test_update_config_workload_not_running_persists_tls_and_refreshes(
     with patch.object(orchestrate.workload, "is_patroni_running", return_value=False):
         assert orchestrate.update_config(postgresql_client) is True
     orchestrate._peer_tls.assert_called_once_with(True)
-    orchestrate.database_manager.update_endpoints.assert_called_once_with()
+    orchestrate.database_manager.update_endpoints.assert_called_once_with(
+        online_members=ANY, client_tls_files=ANY
+    )
     orchestrate.handle_restart_need.assert_not_called()
 
 

--- a/tests/unit/test_database_events.py
+++ b/tests/unit/test_database_events.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 """Unit tests for the client-relation events handler."""
 
+import logging
 from contextlib import contextmanager
 from unittest.mock import Mock, PropertyMock, patch
 
@@ -101,7 +102,7 @@ def request_database(harness, database=DATABASE):
     return rel_id
 
 
-def test_database_requested_creates_the_user_and_database(harness, events, postgresql):
+def test_database_requested_creates_the_user_and_database(substrate, harness, events, postgresql):
     with cluster_ready(harness, postgresql) as update_endpoints:
         rel_id = request_database(harness)
 
@@ -113,7 +114,11 @@ def test_database_requested_creates_the_user_and_database(harness, events, postg
         extra_user_roles=["createdb", "createrole", ACCESS_GROUP_RELATION],
         database=DATABASE,
     )
-    update_endpoints.assert_called_once_with(rel_id)
+    if substrate == "k8s":
+        # K8s refreshed every relation from the request handler; VM scoped to the requester.
+        update_endpoints.assert_called_once_with()
+    else:
+        update_endpoints.assert_called_once_with(rel_id)
 
     data = harness.get_relation_data(rel_id, harness.charm.app.name)
     assert data["username"] == user
@@ -132,6 +137,119 @@ def test_database_requested_defers_until_the_cluster_is_ready(harness, events, p
 
     _defer.assert_called_once()
     postgresql.create_database.assert_not_called()
+
+
+def test_the_request_defer_message_is_substrate_specific(
+    substrate, harness, events, postgresql, caplog
+):
+    caplog.set_level(logging.DEBUG, logger="single_kernel_postgresql.events.database")
+    with (
+        cluster_ready(harness, postgresql, ready=False),
+        patch("ops.framework.EventBase.defer"),
+    ):
+        request_database(harness)
+
+    if substrate == "k8s":
+        assert "Cluster must be initialized before database can be requested" in caplog.text
+    else:
+        assert (
+            "cluster not initialized, Patroni not started or primary endpoint not available"
+            in caplog.text
+        )
+
+
+def test_the_request_guard_reads_substrate_specific_inputs(substrate, harness, events):
+    """K8s waits only on the primary endpoint; VM also requires a started member."""
+    with (
+        patch.object(
+            type(harness.charm),
+            "primary_endpoint",
+            new_callable=PropertyMock,
+            return_value="1.1.1.1",
+        ),
+        patch(
+            "single_kernel_postgresql.managers.patroni.PatroniManager.member_started",
+            new_callable=PropertyMock,
+            return_value=False,
+        ),
+        patch(
+            "single_kernel_postgresql.managers.patroni.PatroniManager.primary_endpoint_ready",
+            new_callable=PropertyMock,
+            return_value=True,
+        ),
+    ):
+        assert events._ready_for_request() is (substrate == "k8s")
+
+
+def test_the_guards_defer_while_the_cluster_is_not_initialised(substrate, harness, events):
+    peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            peer_rel_id, harness.charm.app.name, {"cluster_initialised": ""}
+        )
+    with (
+        patch.object(
+            type(harness.charm),
+            "primary_endpoint",
+            new_callable=PropertyMock,
+            return_value="1.1.1.1",
+        ),
+        patch(
+            "single_kernel_postgresql.managers.patroni.PatroniManager.member_started",
+            new_callable=PropertyMock,
+            return_value=True,
+        ),
+        patch(
+            "single_kernel_postgresql.managers.patroni.PatroniManager.primary_endpoint_ready",
+            new_callable=PropertyMock,
+            return_value=True,
+        ),
+    ):
+        assert events._ready_for_request() is False
+        assert events._ready_for_removal() is False
+
+
+def test_database_requested_blocks_before_creating_when_the_username_is_taken(
+    harness, events, postgresql
+):
+    postgresql.list_users.return_value = {"taken"}
+    with (
+        cluster_ready(harness, postgresql),
+        patch.object(
+            DatabaseRequestedEvent,
+            "requested_entity_secret_content",
+            new_callable=PropertyMock,
+            return_value={"taken": "pw"},
+        ),
+    ):
+        rel_id = request_database(harness)
+
+    assert harness.model.unit.status == BlockedStatus("Requesting an existing username")
+    postgresql.create_database.assert_not_called()
+    assert "username" not in harness.get_relation_data(rel_id, harness.charm.app.name)
+
+
+def test_database_requested_blocks_before_creating_when_the_prefix_is_too_short(
+    harness, events, postgresql
+):
+    with cluster_ready(harness, postgresql):
+        rel_id = request_database(harness, database="a*")
+
+    assert harness.model.unit.status == BlockedStatus("Prefix too short")
+    postgresql.create_database.assert_not_called()
+    assert "username" not in harness.get_relation_data(rel_id, harness.charm.app.name)
+
+
+def test_database_requested_publishes_nothing_when_creation_fails(harness, events, postgresql):
+    postgresql.create_database.side_effect = PostgreSQLCreateDatabaseError("bad name")
+    with cluster_ready(harness, postgresql):
+        rel_id = request_database(harness)
+
+    data = harness.get_relation_data(rel_id, harness.charm.app.name)
+    assert "username" not in data
+    assert "uris" not in data
+    assert "version" not in data
+    assert "database" not in data
 
 
 def test_database_requested_defers_until_peers_have_synced(harness, events, postgresql):
@@ -195,6 +313,26 @@ def test_database_requested_blocks_when_the_requested_entity_secret_is_not_reada
     postgresql.create_database.assert_not_called()
 
 
+def test_the_unreadable_secret_block_routes_through_the_status_bridge(harness, events, postgresql):
+    """The missing-grant block goes through the charm's set_unit_status on both substrates."""
+    with (
+        cluster_ready(harness, postgresql),
+        patch.object(type(harness.charm), "set_unit_status", Mock()) as _gated,
+        patch.object(
+            DatabaseRequestedEvent,
+            "requested_entity_secret_content",
+            new_callable=PropertyMock,
+        ) as _content,
+    ):
+        _content.side_effect = ModelError()
+        request_database(harness)
+
+    _gated.assert_called_once()
+    assert _gated.call_args.args[0] == BlockedStatus("Missing grant to requested entity secret")
+    assert not isinstance(harness.model.unit.status, BlockedStatus)
+    postgresql.create_database.assert_not_called()
+
+
 def test_database_requested_is_a_noop_for_a_follower(harness, events, postgresql):
     """The provider library already filters non-leaders; the handler guard is belt-and-braces."""
     with harness.hooks_disabled():
@@ -228,6 +366,50 @@ def test_database_requested_publishes_k8s_service_endpoints_inline(
         assert "endpoints" not in data
 
 
+def test_the_k8s_inline_publish_sets_the_tls_fields_when_tls_is_enabled(
+    substrate, harness, events, postgresql
+):
+    if substrate != "k8s":
+        pytest.skip("Only K8s wrote the TLS fields inside the request handler")
+    with (
+        cluster_ready(harness, postgresql),
+        patch.object(
+            type(events.manager.tls_manager),
+            "get_client_tls_files",
+            return_value=("key", "CA", "cert"),
+        ),
+    ):
+        rel_id = request_database(harness)
+
+    data = harness.get_relation_data(rel_id, harness.charm.app.name)
+    assert data["tls"] == "True"
+    assert data["tls-ca"] == "CA"
+
+
+def test_the_relation_departed_observer_flags_the_departing_unit(harness, events):
+    """Emitted through the framework, so the observer registration is itself exercised."""
+    peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+    relation = harness.model.get_relation(RELATION_NAME)
+
+    harness.charm.on[RELATION_NAME].relation_departed.emit(
+        relation, departing_unit_name=harness.charm.unit.name
+    )
+
+    assert "departing" in harness.get_relation_data(peer_rel_id, harness.charm.unit)
+
+
+def test_the_relation_broken_observer_deletes_the_user(harness, events, postgresql):
+    """Emitted through the framework, so the observer registration is itself exercised."""
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+
+    with cluster_ready(harness, postgresql):
+        harness.charm.on[RELATION_NAME].relation_broken.emit(
+            harness.model.get_relation(RELATION_NAME)
+        )
+
+    postgresql.delete_user.assert_called_once_with(events.manager.relation_username(rel_id))
+
+
 def test_relation_departed_flags_only_this_unit(harness, events):
     peer_rel_id = harness.model.get_relation(PEER_RELATION).id
     event = Mock()
@@ -242,6 +424,25 @@ def test_relation_departed_flags_only_this_unit(harness, events):
     )
     events._on_relation_departed(event)
     assert "departing" not in harness.get_relation_data(peer_rel_id, harness.charm.unit)
+
+
+def test_the_broken_defer_message_is_substrate_specific(
+    substrate, harness, events, postgresql, caplog
+):
+    caplog.set_level(logging.DEBUG, logger="single_kernel_postgresql.events.database")
+    event = Mock()
+    event.relation = harness.model.get_relation(RELATION_NAME)
+
+    with cluster_ready(harness, postgresql, ready=False):
+        events._on_relation_broken(event)
+
+    if substrate == "k8s":
+        assert "Cluster must be initialized before user can be deleted" in caplog.text
+    else:
+        assert (
+            "Cluster must be initialized and primary available before user can be deleted"
+            in caplog.text
+        )
 
 
 def test_relation_broken_deletes_the_user(harness, events, postgresql):

--- a/tests/unit/test_database_events.py
+++ b/tests/unit/test_database_events.py
@@ -1,0 +1,311 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""Unit tests for the client-relation events handler."""
+
+from contextlib import contextmanager
+from unittest.mock import Mock, PropertyMock, patch
+
+import pytest
+from ops import ActiveStatus, BlockedStatus, Unit
+from single_kernel_postgresql.config.literals import PEER_RELATION
+from single_kernel_postgresql.utils.postgresql import (
+    ACCESS_GROUP_RELATION,
+    PostgreSQLCreateDatabaseError,
+    PostgreSQLCreateUserError,
+    PostgreSQLGetPostgreSQLVersionError,
+)
+
+RELATION_NAME = "database"
+DATABASE = "test_database"
+EXTRA_USER_ROLES = "CREATEDB,CREATEROLE"
+POSTGRESQL_VERSION = "16"
+USER_HASH = "relhash"
+
+
+@pytest.fixture
+def events(harness):
+    """A begun leader charm with the cluster initialised and a client relation."""
+    with harness.hooks_disabled():
+        harness.set_leader(True)
+        peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+        harness.update_relation_data(
+            peer_rel_id, harness.charm.app.name, {"cluster_initialised": "True"}
+        )
+        harness.update_relation_data(
+            peer_rel_id, "postgresql-single-kernel/0", {"user_hash": USER_HASH}
+        )
+    harness.add_relation(RELATION_NAME, "application")
+    return harness.charm.database
+
+
+@pytest.fixture
+def postgresql():
+    client = Mock()
+    client.get_postgresql_version.return_value = POSTGRESQL_VERSION
+    client.list_users.return_value = set()
+    client.list_valid_privileges_and_roles.return_value = (set(), set())
+    return client
+
+
+@contextmanager
+def cluster_ready(harness, postgresql, ready=True):
+    """Patch every readiness input the two substrates' guards consult."""
+    with (
+        patch.object(type(harness.charm), "postgresql", PropertyMock(return_value=postgresql)),
+        patch.object(type(harness.charm), "update_config", Mock(return_value=True)),
+        patch.object(
+            type(harness.charm),
+            "primary_endpoint",
+            new_callable=PropertyMock,
+            return_value="1.1.1.1" if ready else None,
+        ),
+        patch(
+            "single_kernel_postgresql.managers.patroni.PatroniManager.member_started",
+            new_callable=PropertyMock,
+            return_value=ready,
+        ),
+        patch(
+            "single_kernel_postgresql.managers.patroni.PatroniManager.primary_endpoint_ready",
+            new_callable=PropertyMock,
+            return_value=ready,
+        ),
+        patch(
+            "single_kernel_postgresql.managers.database.DatabaseManager.get_plugins",
+            return_value=["pgaudit"],
+        ),
+        patch(
+            "single_kernel_postgresql.managers.database.DatabaseManager.update_endpoints"
+        ) as update_endpoints,
+        patch(
+            "single_kernel_postgresql.managers.database.new_password",
+            return_value="test-password",
+        ),
+        patch(
+            "single_kernel_postgresql.managers.database.DatabaseManager.user_hash",
+            new_callable=PropertyMock,
+            return_value=USER_HASH,
+        ),
+    ):
+        yield update_endpoints
+
+
+def request_database(harness, database=DATABASE):
+    """Drive a real database_requested through the provider library."""
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    harness.update_relation_data(
+        rel_id, "application", {"database": database, "extra-user-roles": EXTRA_USER_ROLES}
+    )
+    return rel_id
+
+
+def test_database_requested_creates_the_user_and_database(harness, events, postgresql):
+    with cluster_ready(harness, postgresql) as update_endpoints:
+        rel_id = request_database(harness)
+
+    user = events.manager.relation_username(rel_id)
+    postgresql.create_database.assert_called_once_with(DATABASE, plugins=["pgaudit"])
+    postgresql.create_user.assert_called_once_with(
+        user,
+        "test-password",
+        extra_user_roles=["createdb", "createrole", ACCESS_GROUP_RELATION],
+        database=DATABASE,
+    )
+    update_endpoints.assert_called_once_with(rel_id)
+
+    data = harness.get_relation_data(rel_id, harness.charm.app.name)
+    assert data["username"] == user
+    assert data["password"] == "test-password"
+    assert data["version"] == POSTGRESQL_VERSION
+    assert data["database"] == DATABASE
+    assert not isinstance(harness.model.unit.status, BlockedStatus)
+
+
+def test_database_requested_defers_until_the_cluster_is_ready(harness, events, postgresql):
+    with (
+        cluster_ready(harness, postgresql, ready=False),
+        patch("ops.framework.EventBase.defer") as _defer,
+    ):
+        request_database(harness)
+
+    _defer.assert_called_once()
+    postgresql.create_database.assert_not_called()
+
+
+def test_database_requested_defers_until_peers_have_synced(harness, events, postgresql):
+    peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+    with harness.hooks_disabled():
+        harness.add_relation_unit(peer_rel_id, "postgresql-single-kernel/1")
+        harness.update_relation_data(
+            peer_rel_id, "postgresql-single-kernel/1", {"user_hash": "stale"}
+        )
+
+    with (
+        cluster_ready(harness, postgresql),
+        patch("ops.framework.EventBase.defer") as _defer,
+    ):
+        request_database(harness)
+
+    _defer.assert_called_once()
+    postgresql.create_database.assert_not_called()
+
+
+def test_database_requested_blocks_with_the_error_message(harness, events, postgresql):
+    postgresql.create_database.side_effect = PostgreSQLCreateDatabaseError("bad name")
+    with cluster_ready(harness, postgresql):
+        request_database(harness)
+
+    assert harness.model.unit.status == BlockedStatus("bad name")
+
+
+def test_database_requested_blocks_generically_without_a_message(harness, events, postgresql):
+    postgresql.create_user.side_effect = PostgreSQLCreateUserError()
+    with cluster_ready(harness, postgresql):
+        request_database(harness)
+
+    assert harness.model.unit.status == BlockedStatus("Failed to initialize database relation")
+
+
+def test_database_requested_blocks_on_a_version_error(harness, events, postgresql):
+    postgresql.get_postgresql_version.side_effect = PostgreSQLGetPostgreSQLVersionError()
+    with cluster_ready(harness, postgresql):
+        request_database(harness)
+
+    assert isinstance(harness.model.unit.status, BlockedStatus)
+
+
+def test_database_requested_publishes_k8s_service_endpoints_inline(
+    substrate, harness, events, postgresql
+):
+    """K8s wrote the primary Service endpoint inside the request handler; VM did not."""
+    with cluster_ready(harness, postgresql):
+        rel_id = request_database(harness)
+
+    data = harness.get_relation_data(rel_id, harness.charm.app.name)
+    if substrate == "k8s":
+        app = harness.charm.app.name
+        assert data["endpoints"] == f"{app}-primary.test-model.svc.cluster.local:5432"
+        assert data["uris"].endswith(
+            f"@{app}-primary.test-model.svc.cluster.local:5432/{DATABASE}"
+        )
+    else:
+        assert "endpoints" not in data
+
+
+def test_relation_departed_flags_only_this_unit(harness, events):
+    peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+    event = Mock()
+    event.departing_unit = harness.charm.unit
+    events._on_relation_departed(event)
+    assert "departing" in harness.get_relation_data(peer_rel_id, harness.charm.unit)
+
+    with harness.hooks_disabled():
+        harness.update_relation_data(peer_rel_id, harness.charm.unit.name, {"departing": ""})
+    event.departing_unit = Unit(
+        f"{harness.charm.app.name}/1", None, harness.charm.app._backend, {}
+    )
+    events._on_relation_departed(event)
+    assert "departing" not in harness.get_relation_data(peer_rel_id, harness.charm.unit)
+
+
+def test_relation_broken_deletes_the_user(harness, events, postgresql):
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    event = Mock()
+    event.relation = harness.model.get_relation(RELATION_NAME)
+
+    with cluster_ready(harness, postgresql):
+        events._on_relation_broken(event)
+
+    postgresql.delete_user.assert_called_once_with(events.manager.relation_username(rel_id))
+
+
+def test_relation_broken_skips_a_departing_unit(harness, events, postgresql):
+    peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+    with harness.hooks_disabled():
+        harness.update_relation_data(peer_rel_id, harness.charm.unit.name, {"departing": "True"})
+    event = Mock()
+    event.relation = harness.model.get_relation(RELATION_NAME)
+
+    with cluster_ready(harness, postgresql):
+        events._on_relation_broken(event)
+
+    postgresql.delete_user.assert_not_called()
+
+
+def test_relation_broken_defers_until_the_cluster_is_ready(harness, events, postgresql):
+    event = Mock()
+    event.relation = harness.model.get_relation(RELATION_NAME)
+
+    with cluster_ready(harness, postgresql, ready=False):
+        events._on_relation_broken(event)
+
+    event.defer.assert_called_once()
+    postgresql.delete_user.assert_not_called()
+
+
+def test_relation_broken_on_a_follower_defers_while_the_user_exists(harness, events, postgresql):
+    with harness.hooks_disabled():
+        harness.set_leader(False)
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    postgresql.list_users.return_value = {events.manager.relation_username(rel_id)}
+    event = Mock()
+    event.relation = harness.model.get_relation(RELATION_NAME)
+
+    with cluster_ready(harness, postgresql):
+        events._on_relation_broken(event)
+
+    event.defer.assert_called_once()
+    postgresql.delete_user.assert_not_called()
+
+
+def test_relation_broken_on_a_follower_updates_config_once_the_user_is_gone(
+    harness, events, postgresql
+):
+    with harness.hooks_disabled():
+        harness.set_leader(False)
+    event = Mock()
+    event.relation = harness.model.get_relation(RELATION_NAME)
+
+    with (
+        cluster_ready(harness, postgresql),
+        patch.object(type(harness.charm), "update_config") as _update_config,
+    ):
+        events._on_relation_broken(event)
+
+    event.defer.assert_not_called()
+    _update_config.assert_called_once()
+    postgresql.delete_user.assert_not_called()
+
+
+def test_k8s_removal_guard_does_not_wait_on_the_primary_endpoint(
+    substrate, harness, events, postgresql
+):
+    """K8s' relation_broken settles for a started member; VM also needs a primary."""
+    with (
+        patch.object(type(harness.charm), "postgresql", PropertyMock(return_value=postgresql)),
+        patch.object(type(harness.charm), "update_config", Mock(return_value=True)),
+        patch.object(
+            type(harness.charm), "primary_endpoint", new_callable=PropertyMock, return_value=None
+        ),
+        patch(
+            "single_kernel_postgresql.managers.patroni.PatroniManager.member_started",
+            new_callable=PropertyMock,
+            return_value=True,
+        ),
+        patch("single_kernel_postgresql.managers.database.DatabaseManager.update_endpoints"),
+    ):
+        assert events._ready_for_removal() is (substrate == "k8s")
+
+
+def test_update_unit_status_runs_before_the_departing_check(harness, events, postgresql):
+    """A stale blocking status clears even when the unit itself is going away."""
+    peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+    with harness.hooks_disabled():
+        harness.update_relation_data(peer_rel_id, harness.charm.unit.name, {"departing": "True"})
+    harness.model.unit.status = BlockedStatus("Failed to initialize database relation")
+    event = Mock()
+    event.relation = harness.model.get_relation(RELATION_NAME)
+
+    with cluster_ready(harness, postgresql):
+        events._on_relation_broken(event)
+
+    assert harness.model.unit.status == ActiveStatus()

--- a/tests/unit/test_database_events.py
+++ b/tests/unit/test_database_events.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
-from ops import ActiveStatus, BlockedStatus, ModelError, Unit
+from ops import ActiveStatus, BlockedStatus, ModelError
 from single_kernel_postgresql.config.literals import PEER_RELATION
 from single_kernel_postgresql.lib.charms.data_platform_libs.v0.data_interfaces import (
     DatabaseRequestedEvent,
@@ -419,9 +419,7 @@ def test_relation_departed_flags_only_this_unit(harness, events):
 
     with harness.hooks_disabled():
         harness.update_relation_data(peer_rel_id, harness.charm.unit.name, {"departing": ""})
-    event.departing_unit = Unit(
-        f"{harness.charm.app.name}/1", None, harness.charm.app._backend, {}
-    )
+    event.departing_unit = harness.model.get_unit(f"{harness.charm.app.name}/1")
     events._on_relation_departed(event)
     assert "departing" not in harness.get_relation_data(peer_rel_id, harness.charm.unit)
 

--- a/tests/unit/test_database_events.py
+++ b/tests/unit/test_database_events.py
@@ -6,8 +6,11 @@ from contextlib import contextmanager
 from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
-from ops import ActiveStatus, BlockedStatus, Unit
+from ops import ActiveStatus, BlockedStatus, ModelError, Unit
 from single_kernel_postgresql.config.literals import PEER_RELATION
+from single_kernel_postgresql.lib.charms.data_platform_libs.v0.data_interfaces import (
+    DatabaseRequestedEvent,
+)
 from single_kernel_postgresql.utils.postgresql import (
     ACCESS_GROUP_RELATION,
     PostgreSQLCreateDatabaseError,
@@ -171,6 +174,40 @@ def test_database_requested_blocks_on_a_version_error(harness, events, postgresq
         request_database(harness)
 
     assert isinstance(harness.model.unit.status, BlockedStatus)
+
+
+def test_database_requested_blocks_when_the_requested_entity_secret_is_not_readable(
+    harness, events, postgresql
+):
+    """An ungranted requested-entity secret blocks the unit instead of crashing the hook."""
+    with (
+        cluster_ready(harness, postgresql),
+        patch.object(
+            DatabaseRequestedEvent,
+            "requested_entity_secret_content",
+            new_callable=PropertyMock,
+        ) as _content,
+    ):
+        _content.side_effect = ModelError()
+        request_database(harness)
+
+    assert harness.model.unit.status == BlockedStatus("Missing grant to requested entity secret")
+    postgresql.create_database.assert_not_called()
+
+
+def test_database_requested_is_a_noop_for_a_follower(harness, events, postgresql):
+    """The provider library already filters non-leaders; the handler guard is belt-and-braces."""
+    with harness.hooks_disabled():
+        harness.set_leader(False)
+    event = Mock()
+    event.relation = harness.model.get_relation(RELATION_NAME)
+
+    with cluster_ready(harness, postgresql):
+        events._on_database_requested(event)
+
+    postgresql.create_database.assert_not_called()
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    assert "username" not in harness.get_relation_data(rel_id, harness.charm.app.name)
 
 
 def test_database_requested_publishes_k8s_service_endpoints_inline(

--- a/tests/unit/test_database_manager.py
+++ b/tests/unit/test_database_manager.py
@@ -206,18 +206,6 @@ def test_get_credentials_blocks_on_an_existing_username(manager, postgresql, har
     assert harness.model.unit.status == BlockedStatus("Requesting an existing username")
 
 
-def test_get_credentials_blocks_when_the_secret_is_not_readable(manager, postgresql, harness):
-    request = DatabaseRequest(
-        relation_id=4,
-        database="db",
-        extra_user_roles=None,
-        prefix_matching=None,
-        requested_entity_secret_content=Mock(items=Mock(side_effect=ModelError)),
-    )
-    assert manager.get_credentials(postgresql, request) is None
-    assert harness.model.unit.status == BlockedStatus("Missing grant to requested entity secret")
-
-
 def test_get_credentials_uses_the_requested_custom_username(manager, postgresql):
     postgresql.list_users.return_value = set()
     with patch("single_kernel_postgresql.managers.database.new_password", return_value="gen"):

--- a/tests/unit/test_database_manager.py
+++ b/tests/unit/test_database_manager.py
@@ -275,7 +275,6 @@ def test_delete_relation_user_clears_every_mapping(manager, postgresql, harness)
     rel_id = harness.model.get_relation(RELATION_NAME).id
     manager.update_username_mapping(rel_id, "custom")
     manager.set_databases_prefix_mapping(rel_id, "custom", "pre", ["pre_a"])
-    harness.charm.app_data_setter = None
     manager.state.application.data["rel_databases"] = json.dumps({str(rel_id): "pre_a"})
 
     manager.delete_relation_user(postgresql, rel_id)
@@ -449,6 +448,96 @@ def test_update_endpoints_read_only_uri_carries_one_port(substrate, manager, har
     assert ":5432:5432" not in uri
 
 
+def test_update_endpoints_publishes_the_primary_ip_verbatim(manager, harness, substrate):
+    """A leader unit without a peer address publishes "None:5432", exactly as the charm did."""
+    if substrate == "k8s":
+        pytest.skip("K8s reads the primary Service, not the Patroni members")
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    with harness.hooks_disabled():
+        harness.update_relation_data(rel_id, "application", {"database": "test_db"})
+
+    with (
+        patch(
+            "single_kernel_postgresql.managers.patroni.PatroniManager.cluster_status",
+            return_value=CLUSTER_STATUS[:1],
+        ),
+        patch(
+            "single_kernel_postgresql.managers.database.DatabaseManager.is_tls_enabled",
+            new_callable=PropertyMock,
+            return_value=False,
+        ),
+        patch.object(
+            manager.database_provides,
+            "fetch_my_relation_data",
+            return_value={rel_id: {"username": "u", "password": "pw"}},
+        ),
+    ):
+        manager.update_endpoints(rel_id)
+
+    data = harness.get_relation_data(rel_id, harness.charm.app.name)
+    assert data["endpoints"] == "None:5432"
+
+
+def test_update_endpoints_publishes_tls_when_enabled(substrate, manager, harness):
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+    with harness.hooks_disabled():
+        harness.update_relation_data(rel_id, "application", {"database": "test_db"})
+        harness.update_relation_data(
+            peer_rel_id, "postgresql-single-kernel/0", {f"{RELATION_NAME}-address": "1.1.1.1"}
+        )
+
+    with (
+        patch(
+            "single_kernel_postgresql.managers.patroni.PatroniManager.cluster_status",
+            return_value=CLUSTER_STATUS[:1],
+        ),
+        patch.object(
+            manager.tls_manager, "get_client_tls_files", return_value=("key", "CA", "cert")
+        ),
+        patch.object(
+            manager.database_provides,
+            "fetch_my_relation_data",
+            return_value={rel_id: {"username": "u", "password": "pw"}},
+        ),
+    ):
+        manager.update_endpoints(rel_id)
+
+    data = harness.get_relation_data(rel_id, harness.charm.app.name)
+    assert data["tls"] == "True"
+    assert data["tls-ca"] == "CA"
+
+
+def test_k8s_endpoints_fall_back_to_the_primary_without_peer_units(substrate, manager, harness):
+    if substrate != "k8s":
+        pytest.skip("VM reads the online Patroni members, not the replicas Service")
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+    with harness.hooks_disabled():
+        harness.remove_relation_unit(peer_rel_id, "postgresql-single-kernel/0")
+        harness.remove_relation_unit(peer_rel_id, "postgresql-single-kernel/1")
+        harness.remove_relation_unit(peer_rel_id, "postgresql-single-kernel/2")
+        harness.update_relation_data(rel_id, "application", {"database": "test_db"})
+
+    with (
+        patch(
+            "single_kernel_postgresql.managers.database.DatabaseManager.is_tls_enabled",
+            new_callable=PropertyMock,
+            return_value=False,
+        ),
+        patch.object(
+            manager.database_provides,
+            "fetch_my_relation_data",
+            return_value={rel_id: {"username": "u", "password": "pw"}},
+        ),
+    ):
+        manager.update_endpoints(rel_id)
+
+    app = harness.charm.app.name
+    data = harness.get_relation_data(rel_id, harness.charm.app.name)
+    assert data["read-only-endpoints"] == f"{app}-primary.test-model.svc.cluster.local:5432"
+
+
 def test_update_endpoints_falls_back_to_the_primary_without_replicas(manager, harness, substrate):
     if substrate == "k8s":
         pytest.skip("K8s reads the replicas Service, not the online Patroni members")
@@ -520,6 +609,17 @@ def test_update_endpoints_filters_out_of_sync_members(manager, harness, substrat
 
     data = harness.get_relation_data(rel_id, harness.charm.app.name)
     assert data["read-only-endpoints"] == "2.2.2.2:5432"
+
+
+def test_update_unit_status_routes_custom_user_blocks_to_unblock(manager, postgresql, harness):
+    """A still-valid custom-user block reaches unblock_custom_user_errors and clears."""
+    postgresql.list_valid_privileges_and_roles.return_value = (set(), set())
+    relation = harness.model.get_relation(RELATION_NAME)
+    harness.model.unit.status = BlockedStatus("Requesting an existing username")
+
+    manager.update_unit_status(postgresql, relation)
+
+    assert harness.model.unit.status == ActiveStatus()
 
 
 def test_update_unit_status_clears_a_failed_init_block(manager, postgresql, harness):

--- a/tests/unit/test_database_manager.py
+++ b/tests/unit/test_database_manager.py
@@ -109,13 +109,14 @@ def test_collect_user_relations_skips_relations_without_a_database(manager):
     assert manager.collect_user_relations() == {}
 
 
-def test_user_hash_tracks_the_collected_relations(manager, harness):
-    empty = manager.user_hash
+def test_user_hash_freezes_for_the_manager_lifetime(manager, harness):
+    """Both charms cached the hash per hook, so a mid-hook mapping change must not alter it."""
+    frozen = manager.user_hash
     rel_id = harness.model.get_relation(RELATION_NAME).id
     with harness.hooks_disabled():
         harness.update_relation_data(rel_id, "application", {"database": "test_db"})
 
-    assert manager.user_hash != empty
+    assert manager.user_hash == frozen
 
 
 def test_are_units_in_sync_compares_every_peer_unit(manager, harness):

--- a/tests/unit/test_database_manager.py
+++ b/tests/unit/test_database_manager.py
@@ -2,9 +2,11 @@
 # See LICENSE file for licensing details.
 """Unit tests for the client-relation DatabaseManager."""
 
+import json
 from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
+from ops import ActiveStatus, BlockedStatus
 from single_kernel_postgresql.config.enums import Substrates
 from single_kernel_postgresql.config.literals import (
     APP_SCOPE,
@@ -12,8 +14,16 @@ from single_kernel_postgresql.config.literals import (
     PEER_RELATION,
     USERNAME_MAPPING_LABEL,
 )
+from single_kernel_postgresql.managers.database import (
+    FORBIDDEN_USER_MSG,
+    NO_ACCESS_TO_SECRET_MSG,
+    PREFIX_TOO_SHORT_MSG,
+    DatabaseRequest,
+)
 from single_kernel_postgresql.utils.postgresql import (
     ACCESS_GROUP_RELATION,
+    PostgreSQLDeleteUserError,
+    PostgreSQLListUsersError,
 )
 
 RELATION_NAME = "database"
@@ -160,6 +170,387 @@ def test_get_plugins_expands_overrides_and_spi(manager):
     assert "pgaudit" in plugins
     assert "spi" not in plugins
     assert "refint" in plugins
+
+
+def test_get_credentials_defaults_to_the_generated_user(manager, postgresql):
+    request = DatabaseRequest(
+        relation_id=4,
+        database="db",
+        extra_user_roles=None,
+        prefix_matching=None,
+        requested_entity_secret_content=None,
+    )
+    with patch("single_kernel_postgresql.managers.database.new_password", return_value="pw"):
+        assert manager.get_credentials(postgresql, request) == (
+            manager.relation_username(4),
+            "pw",
+        )
+
+
+def test_get_credentials_blocks_on_an_existing_username(manager, postgresql, harness):
+    postgresql.list_users.return_value = {"taken"}
+    request = DatabaseRequest(
+        relation_id=4,
+        database="db",
+        extra_user_roles=None,
+        prefix_matching=None,
+        requested_entity_secret_content={"taken": "pw"},
+    )
+    assert manager.get_credentials(postgresql, request) is None
+    assert harness.model.unit.status == BlockedStatus(FORBIDDEN_USER_MSG)
+
+
+def test_get_credentials_blocks_when_the_secret_is_not_readable(manager, postgresql, harness):
+    request = DatabaseRequest(
+        relation_id=4,
+        database="db",
+        extra_user_roles=None,
+        prefix_matching=None,
+        requested_entity_secret_content=Mock(items=Mock(side_effect=__import__("ops").ModelError)),
+    )
+    assert manager.get_credentials(postgresql, request) is None
+    assert harness.model.unit.status == BlockedStatus(NO_ACCESS_TO_SECRET_MSG)
+
+
+def test_collect_databases_plain_database(manager, postgresql):
+    request = DatabaseRequest(
+        relation_id=4,
+        database="test_db",
+        extra_user_roles=None,
+        prefix_matching=None,
+        requested_entity_secret_content=None,
+    )
+    assert manager.collect_databases(postgresql, "user", request) == ("test_db", ["test_db"])
+
+
+def test_collect_databases_prefix_lists_and_caches(manager, postgresql):
+    postgresql.list_databases.return_value = ["pre_b", "pre_a"]
+    request = DatabaseRequest(
+        relation_id=4,
+        database="pre*",
+        extra_user_roles=None,
+        prefix_matching="all",
+        requested_entity_secret_content=None,
+    )
+    assert manager.collect_databases(postgresql, "user", request) == ("pre*", ["pre_a", "pre_b"])
+    postgresql.list_databases.assert_called_once_with("pre")
+    assert manager.get_databases_prefix_mapping()["4"]["prefix"] == "pre"
+
+
+def test_collect_databases_blocks_on_a_too_short_prefix(manager, postgresql, harness):
+    request = DatabaseRequest(
+        relation_id=4,
+        database="a*",
+        extra_user_roles=None,
+        prefix_matching=None,
+        requested_entity_secret_content=None,
+    )
+    assert manager.collect_databases(postgresql, "user", request) is None
+    assert harness.model.unit.status == BlockedStatus(PREFIX_TOO_SHORT_MSG)
+    postgresql.list_databases.assert_not_called()
+
+
+def test_create_relation_user_and_database_plain(manager, postgresql):
+    with patch.object(type(manager), "get_plugins", return_value=["pgaudit"]):
+        manager.create_relation_user_and_database(
+            postgresql, "user", "pw", "test_db", ["test_db"], ["createdb"]
+        )
+    postgresql.create_database.assert_called_once_with("test_db", plugins=["pgaudit"])
+    postgresql.create_user.assert_called_once_with(
+        "user", "pw", extra_user_roles=["createdb"], database="test_db"
+    )
+
+
+def test_create_relation_user_and_database_prefixed_skips_create_database(manager, postgresql):
+    with patch.object(type(manager), "get_plugins", return_value=[]):
+        manager.create_relation_user_and_database(
+            postgresql, "user", "pw", "pre*", ["pre_a"], ["createdb"]
+        )
+    postgresql.create_database.assert_not_called()
+    postgresql.create_user.assert_called_once_with("user", "pw", extra_user_roles=["createdb"])
+    postgresql.add_user_to_databases.assert_called_once_with("user", ["pre_a"], ["createdb"])
+
+
+def test_delete_relation_user_clears_every_mapping(manager, postgresql, harness):
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    manager.update_username_mapping(rel_id, "custom")
+    manager.set_databases_prefix_mapping(rel_id, "custom", "pre", ["pre_a"])
+    harness.charm.app_data_setter = None
+    manager.state.application.data["rel_databases"] = json.dumps({str(rel_id): "pre_a"})
+
+    manager.delete_relation_user(postgresql, rel_id)
+
+    postgresql.delete_user.assert_called_once_with("custom")
+    assert manager.get_username_mapping() == {}
+    assert manager.get_databases_prefix_mapping() == {}
+
+
+def test_delete_relation_user_blocks_when_the_drop_fails(manager, postgresql, harness):
+    postgresql.delete_user.side_effect = PostgreSQLDeleteUserError
+    manager.delete_relation_user(postgresql, 4)
+    assert isinstance(harness.model.unit.status, BlockedStatus)
+
+
+def test_oversee_users_deletes_only_users_without_a_relation(manager, postgresql, harness):
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    stale = manager.relation_username(rel_id + 100)
+    postgresql.list_users.return_value = {
+        manager.relation_username(rel_id),
+        stale,
+        "postgres",
+    }
+
+    manager.oversee_users(postgresql)
+
+    postgresql.delete_user.assert_called_once_with(stale)
+
+
+def test_oversee_users_honours_the_suppress_flag(manager, postgresql):
+    postgresql.list_users.return_value = {manager.relation_username(999)}
+    manager.state.application.data["suppress-oversee-users"] = "True"
+
+    manager.oversee_users(postgresql)
+
+    postgresql.delete_user.assert_not_called()
+
+
+def test_oversee_users_early_exits_when_users_cannot_be_listed(manager, postgresql):
+    postgresql.list_users.side_effect = PostgreSQLListUsersError
+    manager.oversee_users(postgresql)
+    postgresql.delete_user.assert_not_called()
+
+
+def test_oversee_users_is_leader_only(manager, postgresql, harness):
+    with harness.hooks_disabled():
+        harness.set_leader(False)
+    manager.oversee_users(postgresql)
+    postgresql.list_users.assert_not_called()
+
+
+def test_check_for_invalid_extra_user_roles_skips_the_current_relation(
+    manager, postgresql, harness
+):
+    postgresql.list_valid_privileges_and_roles.return_value = ({"createrole"}, set())
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    with harness.hooks_disabled():
+        harness.update_relation_data(rel_id, "application", {"extra-user-roles": "bogus"})
+
+    assert manager.check_for_invalid_extra_user_roles(postgresql, rel_id) is False
+    assert manager.check_for_invalid_extra_user_roles(postgresql, rel_id + 100) is True
+
+
+def test_check_for_invalid_extra_user_roles_createdb_is_vm_only(
+    substrate, manager, postgresql, harness
+):
+    """VM accepts createdb even though PostgreSQL does not report it as a role."""
+    postgresql.list_valid_privileges_and_roles.return_value = (set(), set())
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    with harness.hooks_disabled():
+        harness.update_relation_data(rel_id, "application", {"extra-user-roles": "createdb"})
+
+    invalid = manager.check_for_invalid_extra_user_roles(postgresql, rel_id + 100)
+    assert invalid is (substrate == "k8s")
+
+
+def test_check_for_invalid_database_name(manager, harness):
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    with harness.hooks_disabled():
+        harness.update_relation_data(rel_id, "application", {"database": "a" * 50})
+
+    assert manager.check_for_invalid_database_name(rel_id) is False
+    assert manager.check_for_invalid_database_name(rel_id + 100) is True
+
+
+def test_update_endpoints_is_leader_only(manager, harness):
+    with harness.hooks_disabled():
+        harness.set_leader(False)
+    with patch.object(manager, "database_provides") as _provides:
+        manager.update_endpoints()
+    _provides.fetch_relation_data.assert_not_called()
+
+
+def test_update_endpoints_publishes_rw_ro_and_uris(substrate, manager, harness):
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+    with harness.hooks_disabled():
+        harness.update_relation_data(rel_id, "application", {"database": "test_db"})
+        harness.update_relation_data(
+            peer_rel_id, "postgresql-single-kernel/0", {f"{RELATION_NAME}-address": "1.1.1.1"}
+        )
+        harness.update_relation_data(
+            peer_rel_id, "postgresql-single-kernel/1", {f"{RELATION_NAME}-address": "2.2.2.2"}
+        )
+
+    with (
+        patch(
+            "single_kernel_postgresql.managers.patroni.PatroniManager.cluster_status",
+            return_value=CLUSTER_STATUS[:2],
+        ),
+        patch(
+            "single_kernel_postgresql.managers.database.DatabaseManager.is_tls_enabled",
+            new_callable=PropertyMock,
+            return_value=False,
+        ),
+        patch.object(
+            manager.database_provides,
+            "fetch_my_relation_data",
+            return_value={rel_id: {"username": "u", "password": "pw"}},
+        ),
+    ):
+        manager.update_endpoints(rel_id)
+
+    data = harness.get_relation_data(rel_id, harness.charm.app.name)
+    if substrate == "k8s":
+        app = harness.charm.app.name
+        assert data["endpoints"] == f"{app}-primary.test-model.svc.cluster.local:5432"
+        assert data["read-only-endpoints"] == f"{app}-replicas.test-model.svc.cluster.local:5432"
+    else:
+        assert data["endpoints"] == "1.1.1.1:5432"
+        assert data["read-only-endpoints"] == "2.2.2.2:5432"
+    assert data["tls"] == "False"
+
+
+def test_update_endpoints_read_only_uri_carries_one_port(substrate, manager, harness):
+    """The read-only URI is built from the ro hosts, so the port is not doubled."""
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            rel_id,
+            "application",
+            {"database": "test_db", "requested-secrets": json.dumps(["read-only-uris"])},
+        )
+        harness.update_relation_data(
+            peer_rel_id, "postgresql-single-kernel/0", {f"{RELATION_NAME}-address": "1.1.1.1"}
+        )
+
+    with (
+        patch(
+            "single_kernel_postgresql.managers.patroni.PatroniManager.cluster_status",
+            return_value=CLUSTER_STATUS[:1],
+        ),
+        patch(
+            "single_kernel_postgresql.managers.database.DatabaseManager.is_tls_enabled",
+            new_callable=PropertyMock,
+            return_value=False,
+        ),
+        patch.object(
+            manager.database_provides,
+            "fetch_my_relation_data",
+            return_value={rel_id: {"username": "u", "password": "pw"}},
+        ),
+        patch.object(manager.database_provides, "set_read_only_uris") as _set_ro_uris,
+    ):
+        manager.update_endpoints(rel_id)
+
+    _set_ro_uris.assert_called_once()
+    uri = _set_ro_uris.call_args.args[1]
+    assert uri.endswith(":5432/test_db")
+    assert ":5432:5432" not in uri
+
+
+def test_update_endpoints_falls_back_to_the_primary_without_replicas(manager, harness, substrate):
+    if substrate == "k8s":
+        pytest.skip("K8s reads the replicas Service, not the online Patroni members")
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+    with harness.hooks_disabled():
+        harness.update_relation_data(rel_id, "application", {"database": "test_db"})
+        harness.update_relation_data(
+            peer_rel_id, "postgresql-single-kernel/0", {f"{RELATION_NAME}-address": "1.1.1.1"}
+        )
+
+    with (
+        patch(
+            "single_kernel_postgresql.managers.patroni.PatroniManager.cluster_status",
+            return_value=CLUSTER_STATUS[:1],
+        ),
+        patch(
+            "single_kernel_postgresql.managers.database.DatabaseManager.is_tls_enabled",
+            new_callable=PropertyMock,
+            return_value=False,
+        ),
+        patch.object(
+            manager.database_provides,
+            "fetch_my_relation_data",
+            return_value={rel_id: {"username": "u", "password": "pw"}},
+        ),
+    ):
+        manager.update_endpoints(rel_id)
+
+    data = harness.get_relation_data(rel_id, harness.charm.app.name)
+    assert data["read-only-endpoints"] == "1.1.1.1:5432"
+
+
+def test_update_endpoints_filters_out_of_sync_members(manager, harness, substrate):
+    if substrate == "k8s":
+        pytest.skip("K8s reads the replicas Service, not the online Patroni members")
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+    with harness.hooks_disabled():
+        harness.update_relation_data(rel_id, "application", {"database": "test_db"})
+        harness.update_relation_data(
+            peer_rel_id, "postgresql-single-kernel/0", {f"{RELATION_NAME}-address": "1.1.1.1"}
+        )
+        harness.update_relation_data(
+            peer_rel_id, "postgresql-single-kernel/1", {f"{RELATION_NAME}-address": "2.2.2.2"}
+        )
+        harness.update_relation_data(
+            peer_rel_id, "postgresql-single-kernel/2", {f"{RELATION_NAME}-address": "3.3.3.3"}
+        )
+
+    nosync = [*CLUSTER_STATUS[:2], {**CLUSTER_STATUS[2], "tags": {"nosync": True}}]
+    with (
+        patch(
+            "single_kernel_postgresql.managers.patroni.PatroniManager.cluster_status",
+            return_value=nosync,
+        ),
+        patch(
+            "single_kernel_postgresql.managers.database.DatabaseManager.is_tls_enabled",
+            new_callable=PropertyMock,
+            return_value=False,
+        ),
+        patch.object(
+            manager.database_provides,
+            "fetch_my_relation_data",
+            return_value={rel_id: {"username": "u", "password": "pw"}},
+        ),
+    ):
+        manager.update_endpoints(rel_id)
+
+    data = harness.get_relation_data(rel_id, harness.charm.app.name)
+    assert data["read-only-endpoints"] == "2.2.2.2:5432"
+
+
+def test_update_unit_status_clears_a_failed_init_block(manager, postgresql, harness):
+    postgresql.list_valid_privileges_and_roles.return_value = (set(), set())
+    relation = harness.model.get_relation(RELATION_NAME)
+    harness.model.unit.status = BlockedStatus("Failed to initialize database relation")
+
+    manager.update_unit_status(postgresql, relation)
+
+    assert harness.model.unit.status == ActiveStatus()
+
+
+def test_update_unit_status_keeps_a_prefix_block_while_a_short_prefix_remains(
+    manager, postgresql, harness
+):
+    postgresql.list_valid_privileges_and_roles.return_value = (set(), set())
+    relation = harness.model.get_relation(RELATION_NAME)
+    with harness.hooks_disabled():
+        harness.update_relation_data(relation.id, "application", {"database": "a*"})
+    harness.model.unit.status = BlockedStatus(PREFIX_TOO_SHORT_MSG)
+
+    manager.update_unit_status(postgresql, relation)
+
+    assert harness.model.unit.status == BlockedStatus(PREFIX_TOO_SHORT_MSG)
+
+
+def test_is_tls_enabled_tracks_the_client_files(manager):
+    with patch.object(manager.tls_manager, "get_client_tls_files", return_value=("k", "ca", "c")):
+        assert manager.is_tls_enabled is True
+    with patch.object(manager.tls_manager, "get_client_tls_files", return_value=("k", None, "c")):
+        assert manager.is_tls_enabled is False
 
 
 def test_prefix_mapping_secret_labels_are_stable(manager):

--- a/tests/unit/test_database_manager.py
+++ b/tests/unit/test_database_manager.py
@@ -379,11 +379,96 @@ def test_update_endpoints_publishes_rw_ro_and_uris(substrate, manager, harness):
         harness.update_relation_data(
             peer_rel_id, "postgresql-single-kernel/1", {f"{RELATION_NAME}-address": "2.2.2.2"}
         )
+        other_rel_id = harness.add_relation(RELATION_NAME, "other-application")
+        harness.update_relation_data(other_rel_id, "other-application", {"database": "other_db"})
 
     with (
         patch(
             "single_kernel_postgresql.managers.patroni.PatroniManager.cluster_status",
             return_value=CLUSTER_STATUS[:2],
+        ),
+        patch(
+            "single_kernel_postgresql.managers.database.DatabaseManager.is_tls_enabled",
+            new_callable=PropertyMock,
+            return_value=False,
+        ),
+        patch.object(
+            manager.database_provides,
+            "fetch_my_relation_data",
+            return_value={
+                rel_id: {"username": "u", "password": "pw"},
+                other_rel_id: {"username": "other", "password": "other-pw"},
+            },
+        ),
+    ):
+        manager.update_endpoints(rel_id)
+
+    data = harness.get_relation_data(rel_id, harness.charm.app.name)
+    if substrate == "k8s":
+        app = harness.charm.app.name
+        assert data["endpoints"] == f"{app}-primary.test-model.svc.cluster.local:5432"
+        assert data["read-only-endpoints"] == f"{app}-replicas.test-model.svc.cluster.local:5432"
+        assert (
+            data["uris"] == f"postgresql://u:pw@{app}-primary.test-model.svc.cluster.local:5432/test_db"
+        )
+    else:
+        assert data["endpoints"] == "1.1.1.1:5432"
+        assert data["read-only-endpoints"] == "2.2.2.2:5432"
+        assert data["uris"] == "postgresql://u:pw@1.1.1.1:5432/test_db"
+    assert data["tls"] == "False"
+    # A relation-scoped update touches only that relation's databag.
+    assert harness.get_relation_data(other_rel_id, harness.charm.app.name) == {}
+
+
+def test_update_endpoints_skips_a_relation_without_credentials(manager, harness):
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+    with harness.hooks_disabled():
+        harness.update_relation_data(rel_id, "application", {"database": "test_db"})
+        harness.update_relation_data(
+            peer_rel_id, "postgresql-single-kernel/0", {f"{RELATION_NAME}-address": "1.1.1.1"}
+        )
+
+    with (
+        patch(
+            "single_kernel_postgresql.managers.patroni.PatroniManager.cluster_status",
+            return_value=CLUSTER_STATUS[:1],
+        ),
+        patch(
+            "single_kernel_postgresql.managers.database.DatabaseManager.is_tls_enabled",
+            new_callable=PropertyMock,
+            return_value=False,
+        ),
+        patch.object(
+            manager.database_provides,
+            "fetch_my_relation_data",
+            return_value={},
+        ),
+    ):
+        manager.update_endpoints(rel_id)
+
+    assert harness.get_relation_data(rel_id, harness.charm.app.name) == {}
+
+
+def test_update_endpoints_clears_stale_uris_when_no_database_matches_the_prefix(
+    substrate, manager, harness
+):
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+    manager.set_databases_prefix_mapping(rel_id, "custom", "pre", [])
+    with harness.hooks_disabled():
+        harness.update_relation_data(rel_id, "application", {"database": "pre*"})
+        harness.update_relation_data(
+            peer_rel_id, "postgresql-single-kernel/0", {f"{RELATION_NAME}-address": "1.1.1.1"}
+        )
+        harness.update_relation_data(
+            rel_id, harness.charm.app.name, {"uris": "stale", "read-only-uris": "stale"}
+        )
+
+    with (
+        patch(
+            "single_kernel_postgresql.managers.patroni.PatroniManager.cluster_status",
+            return_value=CLUSTER_STATUS[:1],
         ),
         patch(
             "single_kernel_postgresql.managers.database.DatabaseManager.is_tls_enabled",
@@ -399,14 +484,13 @@ def test_update_endpoints_publishes_rw_ro_and_uris(substrate, manager, harness):
         manager.update_endpoints(rel_id)
 
     data = harness.get_relation_data(rel_id, harness.charm.app.name)
+    assert "uris" not in data
+    assert "read-only-uris" not in data
     if substrate == "k8s":
         app = harness.charm.app.name
         assert data["endpoints"] == f"{app}-primary.test-model.svc.cluster.local:5432"
-        assert data["read-only-endpoints"] == f"{app}-replicas.test-model.svc.cluster.local:5432"
     else:
         assert data["endpoints"] == "1.1.1.1:5432"
-        assert data["read-only-endpoints"] == "2.2.2.2:5432"
-    assert data["tls"] == "False"
 
 
 def test_update_endpoints_read_only_uri_carries_one_port(substrate, manager, harness):

--- a/tests/unit/test_database_manager.py
+++ b/tests/unit/test_database_manager.py
@@ -6,7 +6,7 @@ import json
 from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
-from ops import ActiveStatus, BlockedStatus
+from ops import ActiveStatus, BlockedStatus, ModelError
 from single_kernel_postgresql.config.enums import Substrates
 from single_kernel_postgresql.config.literals import (
     APP_SCOPE,
@@ -214,10 +214,32 @@ def test_get_credentials_blocks_when_the_secret_is_not_readable(manager, postgre
         database="db",
         extra_user_roles=None,
         prefix_matching=None,
-        requested_entity_secret_content=Mock(items=Mock(side_effect=__import__("ops").ModelError)),
+        requested_entity_secret_content=Mock(items=Mock(side_effect=ModelError)),
     )
     assert manager.get_credentials(postgresql, request) is None
     assert harness.model.unit.status == BlockedStatus("Missing grant to requested entity secret")
+
+
+def test_get_credentials_uses_the_requested_custom_username(manager, postgresql):
+    postgresql.list_users.return_value = set()
+    with patch("single_kernel_postgresql.managers.database.new_password", return_value="gen"):
+        granted = DatabaseRequest(
+            relation_id=4,
+            database="db",
+            extra_user_roles=None,
+            prefix_matching=None,
+            requested_entity_secret_content={"custom": "pw"},
+        )
+        assert manager.get_credentials(postgresql, granted) == ("custom", "pw")
+
+        ungranted = DatabaseRequest(
+            relation_id=4,
+            database="db",
+            extra_user_roles=None,
+            prefix_matching=None,
+            requested_entity_secret_content={"custom": None},
+        )
+        assert manager.get_credentials(postgresql, ungranted) == ("custom", "gen")
 
 
 def test_collect_databases_plain_database(manager, postgresql):
@@ -748,6 +770,69 @@ def test_update_unit_status_keeps_a_prefix_block_while_a_short_prefix_remains(
     manager.update_unit_status(postgresql, relation)
 
     assert harness.model.unit.status == BlockedStatus("Prefix too short")
+
+
+def test_unblock_custom_user_errors_clears_the_status(manager, postgresql, harness):
+    postgresql.list_valid_privileges_and_roles.return_value = (set(), set())
+    relation = harness.model.get_relation(RELATION_NAME)
+    harness.model.unit.status = BlockedStatus("Requesting an existing username")
+
+    manager.unblock_custom_user_errors(postgresql, relation)
+
+    assert harness.model.unit.status == ActiveStatus()
+
+
+def test_unblock_custom_user_errors_keeps_the_block_on_invalid_extra_user_roles(
+    manager, postgresql, harness
+):
+    postgresql.list_valid_privileges_and_roles.return_value = (set(), set())
+    relation = harness.model.get_relation(RELATION_NAME)
+    other_rel_id = harness.add_relation(RELATION_NAME, "other-application")
+    with harness.hooks_disabled():
+        # The relation the check skips is the one carrying the invalid roles.
+        harness.update_relation_data(other_rel_id, "other-application", {"extra-user-roles": "bogus"})
+
+    manager.unblock_custom_user_errors(postgresql, relation)
+
+    assert harness.model.unit.status == BlockedStatus("invalid role(s) for extra user roles")
+
+
+def test_unblock_custom_user_errors_keeps_the_block_on_a_forbidden_user(
+    manager, postgresql, harness
+):
+    postgresql.list_valid_privileges_and_roles.return_value = (set(), set())
+    postgresql.list_users.return_value = {"taken"}
+    relation = harness.model.get_relation(RELATION_NAME)
+    secret = Mock(get_content=Mock(return_value={"taken": "pw"}))
+
+    with (
+        patch.object(manager.database_provides, "fetch_my_relation_field", return_value=None),
+        patch.object(
+            manager.database_provides, "fetch_relation_field", return_value="secret-uri"
+        ),
+        patch.object(manager.state.model, "get_secret", return_value=secret),
+    ):
+        manager.unblock_custom_user_errors(postgresql, relation)
+
+    assert harness.model.unit.status == BlockedStatus("Requesting an existing username")
+
+
+def test_unblock_custom_user_errors_keeps_the_block_while_the_secret_is_unreadable(
+    manager, postgresql, harness
+):
+    postgresql.list_valid_privileges_and_roles.return_value = (set(), set())
+    relation = harness.model.get_relation(RELATION_NAME)
+
+    with (
+        patch.object(manager.database_provides, "fetch_my_relation_field", return_value=None),
+        patch.object(
+            manager.database_provides, "fetch_relation_field", return_value="secret-uri"
+        ),
+        patch.object(manager.state.model, "get_secret", side_effect=ModelError),
+    ):
+        manager.unblock_custom_user_errors(postgresql, relation)
+
+    assert harness.model.unit.status == BlockedStatus("Missing grant to requested entity secret")
 
 
 def test_is_tls_enabled_tracks_the_client_files(manager):

--- a/tests/unit/test_database_manager.py
+++ b/tests/unit/test_database_manager.py
@@ -7,7 +7,6 @@ from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
 from ops import ActiveStatus, BlockedStatus, ModelError
-from single_kernel_postgresql.config.enums import Substrates
 from single_kernel_postgresql.config.literals import (
     APP_SCOPE,
     DATABASE_MAPPING_LABEL,
@@ -193,7 +192,8 @@ def test_get_credentials_defaults_to_the_generated_user(manager, postgresql):
         )
 
 
-def test_get_credentials_blocks_on_an_existing_username(manager, postgresql, harness):
+def test_get_credentials_blocks_on_an_existing_username(manager, postgresql):
+    """The forbidden-user block routes through the charm's status bridge."""
     postgresql.list_users.return_value = {"taken"}
     request = DatabaseRequest(
         relation_id=4,
@@ -202,8 +202,9 @@ def test_get_credentials_blocks_on_an_existing_username(manager, postgresql, har
         prefix_matching=None,
         requested_entity_secret_content={"taken": "pw"},
     )
-    assert manager.get_credentials(postgresql, request) is None
-    assert harness.model.unit.status == BlockedStatus("Requesting an existing username")
+    with patch.object(manager, "set_unit_status") as _gated:
+        assert manager.get_credentials(postgresql, request) is None
+    _gated.assert_called_once_with(BlockedStatus("Requesting an existing username"))
 
 
 def test_get_credentials_uses_the_requested_custom_username(manager, postgresql):
@@ -253,7 +254,7 @@ def test_collect_databases_prefix_lists_and_caches(manager, postgresql):
     assert manager.get_databases_prefix_mapping()["4"]["prefix"] == "pre"
 
 
-def test_collect_databases_blocks_on_a_too_short_prefix(manager, postgresql, harness):
+def test_collect_databases_blocks_on_a_too_short_prefix(manager, postgresql):
     request = DatabaseRequest(
         relation_id=4,
         database="a*",
@@ -261,8 +262,9 @@ def test_collect_databases_blocks_on_a_too_short_prefix(manager, postgresql, har
         prefix_matching=None,
         requested_entity_secret_content=None,
     )
-    assert manager.collect_databases(postgresql, "user", request) is None
-    assert harness.model.unit.status == BlockedStatus("Prefix too short")
+    with patch.object(manager, "set_unit_status") as _gated:
+        assert manager.collect_databases(postgresql, "user", request) is None
+    _gated.assert_called_once_with(BlockedStatus("Prefix too short"))
     postgresql.list_databases.assert_not_called()
 
 
@@ -293,7 +295,6 @@ def test_delete_relation_user_clears_every_mapping(manager, postgresql, harness)
     manager.update_username_mapping(rel_id, "custom")
     # The deleted relation's database still sits in another relation's prefix.
     manager.set_databases_prefix_mapping(other_rel_id, "other-user", "pre", ["pre_a"])
-    harness.charm.app_data_setter = None
     manager.state.application.data["rel_databases"] = json.dumps({str(rel_id): "pre_a"})
 
     manager.delete_relation_user(postgresql, rel_id)
@@ -407,13 +408,16 @@ def test_update_endpoints_publishes_rw_ro_and_uris(substrate, manager, harness):
         harness.update_relation_data(
             peer_rel_id, "postgresql-single-kernel/1", {f"{RELATION_NAME}-address": "2.2.2.2"}
         )
+        harness.update_relation_data(
+            peer_rel_id, "postgresql-single-kernel/2", {f"{RELATION_NAME}-address": "3.3.3.3"}
+        )
         other_rel_id = harness.add_relation(RELATION_NAME, "other-application")
         harness.update_relation_data(other_rel_id, "other-application", {"database": "other_db"})
 
     with (
         patch(
             "single_kernel_postgresql.managers.patroni.PatroniManager.cluster_status",
-            return_value=CLUSTER_STATUS[:2],
+            return_value=CLUSTER_STATUS,
         ),
         patch(
             "single_kernel_postgresql.managers.database.DatabaseManager.is_tls_enabled",
@@ -442,7 +446,8 @@ def test_update_endpoints_publishes_rw_ro_and_uris(substrate, manager, harness):
         )
     else:
         assert data["endpoints"] == "1.1.1.1:5432"
-        assert data["read-only-endpoints"] == "2.2.2.2:5432"
+        # Multiple replicas are published comma-joined.
+        assert data["read-only-endpoints"] == "2.2.2.2:5432,3.3.3.3:5432"
         assert data["uris"] == "postgresql://u:pw@1.1.1.1:5432/test_db"
     assert data["tls"] == "False"
     # A relation-scoped update touches only that relation's databag.
@@ -561,6 +566,39 @@ def test_update_endpoints_read_only_uri_carries_one_port(substrate, manager, har
     assert ":5432:5432" not in uri
 
 
+def test_update_endpoints_falls_back_to_the_primary_without_replicas(manager, harness, substrate):
+    if substrate == "k8s":
+        pytest.skip("K8s reads the replicas Service, not the online Patroni members")
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+    with harness.hooks_disabled():
+        harness.update_relation_data(rel_id, "application", {"database": "test_db"})
+        harness.update_relation_data(
+            peer_rel_id, "postgresql-single-kernel/0", {f"{RELATION_NAME}-address": "1.1.1.1"}
+        )
+
+    with (
+        patch(
+            "single_kernel_postgresql.managers.patroni.PatroniManager.cluster_status",
+            return_value=CLUSTER_STATUS[:1],
+        ),
+        patch(
+            "single_kernel_postgresql.managers.database.DatabaseManager.is_tls_enabled",
+            new_callable=PropertyMock,
+            return_value=False,
+        ),
+        patch.object(
+            manager.database_provides,
+            "fetch_my_relation_data",
+            return_value={rel_id: {"username": "u", "password": "pw"}},
+        ),
+    ):
+        manager.update_endpoints(rel_id)
+
+    data = harness.get_relation_data(rel_id, harness.charm.app.name)
+    assert data["read-only-endpoints"] == "1.1.1.1:5432"
+
+
 def test_update_endpoints_publishes_the_primary_ip_verbatim(manager, harness, substrate):
     """A leader unit without a peer address publishes "None:5432", exactly as the charm did."""
     if substrate == "k8s":
@@ -651,39 +689,6 @@ def test_k8s_endpoints_fall_back_to_the_primary_without_peer_units(substrate, ma
     assert data["read-only-endpoints"] == f"{app}-primary.test-model.svc.cluster.local:5432"
 
 
-def test_update_endpoints_falls_back_to_the_primary_without_replicas(manager, harness, substrate):
-    if substrate == "k8s":
-        pytest.skip("K8s reads the replicas Service, not the online Patroni members")
-    rel_id = harness.model.get_relation(RELATION_NAME).id
-    peer_rel_id = harness.model.get_relation(PEER_RELATION).id
-    with harness.hooks_disabled():
-        harness.update_relation_data(rel_id, "application", {"database": "test_db"})
-        harness.update_relation_data(
-            peer_rel_id, "postgresql-single-kernel/0", {f"{RELATION_NAME}-address": "1.1.1.1"}
-        )
-
-    with (
-        patch(
-            "single_kernel_postgresql.managers.patroni.PatroniManager.cluster_status",
-            return_value=CLUSTER_STATUS[:1],
-        ),
-        patch(
-            "single_kernel_postgresql.managers.database.DatabaseManager.is_tls_enabled",
-            new_callable=PropertyMock,
-            return_value=False,
-        ),
-        patch.object(
-            manager.database_provides,
-            "fetch_my_relation_data",
-            return_value={rel_id: {"username": "u", "password": "pw"}},
-        ),
-    ):
-        manager.update_endpoints(rel_id)
-
-    data = harness.get_relation_data(rel_id, harness.charm.app.name)
-    assert data["read-only-endpoints"] == "1.1.1.1:5432"
-
-
 def test_update_endpoints_filters_out_of_sync_members(manager, harness, substrate):
     if substrate == "k8s":
         pytest.skip("K8s reads the replicas Service, not the online Patroni members")
@@ -760,13 +765,14 @@ def test_update_unit_status_keeps_a_prefix_block_while_a_short_prefix_remains(
 
 
 def test_unblock_custom_user_errors_clears_the_status(manager, postgresql, harness):
+    """The final clear routes through the charm's status bridge."""
     postgresql.list_valid_privileges_and_roles.return_value = (set(), set())
     relation = harness.model.get_relation(RELATION_NAME)
-    harness.model.unit.status = BlockedStatus("Requesting an existing username")
 
-    manager.unblock_custom_user_errors(postgresql, relation)
+    with patch.object(manager, "set_unit_status") as _gated:
+        manager.unblock_custom_user_errors(postgresql, relation)
 
-    assert harness.model.unit.status == ActiveStatus()
+    _gated.assert_called_once_with(ActiveStatus())
 
 
 def test_unblock_custom_user_errors_keeps_the_block_on_invalid_extra_user_roles(
@@ -781,9 +787,10 @@ def test_unblock_custom_user_errors_keeps_the_block_on_invalid_extra_user_roles(
             other_rel_id, "other-application", {"extra-user-roles": "bogus"}
         )
 
-    manager.unblock_custom_user_errors(postgresql, relation)
+    with patch.object(manager, "set_unit_status") as _gated:
+        manager.unblock_custom_user_errors(postgresql, relation)
 
-    assert harness.model.unit.status == BlockedStatus("invalid role(s) for extra user roles")
+    _gated.assert_called_once_with(BlockedStatus("invalid role(s) for extra user roles"))
 
 
 def test_unblock_custom_user_errors_keeps_the_block_on_a_forbidden_user(
@@ -798,10 +805,11 @@ def test_unblock_custom_user_errors_keeps_the_block_on_a_forbidden_user(
         patch.object(manager.database_provides, "fetch_my_relation_field", return_value=None),
         patch.object(manager.database_provides, "fetch_relation_field", return_value="secret-uri"),
         patch.object(manager.state.model, "get_secret", return_value=secret),
+        patch.object(manager, "set_unit_status") as _gated,
     ):
         manager.unblock_custom_user_errors(postgresql, relation)
 
-    assert harness.model.unit.status == BlockedStatus("Requesting an existing username")
+    _gated.assert_called_once_with(BlockedStatus("Requesting an existing username"))
 
 
 def test_unblock_custom_user_errors_keeps_the_block_while_the_secret_is_unreadable(
@@ -814,10 +822,11 @@ def test_unblock_custom_user_errors_keeps_the_block_while_the_secret_is_unreadab
         patch.object(manager.database_provides, "fetch_my_relation_field", return_value=None),
         patch.object(manager.database_provides, "fetch_relation_field", return_value="secret-uri"),
         patch.object(manager.state.model, "get_secret", side_effect=ModelError),
+        patch.object(manager, "set_unit_status") as _gated,
     ):
         manager.unblock_custom_user_errors(postgresql, relation)
 
-    assert harness.model.unit.status == BlockedStatus("Missing grant to requested entity secret")
+    _gated.assert_called_once_with(BlockedStatus("Missing grant to requested entity secret"))
 
 
 def test_is_tls_enabled_tracks_the_client_files(manager):
@@ -843,8 +852,3 @@ def test_request_errors_are_substrate_specific(substrate, manager):
         assert PostgreSQLBaseError not in manager.request_errors
     else:
         assert manager.request_errors == (PostgreSQLBaseError,)
-
-
-def test_manager_state_substrate_matches_the_charm(substrate, manager):
-    expected = Substrates.K8S if substrate == "k8s" else Substrates.VM
-    assert manager.state.substrate == expected

--- a/tests/unit/test_database_manager.py
+++ b/tests/unit/test_database_manager.py
@@ -1,0 +1,184 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""Unit tests for the client-relation DatabaseManager."""
+
+from unittest.mock import Mock, PropertyMock, patch
+
+import pytest
+from single_kernel_postgresql.config.enums import Substrates
+from single_kernel_postgresql.config.literals import (
+    APP_SCOPE,
+    DATABASE_MAPPING_LABEL,
+    PEER_RELATION,
+    USERNAME_MAPPING_LABEL,
+)
+from single_kernel_postgresql.utils.postgresql import (
+    ACCESS_GROUP_RELATION,
+)
+
+RELATION_NAME = "database"
+
+CLUSTER_STATUS = [
+    {"name": "postgresql-single-kernel-0", "role": "leader", "state": "running"},
+    {"name": "postgresql-single-kernel-1", "role": "replica", "state": "running"},
+    {"name": "postgresql-single-kernel-2", "role": "replica", "state": "running"},
+]
+
+
+@pytest.fixture
+def manager(harness):
+    """The DatabaseManager of a leader unit with three peers and a client relation."""
+    with harness.hooks_disabled():
+        harness.set_leader(True)
+        peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+        harness.add_relation_unit(peer_rel_id, "postgresql-single-kernel/1")
+        harness.add_relation_unit(peer_rel_id, "postgresql-single-kernel/2")
+        harness.add_relation(RELATION_NAME, "application")
+    return harness.charm.database_manager
+
+
+@pytest.fixture
+def postgresql():
+    return Mock()
+
+
+def test_relation_username_is_substrate_specific(substrate, manager):
+    """VM and K8s keep the live role names their deployed clusters already hold."""
+    expected = "relation_id_7" if substrate == "k8s" else "relation-7"
+    assert manager.relation_username(7) == expected
+
+
+def test_username_mapping_round_trip(manager):
+    assert manager.get_username_mapping() == {}
+
+    manager.update_username_mapping(4, "custom")
+    assert manager.get_username_mapping() == {"4": "custom"}
+
+    manager.update_username_mapping(4, None)
+    assert manager.get_username_mapping() == {}
+
+
+def test_update_username_mapping_ignores_the_generated_name(manager):
+    """Only a custom username is cached; the derived one is recomputed on demand."""
+    manager.update_username_mapping(4, manager.relation_username(4))
+    assert manager.state.get_secret(APP_SCOPE, USERNAME_MAPPING_LABEL) is None
+
+
+def test_set_databases_prefix_mapping_round_trip(manager):
+    manager.set_databases_prefix_mapping(4, "custom", "pre", ["pre_a"])
+    assert manager.get_databases_prefix_mapping() == {
+        "4": {"prefix": "pre", "username": "custom", "databases": ["pre_a"]}
+    }
+
+    manager.set_databases_prefix_mapping(4, None, None, None)
+    assert manager.get_databases_prefix_mapping() == {}
+
+
+def test_add_database_to_prefix_mapping_appends_sorted_and_returns_users(manager):
+    manager.set_databases_prefix_mapping(4, "custom", "pre", ["pre_b"])
+
+    assert manager.add_database_to_prefix_mapping("pre_a") == ["custom"]
+    assert manager.get_databases_prefix_mapping()["4"]["databases"] == ["pre_a", "pre_b"]
+
+    # A database outside every prefix touches nothing.
+    assert manager.add_database_to_prefix_mapping("other") == []
+    assert manager.get_databases_prefix_mapping()["4"]["databases"] == ["pre_a", "pre_b"]
+
+
+def test_remove_database_from_prefix_mapping(manager):
+    manager.set_databases_prefix_mapping(4, "custom", "pre", ["pre_a", "pre_b"])
+
+    assert manager.remove_database_from_prefix_mapping("pre_a") == ["custom"]
+    assert manager.get_databases_prefix_mapping()["4"]["databases"] == ["pre_b"]
+
+    assert manager.remove_database_from_prefix_mapping("absent") == []
+
+
+def test_collect_user_relations_uses_the_custom_username_when_cached(manager, harness):
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    with harness.hooks_disabled():
+        harness.update_relation_data(rel_id, "application", {"database": "test_db"})
+
+    assert manager.collect_user_relations() == {manager.relation_username(rel_id): "test_db"}
+
+    manager.update_username_mapping(rel_id, "custom")
+    assert manager.collect_user_relations() == {"custom": "test_db"}
+
+
+def test_collect_user_relations_skips_relations_without_a_database(manager):
+    assert manager.collect_user_relations() == {}
+
+
+def test_user_hash_tracks_the_collected_relations(manager, harness):
+    empty = manager.user_hash
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    with harness.hooks_disabled():
+        harness.update_relation_data(rel_id, "application", {"database": "test_db"})
+
+    assert manager.user_hash != empty
+
+
+def test_are_units_in_sync_compares_every_peer_unit(manager, harness):
+    peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+    expected = manager.user_hash
+
+    with harness.hooks_disabled():
+        for i in range(3):
+            harness.update_relation_data(
+                peer_rel_id, f"postgresql-single-kernel/{i}", {"user_hash": expected}
+            )
+    assert manager.are_units_in_sync() is True
+
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            peer_rel_id, "postgresql-single-kernel/2", {"user_hash": "stale"}
+        )
+    assert manager.are_units_in_sync() is False
+
+
+def test_sanitize_extra_roles_drops_access_groups_and_lowercases(manager):
+    assert manager.sanitize_extra_roles(None) == []
+    assert manager.sanitize_extra_roles(f"CREATEDB,{ACCESS_GROUP_RELATION}") == ["createdb"]
+
+
+def test_build_extra_user_roles_appends_the_relation_access_group(manager):
+    assert manager.build_extra_user_roles("CREATEDB") == ["createdb", ACCESS_GROUP_RELATION]
+
+
+def test_get_plugins_expands_overrides_and_spi(manager):
+    with patch(
+        "single_kernel_postgresql.core.state.CharmState.config", new_callable=PropertyMock
+    ) as _config:
+        _config.return_value = Mock(
+            plugin_keys=Mock(return_value=["plugin_audit_extension", "plugin_spi_extension"]),
+            plugin_audit_extension=True,
+            plugin_spi_extension=True,
+        )
+        plugins = manager.get_plugins()
+
+    assert "pgaudit" in plugins
+    assert "spi" not in plugins
+    assert "refint" in plugins
+
+
+def test_prefix_mapping_secret_labels_are_stable(manager):
+    """Deployed clusters hold these caches under these labels; renaming orphans them."""
+    manager.update_username_mapping(4, "custom")
+    manager.set_databases_prefix_mapping(4, "custom", "pre", [])
+
+    assert manager.state.get_secret(APP_SCOPE, USERNAME_MAPPING_LABEL) is not None
+    assert manager.state.get_secret(APP_SCOPE, DATABASE_MAPPING_LABEL) is not None
+
+
+def test_request_errors_are_substrate_specific(substrate, manager):
+    from single_kernel_postgresql.utils.postgresql import PostgreSQLBaseError
+
+    if substrate == "k8s":
+        assert PostgreSQLBaseError not in manager.request_errors
+    else:
+        assert manager.request_errors == (PostgreSQLBaseError,)
+
+
+def test_manager_state_substrate_matches_the_charm(substrate, manager):
+    expected = Substrates.K8S if substrate == "k8s" else Substrates.VM
+    assert manager.state.substrate == expected

--- a/tests/unit/test_database_manager.py
+++ b/tests/unit/test_database_manager.py
@@ -122,9 +122,7 @@ def test_set_rel_to_db_mapping_caches_the_databases(manager, harness):
 
     manager.set_rel_to_db_mapping()
 
-    assert (
-        json.loads(manager.state.application.data["rel_databases"]) == {str(rel_id): "test_db"}
-    )
+    assert json.loads(manager.state.application.data["rel_databases"]) == {str(rel_id): "test_db"}
 
 
 def test_user_hash_freezes_for_the_manager_lifetime(manager, harness):
@@ -451,7 +449,8 @@ def test_update_endpoints_publishes_rw_ro_and_uris(substrate, manager, harness):
         assert data["endpoints"] == f"{app}-primary.test-model.svc.cluster.local:5432"
         assert data["read-only-endpoints"] == f"{app}-replicas.test-model.svc.cluster.local:5432"
         assert (
-            data["uris"] == f"postgresql://u:pw@{app}-primary.test-model.svc.cluster.local:5432/test_db"
+            data["uris"]
+            == f"postgresql://u:pw@{app}-primary.test-model.svc.cluster.local:5432/test_db"
         )
     else:
         assert data["endpoints"] == "1.1.1.1:5432"
@@ -790,7 +789,9 @@ def test_unblock_custom_user_errors_keeps_the_block_on_invalid_extra_user_roles(
     other_rel_id = harness.add_relation(RELATION_NAME, "other-application")
     with harness.hooks_disabled():
         # The relation the check skips is the one carrying the invalid roles.
-        harness.update_relation_data(other_rel_id, "other-application", {"extra-user-roles": "bogus"})
+        harness.update_relation_data(
+            other_rel_id, "other-application", {"extra-user-roles": "bogus"}
+        )
 
     manager.unblock_custom_user_errors(postgresql, relation)
 
@@ -807,9 +808,7 @@ def test_unblock_custom_user_errors_keeps_the_block_on_a_forbidden_user(
 
     with (
         patch.object(manager.database_provides, "fetch_my_relation_field", return_value=None),
-        patch.object(
-            manager.database_provides, "fetch_relation_field", return_value="secret-uri"
-        ),
+        patch.object(manager.database_provides, "fetch_relation_field", return_value="secret-uri"),
         patch.object(manager.state.model, "get_secret", return_value=secret),
     ):
         manager.unblock_custom_user_errors(postgresql, relation)
@@ -825,9 +824,7 @@ def test_unblock_custom_user_errors_keeps_the_block_while_the_secret_is_unreadab
 
     with (
         patch.object(manager.database_provides, "fetch_my_relation_field", return_value=None),
-        patch.object(
-            manager.database_provides, "fetch_relation_field", return_value="secret-uri"
-        ),
+        patch.object(manager.database_provides, "fetch_relation_field", return_value="secret-uri"),
         patch.object(manager.state.model, "get_secret", side_effect=ModelError),
     ):
         manager.unblock_custom_user_errors(postgresql, relation)

--- a/tests/unit/test_database_manager.py
+++ b/tests/unit/test_database_manager.py
@@ -381,22 +381,15 @@ def test_update_endpoints_publishes_rw_ro_and_uris(substrate, manager, harness):
         )
 
     with (
-        patch(
-            "single_kernel_postgresql.managers.patroni.PatroniManager.cluster_status",
-            return_value=CLUSTER_STATUS[:2],
-        ),
-        patch(
-            "single_kernel_postgresql.managers.database.DatabaseManager.is_tls_enabled",
-            new_callable=PropertyMock,
-            return_value=False,
-        ),
         patch.object(
             manager.database_provides,
             "fetch_my_relation_data",
             return_value={rel_id: {"username": "u", "password": "pw"}},
         ),
     ):
-        manager.update_endpoints(rel_id)
+        manager.update_endpoints(
+            rel_id, online_members=CLUSTER_STATUS[:2] if substrate == "vm" else None
+        )
 
     data = harness.get_relation_data(rel_id, harness.charm.app.name)
     if substrate == "k8s":
@@ -424,15 +417,6 @@ def test_update_endpoints_read_only_uri_carries_one_port(substrate, manager, har
         )
 
     with (
-        patch(
-            "single_kernel_postgresql.managers.patroni.PatroniManager.cluster_status",
-            return_value=CLUSTER_STATUS[:1],
-        ),
-        patch(
-            "single_kernel_postgresql.managers.database.DatabaseManager.is_tls_enabled",
-            new_callable=PropertyMock,
-            return_value=False,
-        ),
         patch.object(
             manager.database_provides,
             "fetch_my_relation_data",
@@ -440,7 +424,9 @@ def test_update_endpoints_read_only_uri_carries_one_port(substrate, manager, har
         ),
         patch.object(manager.database_provides, "set_read_only_uris") as _set_ro_uris,
     ):
-        manager.update_endpoints(rel_id)
+        manager.update_endpoints(
+            rel_id, online_members=CLUSTER_STATUS[:1] if substrate == "vm" else None
+        )
 
     _set_ro_uris.assert_called_once()
     uri = _set_ro_uris.call_args.args[1]
@@ -456,23 +442,12 @@ def test_update_endpoints_publishes_the_primary_ip_verbatim(manager, harness, su
     with harness.hooks_disabled():
         harness.update_relation_data(rel_id, "application", {"database": "test_db"})
 
-    with (
-        patch(
-            "single_kernel_postgresql.managers.patroni.PatroniManager.cluster_status",
-            return_value=CLUSTER_STATUS[:1],
-        ),
-        patch(
-            "single_kernel_postgresql.managers.database.DatabaseManager.is_tls_enabled",
-            new_callable=PropertyMock,
-            return_value=False,
-        ),
-        patch.object(
-            manager.database_provides,
-            "fetch_my_relation_data",
-            return_value={rel_id: {"username": "u", "password": "pw"}},
-        ),
+    with patch.object(
+        manager.database_provides,
+        "fetch_my_relation_data",
+        return_value={rel_id: {"username": "u", "password": "pw"}},
     ):
-        manager.update_endpoints(rel_id)
+        manager.update_endpoints(rel_id, online_members=CLUSTER_STATUS[:1])
 
     data = harness.get_relation_data(rel_id, harness.charm.app.name)
     assert data["endpoints"] == "None:5432"
@@ -487,21 +462,16 @@ def test_update_endpoints_publishes_tls_when_enabled(substrate, manager, harness
             peer_rel_id, "postgresql-single-kernel/0", {f"{RELATION_NAME}-address": "1.1.1.1"}
         )
 
-    with (
-        patch(
-            "single_kernel_postgresql.managers.patroni.PatroniManager.cluster_status",
-            return_value=CLUSTER_STATUS[:1],
-        ),
-        patch.object(
-            manager.tls_manager, "get_client_tls_files", return_value=("key", "CA", "cert")
-        ),
-        patch.object(
-            manager.database_provides,
-            "fetch_my_relation_data",
-            return_value={rel_id: {"username": "u", "password": "pw"}},
-        ),
+    with patch.object(
+        manager.database_provides,
+        "fetch_my_relation_data",
+        return_value={rel_id: {"username": "u", "password": "pw"}},
     ):
-        manager.update_endpoints(rel_id)
+        manager.update_endpoints(
+            rel_id,
+            online_members=CLUSTER_STATUS[:1] if substrate == "vm" else None,
+            client_tls_files=("key", "CA", "cert"),
+        )
 
     data = harness.get_relation_data(rel_id, harness.charm.app.name)
     assert data["tls"] == "True"
@@ -519,17 +489,10 @@ def test_k8s_endpoints_fall_back_to_the_primary_without_peer_units(substrate, ma
         harness.remove_relation_unit(peer_rel_id, "postgresql-single-kernel/2")
         harness.update_relation_data(rel_id, "application", {"database": "test_db"})
 
-    with (
-        patch(
-            "single_kernel_postgresql.managers.database.DatabaseManager.is_tls_enabled",
-            new_callable=PropertyMock,
-            return_value=False,
-        ),
-        patch.object(
-            manager.database_provides,
-            "fetch_my_relation_data",
-            return_value={rel_id: {"username": "u", "password": "pw"}},
-        ),
+    with patch.object(
+        manager.database_provides,
+        "fetch_my_relation_data",
+        return_value={rel_id: {"username": "u", "password": "pw"}},
     ):
         manager.update_endpoints(rel_id)
 
@@ -549,23 +512,12 @@ def test_update_endpoints_falls_back_to_the_primary_without_replicas(manager, ha
             peer_rel_id, "postgresql-single-kernel/0", {f"{RELATION_NAME}-address": "1.1.1.1"}
         )
 
-    with (
-        patch(
-            "single_kernel_postgresql.managers.patroni.PatroniManager.cluster_status",
-            return_value=CLUSTER_STATUS[:1],
-        ),
-        patch(
-            "single_kernel_postgresql.managers.database.DatabaseManager.is_tls_enabled",
-            new_callable=PropertyMock,
-            return_value=False,
-        ),
-        patch.object(
-            manager.database_provides,
-            "fetch_my_relation_data",
-            return_value={rel_id: {"username": "u", "password": "pw"}},
-        ),
+    with patch.object(
+        manager.database_provides,
+        "fetch_my_relation_data",
+        return_value={rel_id: {"username": "u", "password": "pw"}},
     ):
-        manager.update_endpoints(rel_id)
+        manager.update_endpoints(rel_id, online_members=CLUSTER_STATUS[:1])
 
     data = harness.get_relation_data(rel_id, harness.charm.app.name)
     assert data["read-only-endpoints"] == "1.1.1.1:5432"
@@ -589,23 +541,12 @@ def test_update_endpoints_filters_out_of_sync_members(manager, harness, substrat
         )
 
     nosync = [*CLUSTER_STATUS[:2], {**CLUSTER_STATUS[2], "tags": {"nosync": True}}]
-    with (
-        patch(
-            "single_kernel_postgresql.managers.patroni.PatroniManager.cluster_status",
-            return_value=nosync,
-        ),
-        patch(
-            "single_kernel_postgresql.managers.database.DatabaseManager.is_tls_enabled",
-            new_callable=PropertyMock,
-            return_value=False,
-        ),
-        patch.object(
-            manager.database_provides,
-            "fetch_my_relation_data",
-            return_value={rel_id: {"username": "u", "password": "pw"}},
-        ),
+    with patch.object(
+        manager.database_provides,
+        "fetch_my_relation_data",
+        return_value={rel_id: {"username": "u", "password": "pw"}},
     ):
-        manager.update_endpoints(rel_id)
+        manager.update_endpoints(rel_id, online_members=nosync)
 
     data = harness.get_relation_data(rel_id, harness.charm.app.name)
     assert data["read-only-endpoints"] == "2.2.2.2:5432"
@@ -644,13 +585,6 @@ def test_update_unit_status_keeps_a_prefix_block_while_a_short_prefix_remains(
     manager.update_unit_status(postgresql, relation)
 
     assert harness.model.unit.status == BlockedStatus(PREFIX_TOO_SHORT_MSG)
-
-
-def test_is_tls_enabled_tracks_the_client_files(manager):
-    with patch.object(manager.tls_manager, "get_client_tls_files", return_value=("k", "ca", "c")):
-        assert manager.is_tls_enabled is True
-    with patch.object(manager.tls_manager, "get_client_tls_files", return_value=("k", None, "c")):
-        assert manager.is_tls_enabled is False
 
 
 def test_prefix_mapping_secret_labels_are_stable(manager):

--- a/tests/unit/test_database_manager.py
+++ b/tests/unit/test_database_manager.py
@@ -14,12 +14,7 @@ from single_kernel_postgresql.config.literals import (
     PEER_RELATION,
     USERNAME_MAPPING_LABEL,
 )
-from single_kernel_postgresql.managers.database import (
-    FORBIDDEN_USER_MSG,
-    NO_ACCESS_TO_SECRET_MSG,
-    PREFIX_TOO_SHORT_MSG,
-    DatabaseRequest,
-)
+from single_kernel_postgresql.managers.database import DatabaseRequest
 from single_kernel_postgresql.utils.postgresql import (
     ACCESS_GROUP_RELATION,
     PostgreSQLDeleteUserError,
@@ -119,6 +114,19 @@ def test_collect_user_relations_skips_relations_without_a_database(manager):
     assert manager.collect_user_relations() == {}
 
 
+def test_set_rel_to_db_mapping_caches_the_databases(manager, harness):
+    """The Patroni pg_hba render reads this app-data cache under the same key."""
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    with harness.hooks_disabled():
+        harness.update_relation_data(rel_id, "application", {"database": "test_db"})
+
+    manager.set_rel_to_db_mapping()
+
+    assert (
+        json.loads(manager.state.application.data["rel_databases"]) == {str(rel_id): "test_db"}
+    )
+
+
 def test_user_hash_freezes_for_the_manager_lifetime(manager, harness):
     """Both charms cached the hash per hook, so a mid-hook mapping change must not alter it."""
     frozen = manager.user_hash
@@ -197,7 +205,7 @@ def test_get_credentials_blocks_on_an_existing_username(manager, postgresql, har
         requested_entity_secret_content={"taken": "pw"},
     )
     assert manager.get_credentials(postgresql, request) is None
-    assert harness.model.unit.status == BlockedStatus(FORBIDDEN_USER_MSG)
+    assert harness.model.unit.status == BlockedStatus("Requesting an existing username")
 
 
 def test_get_credentials_blocks_when_the_secret_is_not_readable(manager, postgresql, harness):
@@ -209,7 +217,7 @@ def test_get_credentials_blocks_when_the_secret_is_not_readable(manager, postgre
         requested_entity_secret_content=Mock(items=Mock(side_effect=__import__("ops").ModelError)),
     )
     assert manager.get_credentials(postgresql, request) is None
-    assert harness.model.unit.status == BlockedStatus(NO_ACCESS_TO_SECRET_MSG)
+    assert harness.model.unit.status == BlockedStatus("Missing grant to requested entity secret")
 
 
 def test_collect_databases_plain_database(manager, postgresql):
@@ -246,7 +254,7 @@ def test_collect_databases_blocks_on_a_too_short_prefix(manager, postgresql, har
         requested_entity_secret_content=None,
     )
     assert manager.collect_databases(postgresql, "user", request) is None
-    assert harness.model.unit.status == BlockedStatus(PREFIX_TOO_SHORT_MSG)
+    assert harness.model.unit.status == BlockedStatus("Prefix too short")
     postgresql.list_databases.assert_not_called()
 
 
@@ -273,21 +281,29 @@ def test_create_relation_user_and_database_prefixed_skips_create_database(manage
 
 def test_delete_relation_user_clears_every_mapping(manager, postgresql, harness):
     rel_id = harness.model.get_relation(RELATION_NAME).id
+    other_rel_id = harness.add_relation(RELATION_NAME, "other-application")
     manager.update_username_mapping(rel_id, "custom")
-    manager.set_databases_prefix_mapping(rel_id, "custom", "pre", ["pre_a"])
+    # The deleted relation's database still sits in another relation's prefix.
+    manager.set_databases_prefix_mapping(other_rel_id, "other-user", "pre", ["pre_a"])
+    harness.charm.app_data_setter = None
     manager.state.application.data["rel_databases"] = json.dumps({str(rel_id): "pre_a"})
 
     manager.delete_relation_user(postgresql, rel_id)
 
     postgresql.delete_user.assert_called_once_with("custom")
+    postgresql.remove_user_from_databases.assert_called_once_with("other-user", ["pre_a"])
     assert manager.get_username_mapping() == {}
-    assert manager.get_databases_prefix_mapping() == {}
+    assert manager.get_databases_prefix_mapping() == {
+        str(other_rel_id): {"prefix": "pre", "username": "other-user", "databases": []}
+    }
 
 
 def test_delete_relation_user_blocks_when_the_drop_fails(manager, postgresql, harness):
     postgresql.delete_user.side_effect = PostgreSQLDeleteUserError
     manager.delete_relation_user(postgresql, 4)
-    assert isinstance(harness.model.unit.status, BlockedStatus)
+    assert harness.model.unit.status == BlockedStatus(
+        "Failed to delete user during database relation broken event"
+    )
 
 
 def test_oversee_users_deletes_only_users_without_a_relation(manager, postgresql, harness):
@@ -298,10 +314,14 @@ def test_oversee_users_deletes_only_users_without_a_relation(manager, postgresql
         stale,
         "postgres",
     }
+    manager.state.set_secret(APP_SCOPE, stale, "pw")
+    manager.state.set_secret(APP_SCOPE, f"{stale}-database", "pw")
 
     manager.oversee_users(postgresql)
 
     postgresql.delete_user.assert_called_once_with(stale)
+    assert manager.state.get_secret(APP_SCOPE, stale) is None
+    assert manager.state.get_secret(APP_SCOPE, f"{stale}-database") is None
 
 
 def test_oversee_users_honours_the_suppress_flag(manager, postgresql):
@@ -723,11 +743,11 @@ def test_update_unit_status_keeps_a_prefix_block_while_a_short_prefix_remains(
     relation = harness.model.get_relation(RELATION_NAME)
     with harness.hooks_disabled():
         harness.update_relation_data(relation.id, "application", {"database": "a*"})
-    harness.model.unit.status = BlockedStatus(PREFIX_TOO_SHORT_MSG)
+    harness.model.unit.status = BlockedStatus("Prefix too short")
 
     manager.update_unit_status(postgresql, relation)
 
-    assert harness.model.unit.status == BlockedStatus(PREFIX_TOO_SHORT_MSG)
+    assert harness.model.unit.status == BlockedStatus("Prefix too short")
 
 
 def test_is_tls_enabled_tracks_the_client_files(manager):

--- a/uv.lock
+++ b/uv.lock
@@ -1156,7 +1156,7 @@ wheels = [
 
 [[package]]
 name = "postgresql-charms-single-kernel"
-version = "16.3.5"
+version = "16.3.6"
 source = { editable = "." }
 dependencies = [
     { name = "ops", version = "2.23.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Issue

`postgresql_provider.py` still lives in both charms (VM 645 lines, K8s 606, near-identical), and the config flow it feeds already moved into this library. Until the provider follows, `update_config` has to be handed a `relations_user_databases_map` and a `user_hash` the charm computes from provider state, and it calls back into the charm to refresh client endpoints. This is the first of seven PRs that move the whole client relation here; it carries the state the config flow already reads.

## Solution

Adds `managers/database.py` with the parts of the provider that are pure state:

- the custom-username and prefixed-database caches, kept under the same app-secret labels (`custom-usernames`, `prefix-databases`) so deployed clusters keep their existing content;
- the relation-to-database mapping;
- `collect_user_relations()` and `user_hash`, which the config manager consumes in PR 4 in place of the two injected values;
- `are_units_in_sync()`, the peer-hash comparison the request handler defers on;
- `get_plugins()`, ported from both charms unchanged.

The generated PostgreSQL role name is derived from the substrate rather than converged: VM clusters hold roles named `relation-<id>` and K8s ones `relation_id_<id>`, so a single name would require renaming roles on every deployed K8s cluster. `utils/postgresql.py` already matches both forms in its relation-user SQL. Created https://warthogs.atlassian.net/browse/DPE-10877 for handling that.

Nothing constructs this manager yet — PR 4 wires it in. Unit tests are in PRs 5 and 6, following the split used for the `update_config` migration.

Follow-up lib PRs:
* https://github.com/canonical/postgresql-single-kernel-library/pull/217
* https://github.com/canonical/postgresql-single-kernel-library/pull/226
* https://github.com/canonical/postgresql-single-kernel-library/pull/219
* https://github.com/canonical/postgresql-single-kernel-library/pull/220
* https://github.com/canonical/postgresql-single-kernel-library/pull/221
* https://github.com/canonical/postgresql-single-kernel-library/pull/222

Wiring up at:
* https://github.com/canonical/postgresql-k8s-operator/pull/1696
* https://github.com/canonical/postgresql-operator/pull/1900

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
