### PR TITLE
[DPE-10882] feat(database): own the client relation events, drop the endpoint bridge (4/7)

### DIFF
--- a/single_kernel_postgresql/charms/abstract_charm.py
+++ b/single_kernel_postgresql/charms/abstract_charm.py
@@ -107,8 +107,9 @@ class AbstractPostgreSQLCharm(CharmBase, ABC):
     # Charm-side bridges the lib calls back into. request_restart/restart_services are
     # substrate-tangled and stay until their own migration phases; update_config still
     # supplies the ldap/async/watcher values those phases own; primary_endpoint is the
-    # VM's Patroni-derived primary lookup. set_unit_status is permanent: it gates status
-    # writes on charm_refresh priority, and charm_refresh is not a migration target.
+    # VM's Patroni-derived primary lookup. set_unit_status routes status writes through
+    # the charm_refresh priority gate and stays until the refresh logic itself migrates
+    # into the library, at which point the managers own their status writes.
     @abstractmethod
     def get_resource_provider(self) -> ResourceProvider:
         """Return the substrate's (cpu_cores, memory_bytes) introspector."""

--- a/single_kernel_postgresql/charms/abstract_charm.py
+++ b/single_kernel_postgresql/charms/abstract_charm.py
@@ -5,9 +5,11 @@
 from abc import ABC, abstractmethod
 
 from data_platform_helpers.advanced_statuses import StatusHandler
+from ops import StatusBase
 from ops.charm import CharmBase
 
 from single_kernel_postgresql.core.state import CharmState
+from single_kernel_postgresql.events.database import DatabaseEventsHandler
 from single_kernel_postgresql.events.postgresql import PostgreSQLEventsHandler
 from single_kernel_postgresql.events.tls import TLS
 from single_kernel_postgresql.managers.cluster import ClusterManager
@@ -42,14 +44,22 @@ class AbstractPostgreSQLCharm(CharmBase, ABC):
         )
         self.patroni_manager = PatroniManager(state=self.state, workload=self.workload)
         self.cluster_manager = ClusterManager(state=self.state, workload=self.workload)
+
+        # Client-relation handler owns DatabaseProvides and builds the DatabaseManager the
+        # config manager refreshes endpoints and reads the user hash through.
+        self.database = DatabaseEventsHandler(
+            self, self.state, self.patroni_manager, self.tls_manager
+        )
+        self.database_manager = self.database.manager
+
         self.config_manager = ConfigManager(
             state=self.state,
             workload=self.workload,
             tls_manager=self.tls_manager,
             patroni_manager=self.patroni_manager,
+            database_manager=self.database_manager,
             resource_provider=self.get_resource_provider,
             request_restart=self.request_restart,
-            refresh_endpoints=self.refresh_endpoints,
             restart_services=self.restart_services,
         )
 
@@ -94,9 +104,11 @@ class AbstractPostgreSQLCharm(CharmBase, ABC):
         """Access current substrate."""
         pass
 
-    # Config-update bridges: charm-side callables the ConfigManager invokes for the
-    # substrate-tangled restart trigger, endpoint refresh and monitoring/ldap service
-    # restarts. They stay in the charm until their own migration phases.
+    # Charm-side bridges the lib calls back into. request_restart/restart_services are
+    # substrate-tangled and stay until their own migration phases; update_config still
+    # supplies the ldap/async/watcher values those phases own; primary_endpoint is the
+    # VM's Patroni-derived primary lookup. set_unit_status is permanent: it gates status
+    # writes on charm_refresh priority, and charm_refresh is not a migration target.
     @abstractmethod
     def get_resource_provider(self) -> ResourceProvider:
         """Return the substrate's (cpu_cores, memory_bytes) introspector."""
@@ -108,11 +120,22 @@ class AbstractPostgreSQLCharm(CharmBase, ABC):
         pass
 
     @abstractmethod
-    def refresh_endpoints(self) -> None:
-        """Refresh the client relation endpoints."""
+    def restart_services(self) -> None:
+        """Restart the monitoring and LDAP-sync sidecar services."""
         pass
 
     @abstractmethod
-    def restart_services(self) -> None:
-        """Restart the monitoring and LDAP-sync sidecar services."""
+    def set_unit_status(self, status: StatusBase) -> None:
+        """Set the unit status without overriding a higher-priority refresh status."""
+        pass
+
+    @abstractmethod
+    def update_config(self) -> bool:
+        """Re-render the Patroni configuration and apply it."""
+        pass
+
+    @property
+    @abstractmethod
+    def primary_endpoint(self) -> str | None:
+        """Address of the cluster primary, or None when there is not one."""
         pass

--- a/single_kernel_postgresql/charms/k8s_charm.py
+++ b/single_kernel_postgresql/charms/k8s_charm.py
@@ -6,6 +6,8 @@
 
 import logging
 
+from ops import StatusBase
+
 from single_kernel_postgresql.charms.abstract_charm import AbstractPostgreSQLCharm, PostgreSQL
 from single_kernel_postgresql.config.enums import Substrates
 from single_kernel_postgresql.config.literals import CONTAINER_NAME, SYSTEM_USERS, USER
@@ -66,8 +68,8 @@ class PostgreSQLK8sCharm(AbstractPostgreSQLCharm):
         return Substrates.K8S
 
     # The concrete production charm owns these bridges (update_scrape_job_spec +
-    # acquire_lock, update_endpoints, pebble metrics/ldap restarts), so they default to
-    # no-ops here.
+    # acquire_lock, pebble metrics/ldap restarts, the refresh-aware status write and the
+    # config re-render), so they are minimal here.
     def get_resource_provider(self) -> K8sManager:
         """Return the substrate's (cpu_cores, memory_bytes) introspector."""
         return self.k8s_manager
@@ -75,8 +77,18 @@ class PostgreSQLK8sCharm(AbstractPostgreSQLCharm):
     def request_restart(self) -> None:
         """Run the substrate pre-restart side effect and acquire the restart lock."""
 
-    def refresh_endpoints(self) -> None:
-        """Refresh the client relation endpoints."""
-
     def restart_services(self) -> None:
         """Restart the monitoring and LDAP-sync sidecar services."""
+
+    def set_unit_status(self, status: StatusBase) -> None:
+        """Set the unit status without overriding a higher-priority refresh status."""
+        self.unit.status = status
+
+    def update_config(self) -> bool:
+        """Re-render the Patroni configuration and apply it."""
+        return self.config_manager.update_config(self.postgresql)
+
+    @property
+    def primary_endpoint(self) -> str | None:
+        """Address of the cluster primary's Service."""
+        return self.state.primary_endpoint

--- a/single_kernel_postgresql/charms/vm_charm.py
+++ b/single_kernel_postgresql/charms/vm_charm.py
@@ -6,6 +6,8 @@
 
 import logging
 
+from ops import StatusBase
+
 from single_kernel_postgresql.charms.abstract_charm import AbstractPostgreSQLCharm, PostgreSQL
 from single_kernel_postgresql.config.enums import Substrates
 from single_kernel_postgresql.config.literals import SYSTEM_USERS, USER
@@ -57,8 +59,8 @@ class PostgreSQLVMCharm(AbstractPostgreSQLCharm):
         return Substrates.VM
 
     # The concrete production charm owns these bridges (pops postgresql_restarted +
-    # acquire_lock, update_endpoints, snap metrics/ldap restarts), so they default to
-    # no-ops here.
+    # acquire_lock, snap metrics/ldap restarts, the refresh-aware status write, the
+    # Patroni-derived primary lookup and the config re-render), so they are minimal here.
     def get_resource_provider(self) -> VMWorkload:
         """Return the substrate's (cpu_cores, memory_bytes) introspector."""
         return self.workload
@@ -66,8 +68,19 @@ class PostgreSQLVMCharm(AbstractPostgreSQLCharm):
     def request_restart(self) -> None:
         """Run the substrate pre-restart side effect and acquire the restart lock."""
 
-    def refresh_endpoints(self) -> None:
-        """Refresh the client relation endpoints."""
-
     def restart_services(self) -> None:
         """Restart the monitoring and LDAP-sync sidecar services."""
+
+    def set_unit_status(self, status: StatusBase) -> None:
+        """Set the unit status without overriding a higher-priority refresh status."""
+        self.unit.status = status
+
+    def update_config(self) -> bool:
+        """Re-render the Patroni configuration and apply it."""
+        return self.config_manager.update_config(self.postgresql)
+
+    @property
+    def primary_endpoint(self) -> str | None:
+        """Address of the cluster primary, or None when there is not one."""
+        primary = self.patroni_manager.get_primary()
+        return self.patroni_manager.get_member_ip(primary) if primary else None

--- a/single_kernel_postgresql/events/database.py
+++ b/single_kernel_postgresql/events/database.py
@@ -102,8 +102,10 @@ class DatabaseEventsHandler(Object):
 
         if not self._ready_for_request():
             logger.debug(
-                "Deferring on_database_requested: cluster not initialized, Patroni not started "
-                "or primary endpoint not available"
+                "Deferring on_database_requested: %s",
+                "Cluster must be initialized before database can be requested"
+                if self.state.substrate == Substrates.K8S
+                else "cluster not initialized, Patroni not started or primary endpoint not available",
             )
             event.defer()
             return
@@ -144,7 +146,11 @@ class DatabaseEventsHandler(Object):
                 event.relation.id, postgresql.get_postgresql_version()
             )
             self.database_provides.set_database(event.relation.id, database)
-            self.manager.update_endpoints(event.relation.id)
+            if self.state.substrate == Substrates.K8S:
+                # K8s refreshed every relation from the request handler.
+                self.manager.update_endpoints()
+            else:
+                self.manager.update_endpoints(event.relation.id)
             self.manager.update_unit_status(postgresql, event.relation)
             self.charm.update_config()
         except self.manager.request_errors as e:
@@ -195,8 +201,10 @@ class DatabaseEventsHandler(Object):
         """Remove the user created for this relation."""
         if not self.state.peer_relation or not self._ready_for_removal():
             logger.debug(
-                "Deferring on_relation_broken: Cluster must be initialized and primary "
-                "available before user can be deleted"
+                "Deferring on_relation_broken: %s",
+                "Cluster must be initialized before user can be deleted"
+                if self.state.substrate == Substrates.K8S
+                else "Cluster must be initialized and primary available before user can be deleted",
             )
             event.defer()
             return

--- a/single_kernel_postgresql/events/database.py
+++ b/single_kernel_postgresql/events/database.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""Client-relation events handler — owns DatabaseProvides, delegates to DatabaseManager."""
+
+import logging
+
+from ops import BlockedStatus, Object, RelationBrokenEvent, RelationDepartedEvent
+
+from single_kernel_postgresql.config.enums import Substrates
+from single_kernel_postgresql.config.literals import DATABASE, DATABASE_PORT
+from single_kernel_postgresql.core.state import CharmState
+from single_kernel_postgresql.lib.charms.data_platform_libs.v0.data_interfaces import (
+    DatabaseProvides,
+    DatabaseRequestedEvent,
+)
+from single_kernel_postgresql.managers.database import DatabaseManager, DatabaseRequest
+from single_kernel_postgresql.managers.patroni import PatroniManager
+from single_kernel_postgresql.managers.tls import TLSManager
+from single_kernel_postgresql.utils.postgresql import (
+    PostgreSQLCreateDatabaseError,
+    PostgreSQLCreateUserError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class DatabaseEventsHandler(Object):
+    """Handles the ``database`` (``postgresql_client``) provider relation.
+
+    Owns the :class:`DatabaseProvides` interface and the three observers the client
+    relation needs, and constructor-injects the interface into
+    :class:`~single_kernel_postgresql.managers.database.DatabaseManager`, mirroring how
+    the TLS handler owns its requirers.
+
+    Each handler keeps its guard and its work in one observer: ``defer()`` is
+    per-observer, so splitting the readiness check from the action would let a deferred
+    action retry alone against state its guard never re-checked.
+
+    ``charm`` is deliberately untyped, as in the TLS handler: the production charms do
+    not derive from :class:`AbstractPostgreSQLCharm` until the cutover phase, and they
+    are the callers that construct this.
+    """
+
+    def __init__(
+        self,
+        charm,
+        state: CharmState,
+        patroni_manager: PatroniManager,
+        tls_manager: TLSManager,
+        relation_name: str = DATABASE,
+    ) -> None:
+        super().__init__(charm, key="database")
+        self.charm = charm
+        self.state = state
+        self.relation_name = relation_name
+
+        self.database_provides = DatabaseProvides(charm, relation_name=relation_name)
+        self.manager = DatabaseManager(
+            state=state,
+            workload=charm.workload,
+            database_provides=self.database_provides,
+            patroni_manager=patroni_manager,
+            tls_manager=tls_manager,
+            set_unit_status=charm.set_unit_status,
+            relation_name=relation_name,
+        )
+
+        self.framework.observe(
+            charm.on[relation_name].relation_departed, self._on_relation_departed
+        )
+        self.framework.observe(charm.on[relation_name].relation_broken, self._on_relation_broken)
+        self.framework.observe(
+            self.database_provides.on.database_requested, self._on_database_requested
+        )
+
+    def _ready_for_request(self) -> bool:
+        """Whether the cluster can serve a new client request right now."""
+        if not self.state.application.is_cluster_initialised:
+            return False
+        if self.state.substrate == Substrates.K8S:
+            return self.manager.patroni_manager.primary_endpoint_ready
+        return bool(self.manager.patroni_manager.member_started and self.charm.primary_endpoint)
+
+    def _ready_for_removal(self) -> bool:
+        """Whether the cluster can serve a relation removal right now.
+
+        K8s settles for a started member here where a request additionally waits on the
+        primary endpoint being reachable.
+        """
+        if not self.state.application.is_cluster_initialised:
+            return False
+        if self.state.substrate == Substrates.K8S:
+            return self.manager.patroni_manager.member_started
+        return bool(self.manager.patroni_manager.member_started and self.charm.primary_endpoint)
+
+    def _on_database_requested(self, event: DatabaseRequestedEvent) -> None:
+        """Generate password and handle user and database creation for the related app."""
+        # The provider library only emits this on the leader.
+        if not self.state.peer.is_app_leader:
+            return
+
+        if not self._ready_for_request():
+            logger.debug(
+                "Deferring on_database_requested: cluster not initialized, Patroni not started "
+                "or primary endpoint not available"
+            )
+            event.defer()
+            return
+
+        request = DatabaseRequest(
+            relation_id=event.relation.id,
+            database=event.database or "",
+            extra_user_roles=event.extra_user_roles,
+            prefix_matching=event.prefix_matching,
+            requested_entity_secret_content=event.requested_entity_secret_content,
+        )
+        postgresql = self.charm.postgresql
+
+        if not (creds := self.manager.get_credentials(postgresql, request)):
+            return
+        user, password = creds
+
+        if not (databases_setup := self.manager.collect_databases(postgresql, user, request)):
+            return
+        database, databases = databases_setup
+
+        self.manager.update_username_mapping(event.relation.id, user)
+        self.charm.update_config()
+        if not self.manager.are_units_in_sync():
+            logger.debug("Not all units have synced configuration")
+            event.defer()
+            return
+
+        extra_user_roles = self.manager.build_extra_user_roles(event.extra_user_roles)
+
+        try:
+            self.manager.create_relation_user_and_database(
+                postgresql, user, password, database, databases, extra_user_roles
+            )
+            self.database_provides.set_credentials(event.relation.id, user, password)
+            self._publish_k8s_inline_endpoints(event.relation.id, user, password, database)
+            self.database_provides.set_version(
+                event.relation.id, postgresql.get_postgresql_version()
+            )
+            self.database_provides.set_database(event.relation.id, database)
+            self.manager.update_endpoints(event.relation.id)
+            self.manager.update_unit_status(postgresql, event.relation)
+            self.charm.update_config()
+        except self.manager.request_errors as e:
+            if self.state.substrate == Substrates.K8S:
+                logger.exception(e)
+            self.charm.set_unit_status(
+                BlockedStatus(
+                    e.message
+                    if isinstance(e, PostgreSQLCreateDatabaseError | PostgreSQLCreateUserError)
+                    and e.message is not None
+                    # The clearer of the two charms' wordings, now shared by both.
+                    else f"Failed to initialize {self.relation_name} relation"
+                )
+            )
+            return
+
+    def _publish_k8s_inline_endpoints(
+        self, relation_id: int, user: str, password: str, database: str
+    ) -> None:
+        """Publish the endpoint/URI/TLS fields the K8s charm wrote inside the request handler.
+
+        ``update_endpoints`` writes the same values moments later, so this is redundant;
+        it is kept so the port does not change K8s databag write ordering.
+        """
+        if self.state.substrate != Substrates.K8S:
+            return
+        primary = f"{self.state.primary_endpoint}:{DATABASE_PORT}"
+        self.database_provides.set_endpoints(relation_id, primary)
+        self.database_provides.set_uris(
+            relation_id, f"postgresql://{user}:{password}@{primary}/{database}"
+        )
+        self.database_provides.set_tls(
+            relation_id, "True" if self.manager.is_tls_enabled else "False"
+        )
+        if self.manager.is_tls_enabled:
+            _, ca, _ = self.manager.tls_manager.get_client_tls_files()
+            self.database_provides.set_tls_ca(relation_id, ca or "")
+
+    def _on_relation_departed(self, event: RelationDepartedEvent) -> None:
+        """Set a flag to avoid deleting database users when not wanted."""
+        # Set a flag to avoid deleting database users when this unit
+        # is removed and receives relation broken events from related applications.
+        # This is needed because of https://bugs.launchpad.net/juju/+bug/1979811.
+        if event.departing_unit == self.state.model.unit and self.state.peer_relation:
+            self.state.peer.data.update({"departing": "True"})
+
+    def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
+        """Remove the user created for this relation."""
+        if not self.state.peer_relation or not self._ready_for_removal():
+            logger.debug(
+                "Deferring on_relation_broken: Cluster must be initialized and primary "
+                "available before user can be deleted"
+            )
+            event.defer()
+            return
+
+        postgresql = self.charm.postgresql
+        self.manager.update_unit_status(postgresql, event.relation)
+
+        if self.state.peer.is_unit_departing:
+            logger.debug("Early exit on_relation_broken: Skipping departing unit")
+            return
+
+        if not self.state.peer.is_app_leader:
+            user = self.manager.get_username_mapping().get(
+                str(event.relation.id), self.manager.relation_username(event.relation.id)
+            )
+            if user in postgresql.list_users():
+                logger.debug("Deferring on_relation_broken: user was not deleted yet")
+                event.defer()
+            else:
+                self.charm.update_config()
+            return
+
+        self.manager.delete_relation_user(postgresql, event.relation.id)
+        self.charm.update_config()

--- a/single_kernel_postgresql/managers/config.py
+++ b/single_kernel_postgresql/managers/config.py
@@ -40,6 +40,7 @@ from single_kernel_postgresql.workload.base import BaseWorkload, ResourceProvide
 
 if TYPE_CHECKING:
     # Import-time only: the VM workload pulls the snap charm lib, which K8s does not ship.
+    from single_kernel_postgresql.managers.database import DatabaseManager
     from single_kernel_postgresql.workload.vm import VMWorkload
 
 logger = logging.getLogger(__name__)
@@ -57,21 +58,21 @@ class ConfigManager(BaseManager):
         workload: BaseWorkload,
         tls_manager: TLSManager,
         patroni_manager: PatroniManager,
+        database_manager: "DatabaseManager",
         resource_provider: Callable[[], ResourceProvider],
         request_restart: Callable[[], None],
-        refresh_endpoints: Callable[[], None],
         restart_services: Callable[[], None],
     ):
         super().__init__(state, workload, "config_manager")
         self.tls_manager = tls_manager
         self.patroni_manager = patroni_manager
+        self.database_manager = database_manager
         # Resolved on use, not at construction: the K8s manager that provides it is built
         # after this manager in the charm's __init__.
         self.resource_provider = resource_provider
-        # Charm-side bridges: the substrate-tangled restart trigger, endpoint refresh and
-        # monitoring/ldap service restarts stay in the charm until their own migration phases.
+        # Charm-side bridges: the substrate-tangled restart trigger and the monitoring/ldap
+        # service restarts stay in the charm until their own migration phases.
         self.request_restart = request_restart
-        self.refresh_endpoints = refresh_endpoints
         self.restart_services = restart_services
 
     @staticmethod
@@ -436,7 +437,7 @@ class ConfigManager(BaseManager):
                 pass
 
         self.state.peer.tls = self.is_tls_enabled
-        self.refresh_endpoints()
+        self.database_manager.update_endpoints()
 
         # Restart PostgreSQL if TLS configuration has changed
         # (so the both old and new connections use the configuration).
@@ -447,7 +448,6 @@ class ConfigManager(BaseManager):
     def update_config(
         self,
         postgresql_client: PostgreSQLClient,
-        user_hash: str,
         is_creating_backup: bool = False,
         # TODO add rel handler
         relations_user_databases_map: dict[str, Any] | None = None,
@@ -518,7 +518,7 @@ class ConfigManager(BaseManager):
             # in a bundle together with the TLS certificates operator. This flag is used to
             # know when to call the Patroni API using HTTP or HTTPS.
             self.state.peer.tls = self.is_tls_enabled
-            self.refresh_endpoints()
+            self.database_manager.update_endpoints()
             logger.debug("Early exit update_config: Workload not started yet")
             return True
 
@@ -567,6 +567,7 @@ class ConfigManager(BaseManager):
 
         self.restart_services()
 
+        user_hash = self.database_manager.user_hash
         self.state.peer.user_hash = user_hash
         self.state.peer.config_hash = self.generate_config_hash
         if self.state.peer.is_app_leader:

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -27,7 +27,7 @@ def config(substrate):
             patroni_manager=Mock(),
             resource_provider=Mock(),
             request_restart=Mock(),
-            refresh_endpoints=Mock(),
+            database_manager=Mock(),
             restart_services=Mock(),
         )
     yield config
@@ -632,7 +632,7 @@ def test_handle_restart_need_persists_tls_flag_and_refreshes_endpoints(
     postgresql_client.is_tls_enabled.return_value = True
     restart_engine.handle_restart_need(postgresql_client, config_changed=False)
     restart_engine._peer_tls.assert_called_once_with(True)
-    restart_engine.refresh_endpoints.assert_called_once_with()
+    restart_engine.database_manager.update_endpoints.assert_called_once_with()
 
 
 def test_handle_restart_need_swallows_reload_patroni_error(restart_engine, postgresql_client):
@@ -768,6 +768,7 @@ def orchestrate(config, postgresql_client):
         # patroni_manager is a Mock; member_started / ensure_slots are plain attributes here.
         config.patroni_manager.member_started = True
         config.patroni_manager.ensure_slots_controller_by_patroni.return_value = True
+        config.database_manager.user_hash = "uh"
         config._is_tls = _is_tls
         config._hash = _hash
         config._peer_tls = _peer_tls
@@ -778,21 +779,21 @@ def orchestrate(config, postgresql_client):
 
 
 def test_update_config_no_peers_returns_true_early(orchestrate, postgresql_client):
-    assert orchestrate.update_config(postgresql_client, user_hash="uh", no_peers=True) is True
+    assert orchestrate.update_config(postgresql_client, no_peers=True) is True
     orchestrate.render_patroni_yml_file.assert_called_once()
-    orchestrate.refresh_endpoints.assert_not_called()
+    orchestrate.database_manager.update_endpoints.assert_not_called()
     orchestrate.handle_restart_need.assert_not_called()
 
 
 def test_update_config_threads_tls_flag_into_render(orchestrate, postgresql_client):
     """is_tls_enabled is what update_config passes as render_patroni_yml_file's enable_tls."""
     orchestrate._is_tls.return_value = True
-    orchestrate.update_config(postgresql_client, user_hash="uh", no_peers=True)
+    orchestrate.update_config(postgresql_client, no_peers=True)
     assert orchestrate.render_patroni_yml_file.call_args.kwargs["enable_tls"] is True
 
     orchestrate.render_patroni_yml_file.reset_mock()
     orchestrate._is_tls.return_value = False
-    orchestrate.update_config(postgresql_client, user_hash="uh", no_peers=True)
+    orchestrate.update_config(postgresql_client, no_peers=True)
     assert orchestrate.render_patroni_yml_file.call_args.kwargs["enable_tls"] is False
 
 
@@ -801,9 +802,9 @@ def test_update_config_workload_not_running_persists_tls_and_refreshes(
 ):
     orchestrate._is_tls.return_value = True
     with patch.object(orchestrate.workload, "is_patroni_running", return_value=False):
-        assert orchestrate.update_config(postgresql_client, user_hash="uh") is True
+        assert orchestrate.update_config(postgresql_client) is True
     orchestrate._peer_tls.assert_called_once_with(True)
-    orchestrate.refresh_endpoints.assert_called_once_with()
+    orchestrate.database_manager.update_endpoints.assert_called_once_with()
     orchestrate.handle_restart_need.assert_not_called()
 
 
@@ -812,14 +813,14 @@ def test_update_config_member_not_started_with_tls_forces_handle_restart_true(
 ):
     orchestrate._is_tls.return_value = True
     orchestrate.patroni_manager.member_started = False
-    assert orchestrate.update_config(postgresql_client, user_hash="uh") is True
+    assert orchestrate.update_config(postgresql_client) is True
     orchestrate.handle_restart_need.assert_called_once_with(postgresql_client, True)
 
 
 def test_update_config_member_not_started_no_tls_returns_false(orchestrate, postgresql_client):
     orchestrate._is_tls.return_value = False
     orchestrate.patroni_manager.member_started = False
-    assert orchestrate.update_config(postgresql_client, user_hash="uh") is False
+    assert orchestrate.update_config(postgresql_client) is False
     orchestrate.handle_restart_need.assert_not_called()
 
 
@@ -828,7 +829,7 @@ def test_update_config_cannot_connect_returns_false(substrate, orchestrate, post
     if substrate != Substrates.VM:
         pytest.skip("standalone connect gate is VM-only")
     with patch.object(orchestrate, "_can_connect_to_postgresql", return_value=False):
-        assert orchestrate.update_config(postgresql_client, user_hash="uh") is False
+        assert orchestrate.update_config(postgresql_client) is False
     orchestrate.apply_api_config.assert_not_called()
 
 
@@ -843,13 +844,13 @@ def test_update_config_k8s_proceeds_without_standalone_connect_gate(
     if substrate != Substrates.K8S:
         pytest.skip("this asserts the K8s-only no-gate behavior")
     with patch.object(orchestrate, "_can_connect_to_postgresql", return_value=False):
-        assert orchestrate.update_config(postgresql_client, user_hash="uh") is True
+        assert orchestrate.update_config(postgresql_client) is True
     orchestrate.apply_api_config.assert_called_once()
 
 
 def test_update_config_api_apply_fails_returns_false(orchestrate, postgresql_client):
     with patch.object(orchestrate, "apply_api_config", return_value=False):
-        assert orchestrate.update_config(postgresql_client, user_hash="uh") is False
+        assert orchestrate.update_config(postgresql_client) is False
     orchestrate.handle_restart_need.assert_not_called()
 
 
@@ -861,7 +862,7 @@ def test_update_config_happy_path_persists_hashes_and_calls_bridges(
         new_callable=PropertyMock,
         return_value=True,
     ):
-        assert orchestrate.update_config(postgresql_client, user_hash="uh") is True
+        assert orchestrate.update_config(postgresql_client) is True
     # config_hash change (old "oldhash" != new "newhash") drives handle_restart_need(True).
     orchestrate.handle_restart_need.assert_called_once_with(postgresql_client, True)
     orchestrate.restart_services.assert_called_once_with()
@@ -876,7 +877,7 @@ def test_update_config_ensure_slots_is_k8s_only(substrate, orchestrate, postgres
         new_callable=PropertyMock,
         return_value=False,
     ):
-        orchestrate.update_config(postgresql_client, user_hash="uh")
+        orchestrate.update_config(postgresql_client)
     if substrate == Substrates.K8S:
         orchestrate.patroni_manager.ensure_slots_controller_by_patroni.assert_called_once()
     else:
@@ -894,9 +895,7 @@ def test_update_config_vm_snap_gate_exits_before_restart_services(
     from unittest.mock import call
 
     with patch.object(orchestrate.workload, "get_snap_revision", return_value="123"):
-        assert (
-            orchestrate.update_config(postgresql_client, user_hash="uh", refresh=refresh) is True
-        )
+        assert orchestrate.update_config(postgresql_client, refresh=refresh) is True
     orchestrate.handle_restart_need.assert_called_once()
     orchestrate.restart_services.assert_not_called()
     # config_hash is read (getter, call()) for the restart decision but never PERSISTED


### PR DESCRIPTION
## Issue

The manager from PRs 1–3 has no observers, and `ConfigManager` still reaches back into the charm to refresh endpoints and is still handed a user hash the charm derives from provider state.

## Solution

Adds `events/database.py`, which owns `DatabaseProvides`, observes `database-requested`, `relation-departed` and `relation-broken`, and constructor-injects the interface into `DatabaseManager` — the same shape as the TLS handler and its certificate requirers.

Each handler keeps its readiness guard and its work in one observer. `defer()` is per-observer, so splitting a guard from the action it protects lets a deferred action retry alone against state its guard never re-checked. That is the same failure mode as the TLS reload race in canonical/postgresql-k8s-operator#1618.

The two substrates' guards differ and both are kept. A request waits on the cluster being initialised plus, on VM, a started member and a reachable primary; on K8s, `primary_endpoint_ready`. A removal waits on the same predicate on VM, but on K8s settles for a started member. The K8s handler also wrote the primary Service endpoint, URI and TLS fields inline before `update_endpoints` ran; that write is preserved so databag write ordering is unchanged, though it may be redundant (need to validate in https://warthogs.atlassian.net/browse/DPE-10890) — the provider library emits `database_requested` on the leader only, and `update_endpoints` publishes the same values immediately after. Each substrate also keeps its own defer log wording.

One smaller divergence is deliberate: the endpoint refresh after a request narrows to the requesting relation on VM, while K8s keeps its whole-relation refresh — each exactly as its charm had it.

One parity gap is fixed up-stack rather than here: the `requested_entity_secret_content` read needs the `ModelError` guard the charms wrapped their whole `_get_credentials` in, because the vendored property raises while a cross-model grant is still pending.

Seam changes:

- `ConfigManager` takes the `DatabaseManager` and calls `update_endpoints()` itself. The `refresh_endpoints` charm bridge is deleted.
- `update_config`'s `user_hash` parameter is gone; the manager derives it from the same relation data the user-databases map comes from. `relations_user_databases_map` stays injected — its computation lives in `charm.py` and diverges between substrates, so it belongs to the core event-loop phase.
- `AbstractPostgreSQLCharm` gains `set_unit_status`, `update_config` and `primary_endpoint`. The first routes status writes through the `charm_refresh` priority gate and stays until the refresh logic itself migrates into the library; the other two are reclaimed by later phases.

Follow-up lib PRs:
* https://github.com/canonical/postgresql-single-kernel-library/pull/220
* https://github.com/canonical/postgresql-single-kernel-library/pull/221
* https://github.com/canonical/postgresql-single-kernel-library/pull/222

Wiring up at:
* https://github.com/canonical/postgresql-k8s-operator/pull/1696
* https://github.com/canonical/postgresql-operator/pull/1900

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
