### PR TITLE
[DPE-10885] test(database): cover the client-relation events handler (7/7)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "postgresql-charms-single-kernel"
 description = "Shared and reusable code for PostgreSQL-related charms"
-version = "16.3.5"
+version = "16.3.6"
 readme = "README.md"
 license = {file = "LICENSE"}
 authors = [

--- a/single_kernel_postgresql/events/database.py
+++ b/single_kernel_postgresql/events/database.py
@@ -5,7 +5,7 @@
 
 import logging
 
-from ops import BlockedStatus, Object, RelationBrokenEvent, RelationDepartedEvent
+from ops import BlockedStatus, ModelError, Object, RelationBrokenEvent, RelationDepartedEvent
 
 from single_kernel_postgresql.config.enums import Substrates
 from single_kernel_postgresql.config.literals import DATABASE, DATABASE_PORT
@@ -14,7 +14,11 @@ from single_kernel_postgresql.lib.charms.data_platform_libs.v0.data_interfaces i
     DatabaseProvides,
     DatabaseRequestedEvent,
 )
-from single_kernel_postgresql.managers.database import DatabaseManager, DatabaseRequest
+from single_kernel_postgresql.managers.database import (
+    NO_ACCESS_TO_SECRET_MSG,
+    DatabaseManager,
+    DatabaseRequest,
+)
 from single_kernel_postgresql.managers.patroni import PatroniManager
 from single_kernel_postgresql.managers.tls import TLSManager
 from single_kernel_postgresql.utils.postgresql import (
@@ -110,12 +114,20 @@ class DatabaseEventsHandler(Object):
             event.defer()
             return
 
+        # The vendored property resolves the secret on access: until the grant lands it
+        # raises ModelError, which the manager's own guard can no longer see.
+        try:
+            requested_entity_secret_content = event.requested_entity_secret_content
+        except ModelError:
+            self.charm.set_unit_status(BlockedStatus(NO_ACCESS_TO_SECRET_MSG))
+            return
+
         request = DatabaseRequest(
             relation_id=event.relation.id,
             database=event.database or "",
             extra_user_roles=event.extra_user_roles,
             prefix_matching=event.prefix_matching,
-            requested_entity_secret_content=event.requested_entity_secret_content,
+            requested_entity_secret_content=requested_entity_secret_content,
         )
         postgresql = self.charm.postgresql
 

--- a/single_kernel_postgresql/managers/database.py
+++ b/single_kernel_postgresql/managers/database.py
@@ -300,16 +300,12 @@ class DatabaseManager(BaseManager):
         self, postgresql_client: PostgreSQLClient, request: DatabaseRequest
     ) -> tuple[str, str] | None:
         """Resolve the user and password for a request, or block and return None."""
-        try:
-            if requested_entities := request["requested_entity_secret_content"]:
-                for key, val in requested_entities.items():
-                    if key in SYSTEM_USERS or key in postgresql_client.list_users():
-                        self.set_unit_status(BlockedStatus(FORBIDDEN_USER_MSG))
-                        return None
-                    return key, val or new_password()
-        except ModelError:
-            self.set_unit_status(BlockedStatus(NO_ACCESS_TO_SECRET_MSG))
-            return None
+        if requested_entities := request["requested_entity_secret_content"]:
+            for key, val in requested_entities.items():
+                if key in SYSTEM_USERS or key in postgresql_client.list_users():
+                    self.set_unit_status(BlockedStatus(FORBIDDEN_USER_MSG))
+                    return None
+                return key, val or new_password()
         return self.relation_username(request["relation_id"]), new_password()
 
     def collect_databases(

--- a/tests/unit/test_database_events.py
+++ b/tests/unit/test_database_events.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 """Unit tests for the client-relation events handler."""
 
+import logging
 from contextlib import contextmanager
 from unittest.mock import Mock, PropertyMock, patch
 
@@ -101,7 +102,7 @@ def request_database(harness, database=DATABASE):
     return rel_id
 
 
-def test_database_requested_creates_the_user_and_database(harness, events, postgresql):
+def test_database_requested_creates_the_user_and_database(substrate, harness, events, postgresql):
     with cluster_ready(harness, postgresql) as update_endpoints:
         rel_id = request_database(harness)
 
@@ -113,7 +114,11 @@ def test_database_requested_creates_the_user_and_database(harness, events, postg
         extra_user_roles=["createdb", "createrole", ACCESS_GROUP_RELATION],
         database=DATABASE,
     )
-    update_endpoints.assert_called_once_with(rel_id)
+    if substrate == "k8s":
+        # K8s refreshed every relation from the request handler; VM scoped to the requester.
+        update_endpoints.assert_called_once_with()
+    else:
+        update_endpoints.assert_called_once_with(rel_id)
 
     data = harness.get_relation_data(rel_id, harness.charm.app.name)
     assert data["username"] == user
@@ -132,6 +137,119 @@ def test_database_requested_defers_until_the_cluster_is_ready(harness, events, p
 
     _defer.assert_called_once()
     postgresql.create_database.assert_not_called()
+
+
+def test_the_request_defer_message_is_substrate_specific(
+    substrate, harness, events, postgresql, caplog
+):
+    caplog.set_level(logging.DEBUG, logger="single_kernel_postgresql.events.database")
+    with (
+        cluster_ready(harness, postgresql, ready=False),
+        patch("ops.framework.EventBase.defer"),
+    ):
+        request_database(harness)
+
+    if substrate == "k8s":
+        assert "Cluster must be initialized before database can be requested" in caplog.text
+    else:
+        assert (
+            "cluster not initialized, Patroni not started or primary endpoint not available"
+            in caplog.text
+        )
+
+
+def test_the_request_guard_reads_substrate_specific_inputs(substrate, harness, events):
+    """K8s waits only on the primary endpoint; VM also requires a started member."""
+    with (
+        patch.object(
+            type(harness.charm),
+            "primary_endpoint",
+            new_callable=PropertyMock,
+            return_value="1.1.1.1",
+        ),
+        patch(
+            "single_kernel_postgresql.managers.patroni.PatroniManager.member_started",
+            new_callable=PropertyMock,
+            return_value=False,
+        ),
+        patch(
+            "single_kernel_postgresql.managers.patroni.PatroniManager.primary_endpoint_ready",
+            new_callable=PropertyMock,
+            return_value=True,
+        ),
+    ):
+        assert events._ready_for_request() is (substrate == "k8s")
+
+
+def test_the_guards_defer_while_the_cluster_is_not_initialised(substrate, harness, events):
+    peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            peer_rel_id, harness.charm.app.name, {"cluster_initialised": ""}
+        )
+    with (
+        patch.object(
+            type(harness.charm),
+            "primary_endpoint",
+            new_callable=PropertyMock,
+            return_value="1.1.1.1",
+        ),
+        patch(
+            "single_kernel_postgresql.managers.patroni.PatroniManager.member_started",
+            new_callable=PropertyMock,
+            return_value=True,
+        ),
+        patch(
+            "single_kernel_postgresql.managers.patroni.PatroniManager.primary_endpoint_ready",
+            new_callable=PropertyMock,
+            return_value=True,
+        ),
+    ):
+        assert events._ready_for_request() is False
+        assert events._ready_for_removal() is False
+
+
+def test_database_requested_blocks_before_creating_when_the_username_is_taken(
+    harness, events, postgresql
+):
+    postgresql.list_users.return_value = {"taken"}
+    with (
+        cluster_ready(harness, postgresql),
+        patch.object(
+            DatabaseRequestedEvent,
+            "requested_entity_secret_content",
+            new_callable=PropertyMock,
+            return_value={"taken": "pw"},
+        ),
+    ):
+        rel_id = request_database(harness)
+
+    assert harness.model.unit.status == BlockedStatus("Requesting an existing username")
+    postgresql.create_database.assert_not_called()
+    assert "username" not in harness.get_relation_data(rel_id, harness.charm.app.name)
+
+
+def test_database_requested_blocks_before_creating_when_the_prefix_is_too_short(
+    harness, events, postgresql
+):
+    with cluster_ready(harness, postgresql):
+        rel_id = request_database(harness, database="a*")
+
+    assert harness.model.unit.status == BlockedStatus("Prefix too short")
+    postgresql.create_database.assert_not_called()
+    assert "username" not in harness.get_relation_data(rel_id, harness.charm.app.name)
+
+
+def test_database_requested_publishes_nothing_when_creation_fails(harness, events, postgresql):
+    postgresql.create_database.side_effect = PostgreSQLCreateDatabaseError("bad name")
+    with cluster_ready(harness, postgresql):
+        rel_id = request_database(harness)
+
+    data = harness.get_relation_data(rel_id, harness.charm.app.name)
+    assert "username" not in data
+    assert "uris" not in data
+    assert "version" not in data
+    assert "database" not in data
 
 
 def test_database_requested_defers_until_peers_have_synced(harness, events, postgresql):
@@ -195,6 +313,26 @@ def test_database_requested_blocks_when_the_requested_entity_secret_is_not_reada
     postgresql.create_database.assert_not_called()
 
 
+def test_the_unreadable_secret_block_routes_through_the_status_bridge(harness, events, postgresql):
+    """The missing-grant block goes through the charm's set_unit_status on both substrates."""
+    with (
+        cluster_ready(harness, postgresql),
+        patch.object(type(harness.charm), "set_unit_status", Mock()) as _gated,
+        patch.object(
+            DatabaseRequestedEvent,
+            "requested_entity_secret_content",
+            new_callable=PropertyMock,
+        ) as _content,
+    ):
+        _content.side_effect = ModelError()
+        request_database(harness)
+
+    _gated.assert_called_once()
+    assert _gated.call_args.args[0] == BlockedStatus("Missing grant to requested entity secret")
+    assert not isinstance(harness.model.unit.status, BlockedStatus)
+    postgresql.create_database.assert_not_called()
+
+
 def test_database_requested_is_a_noop_for_a_follower(harness, events, postgresql):
     """The provider library already filters non-leaders; the handler guard is belt-and-braces."""
     with harness.hooks_disabled():
@@ -228,6 +366,50 @@ def test_database_requested_publishes_k8s_service_endpoints_inline(
         assert "endpoints" not in data
 
 
+def test_the_k8s_inline_publish_sets_the_tls_fields_when_tls_is_enabled(
+    substrate, harness, events, postgresql
+):
+    if substrate != "k8s":
+        pytest.skip("Only K8s wrote the TLS fields inside the request handler")
+    with (
+        cluster_ready(harness, postgresql),
+        patch.object(
+            type(events.manager.tls_manager),
+            "get_client_tls_files",
+            return_value=("key", "CA", "cert"),
+        ),
+    ):
+        rel_id = request_database(harness)
+
+    data = harness.get_relation_data(rel_id, harness.charm.app.name)
+    assert data["tls"] == "True"
+    assert data["tls-ca"] == "CA"
+
+
+def test_the_relation_departed_observer_flags_the_departing_unit(harness, events):
+    """Emitted through the framework, so the observer registration is itself exercised."""
+    peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+    relation = harness.model.get_relation(RELATION_NAME)
+
+    harness.charm.on[RELATION_NAME].relation_departed.emit(
+        relation, departing_unit_name=harness.charm.unit.name
+    )
+
+    assert "departing" in harness.get_relation_data(peer_rel_id, harness.charm.unit)
+
+
+def test_the_relation_broken_observer_deletes_the_user(harness, events, postgresql):
+    """Emitted through the framework, so the observer registration is itself exercised."""
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+
+    with cluster_ready(harness, postgresql):
+        harness.charm.on[RELATION_NAME].relation_broken.emit(
+            harness.model.get_relation(RELATION_NAME)
+        )
+
+    postgresql.delete_user.assert_called_once_with(events.manager.relation_username(rel_id))
+
+
 def test_relation_departed_flags_only_this_unit(harness, events):
     peer_rel_id = harness.model.get_relation(PEER_RELATION).id
     event = Mock()
@@ -242,6 +424,25 @@ def test_relation_departed_flags_only_this_unit(harness, events):
     )
     events._on_relation_departed(event)
     assert "departing" not in harness.get_relation_data(peer_rel_id, harness.charm.unit)
+
+
+def test_the_broken_defer_message_is_substrate_specific(
+    substrate, harness, events, postgresql, caplog
+):
+    caplog.set_level(logging.DEBUG, logger="single_kernel_postgresql.events.database")
+    event = Mock()
+    event.relation = harness.model.get_relation(RELATION_NAME)
+
+    with cluster_ready(harness, postgresql, ready=False):
+        events._on_relation_broken(event)
+
+    if substrate == "k8s":
+        assert "Cluster must be initialized before user can be deleted" in caplog.text
+    else:
+        assert (
+            "Cluster must be initialized and primary available before user can be deleted"
+            in caplog.text
+        )
 
 
 def test_relation_broken_deletes_the_user(harness, events, postgresql):

--- a/tests/unit/test_database_events.py
+++ b/tests/unit/test_database_events.py
@@ -1,0 +1,311 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""Unit tests for the client-relation events handler."""
+
+from contextlib import contextmanager
+from unittest.mock import Mock, PropertyMock, patch
+
+import pytest
+from ops import ActiveStatus, BlockedStatus, Unit
+from single_kernel_postgresql.config.literals import PEER_RELATION
+from single_kernel_postgresql.utils.postgresql import (
+    ACCESS_GROUP_RELATION,
+    PostgreSQLCreateDatabaseError,
+    PostgreSQLCreateUserError,
+    PostgreSQLGetPostgreSQLVersionError,
+)
+
+RELATION_NAME = "database"
+DATABASE = "test_database"
+EXTRA_USER_ROLES = "CREATEDB,CREATEROLE"
+POSTGRESQL_VERSION = "16"
+USER_HASH = "relhash"
+
+
+@pytest.fixture
+def events(harness):
+    """A begun leader charm with the cluster initialised and a client relation."""
+    with harness.hooks_disabled():
+        harness.set_leader(True)
+        peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+        harness.update_relation_data(
+            peer_rel_id, harness.charm.app.name, {"cluster_initialised": "True"}
+        )
+        harness.update_relation_data(
+            peer_rel_id, "postgresql-single-kernel/0", {"user_hash": USER_HASH}
+        )
+    harness.add_relation(RELATION_NAME, "application")
+    return harness.charm.database
+
+
+@pytest.fixture
+def postgresql():
+    client = Mock()
+    client.get_postgresql_version.return_value = POSTGRESQL_VERSION
+    client.list_users.return_value = set()
+    client.list_valid_privileges_and_roles.return_value = (set(), set())
+    return client
+
+
+@contextmanager
+def cluster_ready(harness, postgresql, ready=True):
+    """Patch every readiness input the two substrates' guards consult."""
+    with (
+        patch.object(type(harness.charm), "postgresql", PropertyMock(return_value=postgresql)),
+        patch.object(type(harness.charm), "update_config", Mock(return_value=True)),
+        patch.object(
+            type(harness.charm),
+            "primary_endpoint",
+            new_callable=PropertyMock,
+            return_value="1.1.1.1" if ready else None,
+        ),
+        patch(
+            "single_kernel_postgresql.managers.patroni.PatroniManager.member_started",
+            new_callable=PropertyMock,
+            return_value=ready,
+        ),
+        patch(
+            "single_kernel_postgresql.managers.patroni.PatroniManager.primary_endpoint_ready",
+            new_callable=PropertyMock,
+            return_value=ready,
+        ),
+        patch(
+            "single_kernel_postgresql.managers.database.DatabaseManager.get_plugins",
+            return_value=["pgaudit"],
+        ),
+        patch(
+            "single_kernel_postgresql.managers.database.DatabaseManager.update_endpoints"
+        ) as update_endpoints,
+        patch(
+            "single_kernel_postgresql.managers.database.new_password",
+            return_value="test-password",
+        ),
+        patch(
+            "single_kernel_postgresql.managers.database.DatabaseManager.user_hash",
+            new_callable=PropertyMock,
+            return_value=USER_HASH,
+        ),
+    ):
+        yield update_endpoints
+
+
+def request_database(harness, database=DATABASE):
+    """Drive a real database_requested through the provider library."""
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    harness.update_relation_data(
+        rel_id, "application", {"database": database, "extra-user-roles": EXTRA_USER_ROLES}
+    )
+    return rel_id
+
+
+def test_database_requested_creates_the_user_and_database(harness, events, postgresql):
+    with cluster_ready(harness, postgresql) as update_endpoints:
+        rel_id = request_database(harness)
+
+    user = events.manager.relation_username(rel_id)
+    postgresql.create_database.assert_called_once_with(DATABASE, plugins=["pgaudit"])
+    postgresql.create_user.assert_called_once_with(
+        user,
+        "test-password",
+        extra_user_roles=["createdb", "createrole", ACCESS_GROUP_RELATION],
+        database=DATABASE,
+    )
+    update_endpoints.assert_called_once_with(rel_id)
+
+    data = harness.get_relation_data(rel_id, harness.charm.app.name)
+    assert data["username"] == user
+    assert data["password"] == "test-password"
+    assert data["version"] == POSTGRESQL_VERSION
+    assert data["database"] == DATABASE
+    assert not isinstance(harness.model.unit.status, BlockedStatus)
+
+
+def test_database_requested_defers_until_the_cluster_is_ready(harness, events, postgresql):
+    with (
+        cluster_ready(harness, postgresql, ready=False),
+        patch("ops.framework.EventBase.defer") as _defer,
+    ):
+        request_database(harness)
+
+    _defer.assert_called_once()
+    postgresql.create_database.assert_not_called()
+
+
+def test_database_requested_defers_until_peers_have_synced(harness, events, postgresql):
+    peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+    with harness.hooks_disabled():
+        harness.add_relation_unit(peer_rel_id, "postgresql-single-kernel/1")
+        harness.update_relation_data(
+            peer_rel_id, "postgresql-single-kernel/1", {"user_hash": "stale"}
+        )
+
+    with (
+        cluster_ready(harness, postgresql),
+        patch("ops.framework.EventBase.defer") as _defer,
+    ):
+        request_database(harness)
+
+    _defer.assert_called_once()
+    postgresql.create_database.assert_not_called()
+
+
+def test_database_requested_blocks_with_the_error_message(harness, events, postgresql):
+    postgresql.create_database.side_effect = PostgreSQLCreateDatabaseError("bad name")
+    with cluster_ready(harness, postgresql):
+        request_database(harness)
+
+    assert harness.model.unit.status == BlockedStatus("bad name")
+
+
+def test_database_requested_blocks_generically_without_a_message(harness, events, postgresql):
+    postgresql.create_user.side_effect = PostgreSQLCreateUserError()
+    with cluster_ready(harness, postgresql):
+        request_database(harness)
+
+    assert harness.model.unit.status == BlockedStatus("Failed to initialize database relation")
+
+
+def test_database_requested_blocks_on_a_version_error(harness, events, postgresql):
+    postgresql.get_postgresql_version.side_effect = PostgreSQLGetPostgreSQLVersionError()
+    with cluster_ready(harness, postgresql):
+        request_database(harness)
+
+    assert isinstance(harness.model.unit.status, BlockedStatus)
+
+
+def test_database_requested_publishes_k8s_service_endpoints_inline(
+    substrate, harness, events, postgresql
+):
+    """K8s wrote the primary Service endpoint inside the request handler; VM did not."""
+    with cluster_ready(harness, postgresql):
+        rel_id = request_database(harness)
+
+    data = harness.get_relation_data(rel_id, harness.charm.app.name)
+    if substrate == "k8s":
+        app = harness.charm.app.name
+        assert data["endpoints"] == f"{app}-primary.test-model.svc.cluster.local:5432"
+        assert data["uris"].endswith(
+            f"@{app}-primary.test-model.svc.cluster.local:5432/{DATABASE}"
+        )
+    else:
+        assert "endpoints" not in data
+
+
+def test_relation_departed_flags_only_this_unit(harness, events):
+    peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+    event = Mock()
+    event.departing_unit = harness.charm.unit
+    events._on_relation_departed(event)
+    assert "departing" in harness.get_relation_data(peer_rel_id, harness.charm.unit)
+
+    with harness.hooks_disabled():
+        harness.update_relation_data(peer_rel_id, harness.charm.unit.name, {"departing": ""})
+    event.departing_unit = Unit(
+        f"{harness.charm.app.name}/1", None, harness.charm.app._backend, {}
+    )
+    events._on_relation_departed(event)
+    assert "departing" not in harness.get_relation_data(peer_rel_id, harness.charm.unit)
+
+
+def test_relation_broken_deletes_the_user(harness, events, postgresql):
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    event = Mock()
+    event.relation = harness.model.get_relation(RELATION_NAME)
+
+    with cluster_ready(harness, postgresql):
+        events._on_relation_broken(event)
+
+    postgresql.delete_user.assert_called_once_with(events.manager.relation_username(rel_id))
+
+
+def test_relation_broken_skips_a_departing_unit(harness, events, postgresql):
+    peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+    with harness.hooks_disabled():
+        harness.update_relation_data(peer_rel_id, harness.charm.unit.name, {"departing": "True"})
+    event = Mock()
+    event.relation = harness.model.get_relation(RELATION_NAME)
+
+    with cluster_ready(harness, postgresql):
+        events._on_relation_broken(event)
+
+    postgresql.delete_user.assert_not_called()
+
+
+def test_relation_broken_defers_until_the_cluster_is_ready(harness, events, postgresql):
+    event = Mock()
+    event.relation = harness.model.get_relation(RELATION_NAME)
+
+    with cluster_ready(harness, postgresql, ready=False):
+        events._on_relation_broken(event)
+
+    event.defer.assert_called_once()
+    postgresql.delete_user.assert_not_called()
+
+
+def test_relation_broken_on_a_follower_defers_while_the_user_exists(harness, events, postgresql):
+    with harness.hooks_disabled():
+        harness.set_leader(False)
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    postgresql.list_users.return_value = {events.manager.relation_username(rel_id)}
+    event = Mock()
+    event.relation = harness.model.get_relation(RELATION_NAME)
+
+    with cluster_ready(harness, postgresql):
+        events._on_relation_broken(event)
+
+    event.defer.assert_called_once()
+    postgresql.delete_user.assert_not_called()
+
+
+def test_relation_broken_on_a_follower_updates_config_once_the_user_is_gone(
+    harness, events, postgresql
+):
+    with harness.hooks_disabled():
+        harness.set_leader(False)
+    event = Mock()
+    event.relation = harness.model.get_relation(RELATION_NAME)
+
+    with (
+        cluster_ready(harness, postgresql),
+        patch.object(type(harness.charm), "update_config") as _update_config,
+    ):
+        events._on_relation_broken(event)
+
+    event.defer.assert_not_called()
+    _update_config.assert_called_once()
+    postgresql.delete_user.assert_not_called()
+
+
+def test_k8s_removal_guard_does_not_wait_on_the_primary_endpoint(
+    substrate, harness, events, postgresql
+):
+    """K8s' relation_broken settles for a started member; VM also needs a primary."""
+    with (
+        patch.object(type(harness.charm), "postgresql", PropertyMock(return_value=postgresql)),
+        patch.object(type(harness.charm), "update_config", Mock(return_value=True)),
+        patch.object(
+            type(harness.charm), "primary_endpoint", new_callable=PropertyMock, return_value=None
+        ),
+        patch(
+            "single_kernel_postgresql.managers.patroni.PatroniManager.member_started",
+            new_callable=PropertyMock,
+            return_value=True,
+        ),
+        patch("single_kernel_postgresql.managers.database.DatabaseManager.update_endpoints"),
+    ):
+        assert events._ready_for_removal() is (substrate == "k8s")
+
+
+def test_update_unit_status_runs_before_the_departing_check(harness, events, postgresql):
+    """A stale blocking status clears even when the unit itself is going away."""
+    peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+    with harness.hooks_disabled():
+        harness.update_relation_data(peer_rel_id, harness.charm.unit.name, {"departing": "True"})
+    harness.model.unit.status = BlockedStatus("Failed to initialize database relation")
+    event = Mock()
+    event.relation = harness.model.get_relation(RELATION_NAME)
+
+    with cluster_ready(harness, postgresql):
+        events._on_relation_broken(event)
+
+    assert harness.model.unit.status == ActiveStatus()

--- a/tests/unit/test_database_events.py
+++ b/tests/unit/test_database_events.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
-from ops import ActiveStatus, BlockedStatus, ModelError, Unit
+from ops import ActiveStatus, BlockedStatus, ModelError
 from single_kernel_postgresql.config.literals import PEER_RELATION
 from single_kernel_postgresql.lib.charms.data_platform_libs.v0.data_interfaces import (
     DatabaseRequestedEvent,
@@ -419,9 +419,7 @@ def test_relation_departed_flags_only_this_unit(harness, events):
 
     with harness.hooks_disabled():
         harness.update_relation_data(peer_rel_id, harness.charm.unit.name, {"departing": ""})
-    event.departing_unit = Unit(
-        f"{harness.charm.app.name}/1", None, harness.charm.app._backend, {}
-    )
+    event.departing_unit = harness.model.get_unit(f"{harness.charm.app.name}/1")
     events._on_relation_departed(event)
     assert "departing" not in harness.get_relation_data(peer_rel_id, harness.charm.unit)
 

--- a/tests/unit/test_database_events.py
+++ b/tests/unit/test_database_events.py
@@ -6,8 +6,11 @@ from contextlib import contextmanager
 from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
-from ops import ActiveStatus, BlockedStatus, Unit
+from ops import ActiveStatus, BlockedStatus, ModelError, Unit
 from single_kernel_postgresql.config.literals import PEER_RELATION
+from single_kernel_postgresql.lib.charms.data_platform_libs.v0.data_interfaces import (
+    DatabaseRequestedEvent,
+)
 from single_kernel_postgresql.utils.postgresql import (
     ACCESS_GROUP_RELATION,
     PostgreSQLCreateDatabaseError,
@@ -171,6 +174,40 @@ def test_database_requested_blocks_on_a_version_error(harness, events, postgresq
         request_database(harness)
 
     assert isinstance(harness.model.unit.status, BlockedStatus)
+
+
+def test_database_requested_blocks_when_the_requested_entity_secret_is_not_readable(
+    harness, events, postgresql
+):
+    """An ungranted requested-entity secret blocks the unit instead of crashing the hook."""
+    with (
+        cluster_ready(harness, postgresql),
+        patch.object(
+            DatabaseRequestedEvent,
+            "requested_entity_secret_content",
+            new_callable=PropertyMock,
+        ) as _content,
+    ):
+        _content.side_effect = ModelError()
+        request_database(harness)
+
+    assert harness.model.unit.status == BlockedStatus("Missing grant to requested entity secret")
+    postgresql.create_database.assert_not_called()
+
+
+def test_database_requested_is_a_noop_for_a_follower(harness, events, postgresql):
+    """The provider library already filters non-leaders; the handler guard is belt-and-braces."""
+    with harness.hooks_disabled():
+        harness.set_leader(False)
+    event = Mock()
+    event.relation = harness.model.get_relation(RELATION_NAME)
+
+    with cluster_ready(harness, postgresql):
+        events._on_database_requested(event)
+
+    postgresql.create_database.assert_not_called()
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    assert "username" not in harness.get_relation_data(rel_id, harness.charm.app.name)
 
 
 def test_database_requested_publishes_k8s_service_endpoints_inline(

--- a/tests/unit/test_database_manager.py
+++ b/tests/unit/test_database_manager.py
@@ -206,18 +206,6 @@ def test_get_credentials_blocks_on_an_existing_username(manager, postgresql, har
     assert harness.model.unit.status == BlockedStatus("Requesting an existing username")
 
 
-def test_get_credentials_blocks_when_the_secret_is_not_readable(manager, postgresql, harness):
-    request = DatabaseRequest(
-        relation_id=4,
-        database="db",
-        extra_user_roles=None,
-        prefix_matching=None,
-        requested_entity_secret_content=Mock(items=Mock(side_effect=ModelError)),
-    )
-    assert manager.get_credentials(postgresql, request) is None
-    assert harness.model.unit.status == BlockedStatus("Missing grant to requested entity secret")
-
-
 def test_get_credentials_uses_the_requested_custom_username(manager, postgresql):
     postgresql.list_users.return_value = set()
     with patch("single_kernel_postgresql.managers.database.new_password", return_value="gen"):

--- a/tests/unit/test_database_manager.py
+++ b/tests/unit/test_database_manager.py
@@ -379,11 +379,96 @@ def test_update_endpoints_publishes_rw_ro_and_uris(substrate, manager, harness):
         harness.update_relation_data(
             peer_rel_id, "postgresql-single-kernel/1", {f"{RELATION_NAME}-address": "2.2.2.2"}
         )
+        other_rel_id = harness.add_relation(RELATION_NAME, "other-application")
+        harness.update_relation_data(other_rel_id, "other-application", {"database": "other_db"})
 
     with (
         patch(
             "single_kernel_postgresql.managers.patroni.PatroniManager.cluster_status",
             return_value=CLUSTER_STATUS[:2],
+        ),
+        patch(
+            "single_kernel_postgresql.managers.database.DatabaseManager.is_tls_enabled",
+            new_callable=PropertyMock,
+            return_value=False,
+        ),
+        patch.object(
+            manager.database_provides,
+            "fetch_my_relation_data",
+            return_value={
+                rel_id: {"username": "u", "password": "pw"},
+                other_rel_id: {"username": "other", "password": "other-pw"},
+            },
+        ),
+    ):
+        manager.update_endpoints(rel_id)
+
+    data = harness.get_relation_data(rel_id, harness.charm.app.name)
+    if substrate == "k8s":
+        app = harness.charm.app.name
+        assert data["endpoints"] == f"{app}-primary.test-model.svc.cluster.local:5432"
+        assert data["read-only-endpoints"] == f"{app}-replicas.test-model.svc.cluster.local:5432"
+        assert (
+            data["uris"] == f"postgresql://u:pw@{app}-primary.test-model.svc.cluster.local:5432/test_db"
+        )
+    else:
+        assert data["endpoints"] == "1.1.1.1:5432"
+        assert data["read-only-endpoints"] == "2.2.2.2:5432"
+        assert data["uris"] == "postgresql://u:pw@1.1.1.1:5432/test_db"
+    assert data["tls"] == "False"
+    # A relation-scoped update touches only that relation's databag.
+    assert harness.get_relation_data(other_rel_id, harness.charm.app.name) == {}
+
+
+def test_update_endpoints_skips_a_relation_without_credentials(manager, harness):
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+    with harness.hooks_disabled():
+        harness.update_relation_data(rel_id, "application", {"database": "test_db"})
+        harness.update_relation_data(
+            peer_rel_id, "postgresql-single-kernel/0", {f"{RELATION_NAME}-address": "1.1.1.1"}
+        )
+
+    with (
+        patch(
+            "single_kernel_postgresql.managers.patroni.PatroniManager.cluster_status",
+            return_value=CLUSTER_STATUS[:1],
+        ),
+        patch(
+            "single_kernel_postgresql.managers.database.DatabaseManager.is_tls_enabled",
+            new_callable=PropertyMock,
+            return_value=False,
+        ),
+        patch.object(
+            manager.database_provides,
+            "fetch_my_relation_data",
+            return_value={},
+        ),
+    ):
+        manager.update_endpoints(rel_id)
+
+    assert harness.get_relation_data(rel_id, harness.charm.app.name) == {}
+
+
+def test_update_endpoints_clears_stale_uris_when_no_database_matches_the_prefix(
+    substrate, manager, harness
+):
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+    manager.set_databases_prefix_mapping(rel_id, "custom", "pre", [])
+    with harness.hooks_disabled():
+        harness.update_relation_data(rel_id, "application", {"database": "pre*"})
+        harness.update_relation_data(
+            peer_rel_id, "postgresql-single-kernel/0", {f"{RELATION_NAME}-address": "1.1.1.1"}
+        )
+        harness.update_relation_data(
+            rel_id, harness.charm.app.name, {"uris": "stale", "read-only-uris": "stale"}
+        )
+
+    with (
+        patch(
+            "single_kernel_postgresql.managers.patroni.PatroniManager.cluster_status",
+            return_value=CLUSTER_STATUS[:1],
         ),
         patch(
             "single_kernel_postgresql.managers.database.DatabaseManager.is_tls_enabled",
@@ -399,14 +484,13 @@ def test_update_endpoints_publishes_rw_ro_and_uris(substrate, manager, harness):
         manager.update_endpoints(rel_id)
 
     data = harness.get_relation_data(rel_id, harness.charm.app.name)
+    assert "uris" not in data
+    assert "read-only-uris" not in data
     if substrate == "k8s":
         app = harness.charm.app.name
         assert data["endpoints"] == f"{app}-primary.test-model.svc.cluster.local:5432"
-        assert data["read-only-endpoints"] == f"{app}-replicas.test-model.svc.cluster.local:5432"
     else:
         assert data["endpoints"] == "1.1.1.1:5432"
-        assert data["read-only-endpoints"] == "2.2.2.2:5432"
-    assert data["tls"] == "False"
 
 
 def test_update_endpoints_read_only_uri_carries_one_port(substrate, manager, harness):

--- a/tests/unit/test_database_manager.py
+++ b/tests/unit/test_database_manager.py
@@ -6,7 +6,7 @@ import json
 from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
-from ops import ActiveStatus, BlockedStatus
+from ops import ActiveStatus, BlockedStatus, ModelError
 from single_kernel_postgresql.config.enums import Substrates
 from single_kernel_postgresql.config.literals import (
     APP_SCOPE,
@@ -214,10 +214,32 @@ def test_get_credentials_blocks_when_the_secret_is_not_readable(manager, postgre
         database="db",
         extra_user_roles=None,
         prefix_matching=None,
-        requested_entity_secret_content=Mock(items=Mock(side_effect=__import__("ops").ModelError)),
+        requested_entity_secret_content=Mock(items=Mock(side_effect=ModelError)),
     )
     assert manager.get_credentials(postgresql, request) is None
     assert harness.model.unit.status == BlockedStatus("Missing grant to requested entity secret")
+
+
+def test_get_credentials_uses_the_requested_custom_username(manager, postgresql):
+    postgresql.list_users.return_value = set()
+    with patch("single_kernel_postgresql.managers.database.new_password", return_value="gen"):
+        granted = DatabaseRequest(
+            relation_id=4,
+            database="db",
+            extra_user_roles=None,
+            prefix_matching=None,
+            requested_entity_secret_content={"custom": "pw"},
+        )
+        assert manager.get_credentials(postgresql, granted) == ("custom", "pw")
+
+        ungranted = DatabaseRequest(
+            relation_id=4,
+            database="db",
+            extra_user_roles=None,
+            prefix_matching=None,
+            requested_entity_secret_content={"custom": None},
+        )
+        assert manager.get_credentials(postgresql, ungranted) == ("custom", "gen")
 
 
 def test_collect_databases_plain_database(manager, postgresql):
@@ -748,6 +770,69 @@ def test_update_unit_status_keeps_a_prefix_block_while_a_short_prefix_remains(
     manager.update_unit_status(postgresql, relation)
 
     assert harness.model.unit.status == BlockedStatus("Prefix too short")
+
+
+def test_unblock_custom_user_errors_clears_the_status(manager, postgresql, harness):
+    postgresql.list_valid_privileges_and_roles.return_value = (set(), set())
+    relation = harness.model.get_relation(RELATION_NAME)
+    harness.model.unit.status = BlockedStatus("Requesting an existing username")
+
+    manager.unblock_custom_user_errors(postgresql, relation)
+
+    assert harness.model.unit.status == ActiveStatus()
+
+
+def test_unblock_custom_user_errors_keeps_the_block_on_invalid_extra_user_roles(
+    manager, postgresql, harness
+):
+    postgresql.list_valid_privileges_and_roles.return_value = (set(), set())
+    relation = harness.model.get_relation(RELATION_NAME)
+    other_rel_id = harness.add_relation(RELATION_NAME, "other-application")
+    with harness.hooks_disabled():
+        # The relation the check skips is the one carrying the invalid roles.
+        harness.update_relation_data(other_rel_id, "other-application", {"extra-user-roles": "bogus"})
+
+    manager.unblock_custom_user_errors(postgresql, relation)
+
+    assert harness.model.unit.status == BlockedStatus("invalid role(s) for extra user roles")
+
+
+def test_unblock_custom_user_errors_keeps_the_block_on_a_forbidden_user(
+    manager, postgresql, harness
+):
+    postgresql.list_valid_privileges_and_roles.return_value = (set(), set())
+    postgresql.list_users.return_value = {"taken"}
+    relation = harness.model.get_relation(RELATION_NAME)
+    secret = Mock(get_content=Mock(return_value={"taken": "pw"}))
+
+    with (
+        patch.object(manager.database_provides, "fetch_my_relation_field", return_value=None),
+        patch.object(
+            manager.database_provides, "fetch_relation_field", return_value="secret-uri"
+        ),
+        patch.object(manager.state.model, "get_secret", return_value=secret),
+    ):
+        manager.unblock_custom_user_errors(postgresql, relation)
+
+    assert harness.model.unit.status == BlockedStatus("Requesting an existing username")
+
+
+def test_unblock_custom_user_errors_keeps_the_block_while_the_secret_is_unreadable(
+    manager, postgresql, harness
+):
+    postgresql.list_valid_privileges_and_roles.return_value = (set(), set())
+    relation = harness.model.get_relation(RELATION_NAME)
+
+    with (
+        patch.object(manager.database_provides, "fetch_my_relation_field", return_value=None),
+        patch.object(
+            manager.database_provides, "fetch_relation_field", return_value="secret-uri"
+        ),
+        patch.object(manager.state.model, "get_secret", side_effect=ModelError),
+    ):
+        manager.unblock_custom_user_errors(postgresql, relation)
+
+    assert harness.model.unit.status == BlockedStatus("Missing grant to requested entity secret")
 
 
 def test_is_tls_enabled_tracks_the_client_files(manager):

--- a/tests/unit/test_database_manager.py
+++ b/tests/unit/test_database_manager.py
@@ -7,7 +7,6 @@ from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
 from ops import ActiveStatus, BlockedStatus, ModelError
-from single_kernel_postgresql.config.enums import Substrates
 from single_kernel_postgresql.config.literals import (
     APP_SCOPE,
     DATABASE_MAPPING_LABEL,
@@ -193,7 +192,8 @@ def test_get_credentials_defaults_to_the_generated_user(manager, postgresql):
         )
 
 
-def test_get_credentials_blocks_on_an_existing_username(manager, postgresql, harness):
+def test_get_credentials_blocks_on_an_existing_username(manager, postgresql):
+    """The forbidden-user block routes through the charm's status bridge."""
     postgresql.list_users.return_value = {"taken"}
     request = DatabaseRequest(
         relation_id=4,
@@ -202,8 +202,9 @@ def test_get_credentials_blocks_on_an_existing_username(manager, postgresql, har
         prefix_matching=None,
         requested_entity_secret_content={"taken": "pw"},
     )
-    assert manager.get_credentials(postgresql, request) is None
-    assert harness.model.unit.status == BlockedStatus("Requesting an existing username")
+    with patch.object(manager, "set_unit_status") as _gated:
+        assert manager.get_credentials(postgresql, request) is None
+    _gated.assert_called_once_with(BlockedStatus("Requesting an existing username"))
 
 
 def test_get_credentials_uses_the_requested_custom_username(manager, postgresql):
@@ -253,7 +254,7 @@ def test_collect_databases_prefix_lists_and_caches(manager, postgresql):
     assert manager.get_databases_prefix_mapping()["4"]["prefix"] == "pre"
 
 
-def test_collect_databases_blocks_on_a_too_short_prefix(manager, postgresql, harness):
+def test_collect_databases_blocks_on_a_too_short_prefix(manager, postgresql):
     request = DatabaseRequest(
         relation_id=4,
         database="a*",
@@ -261,8 +262,9 @@ def test_collect_databases_blocks_on_a_too_short_prefix(manager, postgresql, har
         prefix_matching=None,
         requested_entity_secret_content=None,
     )
-    assert manager.collect_databases(postgresql, "user", request) is None
-    assert harness.model.unit.status == BlockedStatus("Prefix too short")
+    with patch.object(manager, "set_unit_status") as _gated:
+        assert manager.collect_databases(postgresql, "user", request) is None
+    _gated.assert_called_once_with(BlockedStatus("Prefix too short"))
     postgresql.list_databases.assert_not_called()
 
 
@@ -293,7 +295,6 @@ def test_delete_relation_user_clears_every_mapping(manager, postgresql, harness)
     manager.update_username_mapping(rel_id, "custom")
     # The deleted relation's database still sits in another relation's prefix.
     manager.set_databases_prefix_mapping(other_rel_id, "other-user", "pre", ["pre_a"])
-    harness.charm.app_data_setter = None
     manager.state.application.data["rel_databases"] = json.dumps({str(rel_id): "pre_a"})
 
     manager.delete_relation_user(postgresql, rel_id)
@@ -407,13 +408,16 @@ def test_update_endpoints_publishes_rw_ro_and_uris(substrate, manager, harness):
         harness.update_relation_data(
             peer_rel_id, "postgresql-single-kernel/1", {f"{RELATION_NAME}-address": "2.2.2.2"}
         )
+        harness.update_relation_data(
+            peer_rel_id, "postgresql-single-kernel/2", {f"{RELATION_NAME}-address": "3.3.3.3"}
+        )
         other_rel_id = harness.add_relation(RELATION_NAME, "other-application")
         harness.update_relation_data(other_rel_id, "other-application", {"database": "other_db"})
 
     with (
         patch(
             "single_kernel_postgresql.managers.patroni.PatroniManager.cluster_status",
-            return_value=CLUSTER_STATUS[:2],
+            return_value=CLUSTER_STATUS,
         ),
         patch(
             "single_kernel_postgresql.managers.database.DatabaseManager.is_tls_enabled",
@@ -442,7 +446,8 @@ def test_update_endpoints_publishes_rw_ro_and_uris(substrate, manager, harness):
         )
     else:
         assert data["endpoints"] == "1.1.1.1:5432"
-        assert data["read-only-endpoints"] == "2.2.2.2:5432"
+        # Multiple replicas are published comma-joined.
+        assert data["read-only-endpoints"] == "2.2.2.2:5432,3.3.3.3:5432"
         assert data["uris"] == "postgresql://u:pw@1.1.1.1:5432/test_db"
     assert data["tls"] == "False"
     # A relation-scoped update touches only that relation's databag.
@@ -561,6 +566,39 @@ def test_update_endpoints_read_only_uri_carries_one_port(substrate, manager, har
     assert ":5432:5432" not in uri
 
 
+def test_update_endpoints_falls_back_to_the_primary_without_replicas(manager, harness, substrate):
+    if substrate == "k8s":
+        pytest.skip("K8s reads the replicas Service, not the online Patroni members")
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+    with harness.hooks_disabled():
+        harness.update_relation_data(rel_id, "application", {"database": "test_db"})
+        harness.update_relation_data(
+            peer_rel_id, "postgresql-single-kernel/0", {f"{RELATION_NAME}-address": "1.1.1.1"}
+        )
+
+    with (
+        patch(
+            "single_kernel_postgresql.managers.patroni.PatroniManager.cluster_status",
+            return_value=CLUSTER_STATUS[:1],
+        ),
+        patch(
+            "single_kernel_postgresql.managers.database.DatabaseManager.is_tls_enabled",
+            new_callable=PropertyMock,
+            return_value=False,
+        ),
+        patch.object(
+            manager.database_provides,
+            "fetch_my_relation_data",
+            return_value={rel_id: {"username": "u", "password": "pw"}},
+        ),
+    ):
+        manager.update_endpoints(rel_id)
+
+    data = harness.get_relation_data(rel_id, harness.charm.app.name)
+    assert data["read-only-endpoints"] == "1.1.1.1:5432"
+
+
 def test_update_endpoints_publishes_the_primary_ip_verbatim(manager, harness, substrate):
     """A leader unit without a peer address publishes "None:5432", exactly as the charm did."""
     if substrate == "k8s":
@@ -651,39 +689,6 @@ def test_k8s_endpoints_fall_back_to_the_primary_without_peer_units(substrate, ma
     assert data["read-only-endpoints"] == f"{app}-primary.test-model.svc.cluster.local:5432"
 
 
-def test_update_endpoints_falls_back_to_the_primary_without_replicas(manager, harness, substrate):
-    if substrate == "k8s":
-        pytest.skip("K8s reads the replicas Service, not the online Patroni members")
-    rel_id = harness.model.get_relation(RELATION_NAME).id
-    peer_rel_id = harness.model.get_relation(PEER_RELATION).id
-    with harness.hooks_disabled():
-        harness.update_relation_data(rel_id, "application", {"database": "test_db"})
-        harness.update_relation_data(
-            peer_rel_id, "postgresql-single-kernel/0", {f"{RELATION_NAME}-address": "1.1.1.1"}
-        )
-
-    with (
-        patch(
-            "single_kernel_postgresql.managers.patroni.PatroniManager.cluster_status",
-            return_value=CLUSTER_STATUS[:1],
-        ),
-        patch(
-            "single_kernel_postgresql.managers.database.DatabaseManager.is_tls_enabled",
-            new_callable=PropertyMock,
-            return_value=False,
-        ),
-        patch.object(
-            manager.database_provides,
-            "fetch_my_relation_data",
-            return_value={rel_id: {"username": "u", "password": "pw"}},
-        ),
-    ):
-        manager.update_endpoints(rel_id)
-
-    data = harness.get_relation_data(rel_id, harness.charm.app.name)
-    assert data["read-only-endpoints"] == "1.1.1.1:5432"
-
-
 def test_update_endpoints_filters_out_of_sync_members(manager, harness, substrate):
     if substrate == "k8s":
         pytest.skip("K8s reads the replicas Service, not the online Patroni members")
@@ -760,13 +765,14 @@ def test_update_unit_status_keeps_a_prefix_block_while_a_short_prefix_remains(
 
 
 def test_unblock_custom_user_errors_clears_the_status(manager, postgresql, harness):
+    """The final clear routes through the charm's status bridge."""
     postgresql.list_valid_privileges_and_roles.return_value = (set(), set())
     relation = harness.model.get_relation(RELATION_NAME)
-    harness.model.unit.status = BlockedStatus("Requesting an existing username")
 
-    manager.unblock_custom_user_errors(postgresql, relation)
+    with patch.object(manager, "set_unit_status") as _gated:
+        manager.unblock_custom_user_errors(postgresql, relation)
 
-    assert harness.model.unit.status == ActiveStatus()
+    _gated.assert_called_once_with(ActiveStatus())
 
 
 def test_unblock_custom_user_errors_keeps_the_block_on_invalid_extra_user_roles(
@@ -781,9 +787,10 @@ def test_unblock_custom_user_errors_keeps_the_block_on_invalid_extra_user_roles(
             other_rel_id, "other-application", {"extra-user-roles": "bogus"}
         )
 
-    manager.unblock_custom_user_errors(postgresql, relation)
+    with patch.object(manager, "set_unit_status") as _gated:
+        manager.unblock_custom_user_errors(postgresql, relation)
 
-    assert harness.model.unit.status == BlockedStatus("invalid role(s) for extra user roles")
+    _gated.assert_called_once_with(BlockedStatus("invalid role(s) for extra user roles"))
 
 
 def test_unblock_custom_user_errors_keeps_the_block_on_a_forbidden_user(
@@ -798,10 +805,11 @@ def test_unblock_custom_user_errors_keeps_the_block_on_a_forbidden_user(
         patch.object(manager.database_provides, "fetch_my_relation_field", return_value=None),
         patch.object(manager.database_provides, "fetch_relation_field", return_value="secret-uri"),
         patch.object(manager.state.model, "get_secret", return_value=secret),
+        patch.object(manager, "set_unit_status") as _gated,
     ):
         manager.unblock_custom_user_errors(postgresql, relation)
 
-    assert harness.model.unit.status == BlockedStatus("Requesting an existing username")
+    _gated.assert_called_once_with(BlockedStatus("Requesting an existing username"))
 
 
 def test_unblock_custom_user_errors_keeps_the_block_while_the_secret_is_unreadable(
@@ -814,10 +822,11 @@ def test_unblock_custom_user_errors_keeps_the_block_while_the_secret_is_unreadab
         patch.object(manager.database_provides, "fetch_my_relation_field", return_value=None),
         patch.object(manager.database_provides, "fetch_relation_field", return_value="secret-uri"),
         patch.object(manager.state.model, "get_secret", side_effect=ModelError),
+        patch.object(manager, "set_unit_status") as _gated,
     ):
         manager.unblock_custom_user_errors(postgresql, relation)
 
-    assert harness.model.unit.status == BlockedStatus("Missing grant to requested entity secret")
+    _gated.assert_called_once_with(BlockedStatus("Missing grant to requested entity secret"))
 
 
 def test_is_tls_enabled_tracks_the_client_files(manager):
@@ -843,8 +852,3 @@ def test_request_errors_are_substrate_specific(substrate, manager):
         assert PostgreSQLBaseError not in manager.request_errors
     else:
         assert manager.request_errors == (PostgreSQLBaseError,)
-
-
-def test_manager_state_substrate_matches_the_charm(substrate, manager):
-    expected = Substrates.K8S if substrate == "k8s" else Substrates.VM
-    assert manager.state.substrate == expected

--- a/tests/unit/test_database_manager.py
+++ b/tests/unit/test_database_manager.py
@@ -122,9 +122,7 @@ def test_set_rel_to_db_mapping_caches_the_databases(manager, harness):
 
     manager.set_rel_to_db_mapping()
 
-    assert (
-        json.loads(manager.state.application.data["rel_databases"]) == {str(rel_id): "test_db"}
-    )
+    assert json.loads(manager.state.application.data["rel_databases"]) == {str(rel_id): "test_db"}
 
 
 def test_user_hash_freezes_for_the_manager_lifetime(manager, harness):
@@ -451,7 +449,8 @@ def test_update_endpoints_publishes_rw_ro_and_uris(substrate, manager, harness):
         assert data["endpoints"] == f"{app}-primary.test-model.svc.cluster.local:5432"
         assert data["read-only-endpoints"] == f"{app}-replicas.test-model.svc.cluster.local:5432"
         assert (
-            data["uris"] == f"postgresql://u:pw@{app}-primary.test-model.svc.cluster.local:5432/test_db"
+            data["uris"]
+            == f"postgresql://u:pw@{app}-primary.test-model.svc.cluster.local:5432/test_db"
         )
     else:
         assert data["endpoints"] == "1.1.1.1:5432"
@@ -790,7 +789,9 @@ def test_unblock_custom_user_errors_keeps_the_block_on_invalid_extra_user_roles(
     other_rel_id = harness.add_relation(RELATION_NAME, "other-application")
     with harness.hooks_disabled():
         # The relation the check skips is the one carrying the invalid roles.
-        harness.update_relation_data(other_rel_id, "other-application", {"extra-user-roles": "bogus"})
+        harness.update_relation_data(
+            other_rel_id, "other-application", {"extra-user-roles": "bogus"}
+        )
 
     manager.unblock_custom_user_errors(postgresql, relation)
 
@@ -807,9 +808,7 @@ def test_unblock_custom_user_errors_keeps_the_block_on_a_forbidden_user(
 
     with (
         patch.object(manager.database_provides, "fetch_my_relation_field", return_value=None),
-        patch.object(
-            manager.database_provides, "fetch_relation_field", return_value="secret-uri"
-        ),
+        patch.object(manager.database_provides, "fetch_relation_field", return_value="secret-uri"),
         patch.object(manager.state.model, "get_secret", return_value=secret),
     ):
         manager.unblock_custom_user_errors(postgresql, relation)
@@ -825,9 +824,7 @@ def test_unblock_custom_user_errors_keeps_the_block_while_the_secret_is_unreadab
 
     with (
         patch.object(manager.database_provides, "fetch_my_relation_field", return_value=None),
-        patch.object(
-            manager.database_provides, "fetch_relation_field", return_value="secret-uri"
-        ),
+        patch.object(manager.database_provides, "fetch_relation_field", return_value="secret-uri"),
         patch.object(manager.state.model, "get_secret", side_effect=ModelError),
     ):
         manager.unblock_custom_user_errors(postgresql, relation)

--- a/tests/unit/test_database_manager.py
+++ b/tests/unit/test_database_manager.py
@@ -14,12 +14,7 @@ from single_kernel_postgresql.config.literals import (
     PEER_RELATION,
     USERNAME_MAPPING_LABEL,
 )
-from single_kernel_postgresql.managers.database import (
-    FORBIDDEN_USER_MSG,
-    NO_ACCESS_TO_SECRET_MSG,
-    PREFIX_TOO_SHORT_MSG,
-    DatabaseRequest,
-)
+from single_kernel_postgresql.managers.database import DatabaseRequest
 from single_kernel_postgresql.utils.postgresql import (
     ACCESS_GROUP_RELATION,
     PostgreSQLDeleteUserError,
@@ -119,6 +114,19 @@ def test_collect_user_relations_skips_relations_without_a_database(manager):
     assert manager.collect_user_relations() == {}
 
 
+def test_set_rel_to_db_mapping_caches_the_databases(manager, harness):
+    """The Patroni pg_hba render reads this app-data cache under the same key."""
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    with harness.hooks_disabled():
+        harness.update_relation_data(rel_id, "application", {"database": "test_db"})
+
+    manager.set_rel_to_db_mapping()
+
+    assert (
+        json.loads(manager.state.application.data["rel_databases"]) == {str(rel_id): "test_db"}
+    )
+
+
 def test_user_hash_freezes_for_the_manager_lifetime(manager, harness):
     """Both charms cached the hash per hook, so a mid-hook mapping change must not alter it."""
     frozen = manager.user_hash
@@ -197,7 +205,7 @@ def test_get_credentials_blocks_on_an_existing_username(manager, postgresql, har
         requested_entity_secret_content={"taken": "pw"},
     )
     assert manager.get_credentials(postgresql, request) is None
-    assert harness.model.unit.status == BlockedStatus(FORBIDDEN_USER_MSG)
+    assert harness.model.unit.status == BlockedStatus("Requesting an existing username")
 
 
 def test_get_credentials_blocks_when_the_secret_is_not_readable(manager, postgresql, harness):
@@ -209,7 +217,7 @@ def test_get_credentials_blocks_when_the_secret_is_not_readable(manager, postgre
         requested_entity_secret_content=Mock(items=Mock(side_effect=__import__("ops").ModelError)),
     )
     assert manager.get_credentials(postgresql, request) is None
-    assert harness.model.unit.status == BlockedStatus(NO_ACCESS_TO_SECRET_MSG)
+    assert harness.model.unit.status == BlockedStatus("Missing grant to requested entity secret")
 
 
 def test_collect_databases_plain_database(manager, postgresql):
@@ -246,7 +254,7 @@ def test_collect_databases_blocks_on_a_too_short_prefix(manager, postgresql, har
         requested_entity_secret_content=None,
     )
     assert manager.collect_databases(postgresql, "user", request) is None
-    assert harness.model.unit.status == BlockedStatus(PREFIX_TOO_SHORT_MSG)
+    assert harness.model.unit.status == BlockedStatus("Prefix too short")
     postgresql.list_databases.assert_not_called()
 
 
@@ -273,21 +281,29 @@ def test_create_relation_user_and_database_prefixed_skips_create_database(manage
 
 def test_delete_relation_user_clears_every_mapping(manager, postgresql, harness):
     rel_id = harness.model.get_relation(RELATION_NAME).id
+    other_rel_id = harness.add_relation(RELATION_NAME, "other-application")
     manager.update_username_mapping(rel_id, "custom")
-    manager.set_databases_prefix_mapping(rel_id, "custom", "pre", ["pre_a"])
+    # The deleted relation's database still sits in another relation's prefix.
+    manager.set_databases_prefix_mapping(other_rel_id, "other-user", "pre", ["pre_a"])
+    harness.charm.app_data_setter = None
     manager.state.application.data["rel_databases"] = json.dumps({str(rel_id): "pre_a"})
 
     manager.delete_relation_user(postgresql, rel_id)
 
     postgresql.delete_user.assert_called_once_with("custom")
+    postgresql.remove_user_from_databases.assert_called_once_with("other-user", ["pre_a"])
     assert manager.get_username_mapping() == {}
-    assert manager.get_databases_prefix_mapping() == {}
+    assert manager.get_databases_prefix_mapping() == {
+        str(other_rel_id): {"prefix": "pre", "username": "other-user", "databases": []}
+    }
 
 
 def test_delete_relation_user_blocks_when_the_drop_fails(manager, postgresql, harness):
     postgresql.delete_user.side_effect = PostgreSQLDeleteUserError
     manager.delete_relation_user(postgresql, 4)
-    assert isinstance(harness.model.unit.status, BlockedStatus)
+    assert harness.model.unit.status == BlockedStatus(
+        "Failed to delete user during database relation broken event"
+    )
 
 
 def test_oversee_users_deletes_only_users_without_a_relation(manager, postgresql, harness):
@@ -298,10 +314,14 @@ def test_oversee_users_deletes_only_users_without_a_relation(manager, postgresql
         stale,
         "postgres",
     }
+    manager.state.set_secret(APP_SCOPE, stale, "pw")
+    manager.state.set_secret(APP_SCOPE, f"{stale}-database", "pw")
 
     manager.oversee_users(postgresql)
 
     postgresql.delete_user.assert_called_once_with(stale)
+    assert manager.state.get_secret(APP_SCOPE, stale) is None
+    assert manager.state.get_secret(APP_SCOPE, f"{stale}-database") is None
 
 
 def test_oversee_users_honours_the_suppress_flag(manager, postgresql):
@@ -723,11 +743,11 @@ def test_update_unit_status_keeps_a_prefix_block_while_a_short_prefix_remains(
     relation = harness.model.get_relation(RELATION_NAME)
     with harness.hooks_disabled():
         harness.update_relation_data(relation.id, "application", {"database": "a*"})
-    harness.model.unit.status = BlockedStatus(PREFIX_TOO_SHORT_MSG)
+    harness.model.unit.status = BlockedStatus("Prefix too short")
 
     manager.update_unit_status(postgresql, relation)
 
-    assert harness.model.unit.status == BlockedStatus(PREFIX_TOO_SHORT_MSG)
+    assert harness.model.unit.status == BlockedStatus("Prefix too short")
 
 
 def test_is_tls_enabled_tracks_the_client_files(manager):

--- a/uv.lock
+++ b/uv.lock
@@ -1156,7 +1156,7 @@ wheels = [
 
 [[package]]
 name = "postgresql-charms-single-kernel"
-version = "16.3.5"
+version = "16.3.6"
 source = { editable = "." }
 dependencies = [
     { name = "ops", version = "2.23.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Issue

Last of the seven. PRs 5 and 6 cover the manager; the events handler's guards, defers and status mapping are still untested.

## Solution

The request cases drive a real `database_requested` by writing to the requirer databag rather than calling the handler directly, so the provider library's own leader gate and diff bookkeeping stay in the path under test.

Covers the happy path end to end, both defer paths (cluster not ready, peers not synced), the three blocking outcomes, the departing-unit flag, the leader and follower relation-broken paths, and the substrate split in the removal guard — K8s settles for a started member where VM also needs a primary. The K8s inline endpoint write is asserted present on K8s and absent on VM.

The PR also carries one fix: building `DatabaseRequest` read `event.requested_entity_secret_content` outside any `ModelError` guard, so an ungranted cross-model secret crashed the hook where both charms set `Missing grant to requested entity secret` and recovered on the next relation-changed. The guard now sits at the read itself, and its test drives the real event with the property raising.

Wiring up at:
* https://github.com/canonical/postgresql-k8s-operator/pull/1696
* https://github.com/canonical/postgresql-operator/pull/1900

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.

