### PR TITLE
[DPE-10985] docs: fix workload command user context for the 14 track

### DIFF
--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -107,7 +107,7 @@ The charmed-postgresql snap also ships list of tools used by charm:
 
 To avoid a split-brain scenario, we recommend you do **not** start, stop, and restart snap services manually. See {ref}`this guide <troubleshooting>` for troubleshooting guidance.
 
-All snap resources must be executed under the special **snap user `_daemon_`** only!
+All snap resources must be executed under the special **snap user `snap_daemon`** only!
 ```
 
 ````

--- a/docs/explanation/logs.md
+++ b/docs/explanation/logs.md
@@ -41,23 +41,23 @@ PostgreSQL and Patroni logs can be found in `/var/snap/charmed-postgresql/common
 
     $ ls -alh /var/snap/charmed-postgresql/common/var/log/postgresql
     total 20K
-    drwxr-xr-x 2 _daemon_ root        4.0K Oct 11 15:09 .
-    drwxr-xr-x 6 _daemon_ root        4.0K Oct 11 15:04 ..
-    -rw------- 1 _daemon_ _daemon_ 4.3K Oct 11 15:05 postgresql-3_1505.log
-    -rw------- 1 _daemon_ _daemon_    0 Oct 11 15:06 postgresql-3_1506.log
-    -rw------- 1 _daemon_ _daemon_    0 Oct 11 15:07 postgresql-3_1507.log
-    -rw------- 1 _daemon_ _daemon_  817 Oct 11 15:08 postgresql-3_1508.log
-    -rw------- 1 _daemon_ _daemon_    0 Oct 11 15:09 postgresql-3_1509.log
+    drwxr-xr-x 2 snap_daemon root        4.0K Oct 11 15:09 .
+    drwxr-xr-x 6 snap_daemon root        4.0K Oct 11 15:04 ..
+    -rw------- 1 snap_daemon snap_daemon 4.3K Oct 11 15:05 postgresql-3_1505.log
+    -rw------- 1 snap_daemon snap_daemon    0 Oct 11 15:06 postgresql-3_1506.log
+    -rw------- 1 snap_daemon snap_daemon    0 Oct 11 15:07 postgresql-3_1507.log
+    -rw------- 1 snap_daemon snap_daemon  817 Oct 11 15:08 postgresql-3_1508.log
+    -rw------- 1 snap_daemon snap_daemon    0 Oct 11 15:09 postgresql-3_1509.log
 
     $  ls -alh /var/snap/charmed-postgresql/common/var/log/patroni/
     total 28K
-    drwxr-xr-x 2 _daemon_ root        4.0K Oct 11 15:29 .
-    drwxr-xr-x 6 _daemon_ root        4.0K Oct 11 15:25 ..
-    -rw-r--r-- 1 _daemon_ _daemon_  356 Oct 11 15:29 patroni.log
-    -rw-r--r-- 1 _daemon_ _daemon_  534 Oct 11 15:28 patroni.log.1
-    -rw-r--r-- 1 _daemon_ _daemon_  520 Oct 11 15:27 patroni.log.2
-    -rw-r--r-- 1 _daemon_ _daemon_  584 Oct 11 15:27 patroni.log.3
-    -rw-r--r-- 1 _daemon_ _daemon_  464 Oct 11 15:27 patroni.log.4
+    drwxr-xr-x 2 snap_daemon root        4.0K Oct 11 15:29 .
+    drwxr-xr-x 6 snap_daemon root        4.0K Oct 11 15:25 ..
+    -rw-r--r-- 1 snap_daemon snap_daemon  356 Oct 11 15:29 patroni.log
+    -rw-r--r-- 1 snap_daemon snap_daemon  534 Oct 11 15:28 patroni.log.1
+    -rw-r--r-- 1 snap_daemon snap_daemon  520 Oct 11 15:27 patroni.log.2
+    -rw-r--r-- 1 snap_daemon snap_daemon  584 Oct 11 15:27 patroni.log.3
+    -rw-r--r-- 1 snap_daemon snap_daemon  464 Oct 11 15:27 patroni.log.4
 
 ### Formatting
 
@@ -150,11 +150,11 @@ If S3 backups are enabled, pgBackRest logs would be located in `/var/snap/charme
 
     $ ls -alh  /var/snap/charmed-postgresql/common/var/log/pgbackrest/
     total 20K
-    drwxr-xr-x 2 _daemon_ root        4.0K Oct 11 15:14 .
-    drwxr-xr-x 6 _daemon_ root        4.0K Oct 11 15:04 ..
-    -rw-r----- 1 _daemon_ _daemon_ 1.7K Oct 11 15:14 pg.pg-backup.log
-    -rw-r----- 1 _daemon_ _daemon_  717 Oct 11 15:14 pg.pg-expire.log
-    -rw-r----- 1 _daemon_ _daemon_  859 Oct 11 15:08 pg.pg-stanza-create.log
+    drwxr-xr-x 2 snap_daemon root        4.0K Oct 11 15:14 .
+    drwxr-xr-x 6 snap_daemon root        4.0K Oct 11 15:04 ..
+    -rw-r----- 1 snap_daemon snap_daemon 1.7K Oct 11 15:14 pg.pg-backup.log
+    -rw-r----- 1 snap_daemon snap_daemon  717 Oct 11 15:14 pg.pg-expire.log
+    -rw-r----- 1 snap_daemon snap_daemon  859 Oct 11 15:08 pg.pg-stanza-create.log
 
 ### Formatting
 

--- a/docs/how-to/troubleshooting/cli-helpers.md
+++ b/docs/how-to/troubleshooting/cli-helpers.md
@@ -33,7 +33,7 @@ Learn more about Patroni in {ref}`architecture`.
 
 The main Patroni tool is `patronictl`.
 
-**It should only be used under the snap context**, via the root user.
+**It should only be used under the snap context**, via the user `snap_daemon`.
 
 #### Cluster status
 
@@ -46,7 +46,7 @@ $ juju deploy postgresql --channel 14/stable -n 3 # and wait for deployment
 $ juju ssh postgresql/2
 ...
 
-ubuntu@juju-b87344-2:~$ sudo patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml topology
+ubuntu@juju-b87344-2:~$ sudo -H -u snap_daemon patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml topology
 + Cluster: postgresql (7496847632512033809) ------+-----------+----+-----------+
 | Member          | Host           | Role         | State     | TL | Lag in MB |
 +-----------------+----------------+--------------+-----------+----+-----------+
@@ -64,7 +64,7 @@ Use `--help` to find all the available Patroni actions.
 <details><summary>Example: Patroni actions</summary>
 
 ```shell
-$  sudo patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml --help
+$  sudo -H -u snap_daemon patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml --help
 ...
   failover     Failover to a replica
   history      Show the history of failovers/switchovers
@@ -89,7 +89,7 @@ Patroni can perform a low-level [switchover/failover](https://patroni.readthedoc
 <details><summary>Example: switchover (healthy cluster only)</summary>
 
 ```shell
-$ sudo patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml switchover postgresql --candidate postgresql-2 --force
+$ sudo -H -u snap_daemon patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml switchover postgresql --candidate postgresql-2 --force
 Current cluster topology
 + Cluster: postgresql (7496847632512033809) ----+-----------+----+-----------+
 | Member        | Host           | Role         | State     | TL | Lag in MB |
@@ -107,7 +107,7 @@ Current cluster topology
 | postgresql-3  | 10.189.210.26  | Replica | stopped   |    |   unknown |
 +---------------+----------------+---------+-----------+----+-----------+
 
-$ sudo patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml list
+$ sudo -H -u snap_daemon patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml list
 + Cluster: postgresql (7496847632512033809) ----+-----------+----+-----------+
 | Member        | Host           | Role         | State     | TL | Lag in MB |
 +---------------+----------------+--------------+-----------+----+-----------+
@@ -121,7 +121,7 @@ $ sudo patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.ya
 <details><summary>Example: failover</summary>
 
 ```shell
-$ sudo patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml failover postgresql --candidate postgresql-3
+$ sudo -H -u snap_daemon patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml failover postgresql --candidate postgresql-3
 Current cluster list
 + Cluster: postgresql (7496847632512033809) ----+-----------+----+-----------+
 | Member        | Host           | Role         | State     | TL | Lag in MB |
@@ -140,14 +140,14 @@ Are you sure you want to failover cluster postgresql, demoting current leader po
 | postgresql-3  | 10.189.210.26  | Leader  | running |  1 |           |
 +---------------+----------------+---------+---------+----+-----------+
 
-$ sudo patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml history
+$ sudo -H -u snap_daemon patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml history
 +----+-----------+------------------------------+----------------------------------+--------------+
 | TL |       LSN | Reason                       | Timestamp                        | New Leader   |
 +----+-----------+------------------------------+----------------------------------+--------------+
 |  1 | 335544480 | no recovery target specified | 2025-04-25T04:44:53.137152+00:00 | postgresql-3 |
 +----+-----------+------------------------------+----------------------------------+--------------+
 
-$ sudo patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml list
+$ sudo -H -u snap_daemon patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml list
 + Cluster: postgresql (7496847632512033809) ----+-----------+----+-----------+
 | Member        | Host           | Role         | State     | TL | Lag in MB |
 +---------------+----------------+--------------+-----------+----+-----------+
@@ -164,7 +164,7 @@ Sometimes the cluster member might stuck in the middle of nowhere, the easiest w
 <details><summary>Example: cluster member re-initialisation</summary>
 
 ```shell
-$ sudo patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml reinit postgresql postgresql-1
+$ sudo -H -u snap_daemon patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml reinit postgresql postgresql-1
 + Cluster: postgresql (7496847632512033809) ----+-----------+----+-----------+
 | Member        | Host           | Role         | State     | TL | Lag in MB |
 +---------------+----------------+--------------+-----------+----+-----------+

--- a/docs/how-to/troubleshooting/switchover-failover.md
+++ b/docs/how-to/troubleshooting/switchover-failover.md
@@ -100,7 +100,7 @@ Find the current primary/standby/replica:
 
 ```shell
 $ juju ssh postgresql/0
-ubuntu@juju-422c1a-0:~$ sudo patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml list
+ubuntu@juju-422c1a-0:~$ sudo -H -u snap_daemon patronictl -c /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml list
 + Cluster: postgresql (7499430436963402504) ---+-----------+----+-----------+
 | Member       | Host           | Role         | State     | TL | Lag in MB |
 +--------------+----------------+--------------+-----------+----+-----------+


### PR DESCRIPTION
## Issue

The `patronictl` commands documented on this track fail with `Provided config file /var/snap/charmed-postgresql/current/etc/patroni/patroni.yaml not existing or no read rights` because they run outside the snap context — reported in canonical/postgresql-operator#1922 against the PostgreSQL 14 charm (rev1162). Two defects in the 14 docs tree:

1. The troubleshooting pages show plain `sudo patronictl ...` and state the tool "should only be used under the snap context, via the root user". The docs these pages replaced carried `sudo -u snap_daemon patronictl ...` until they were deleted from the charm repository in canonical/postgresql-operator#1850; their initial import into this repository ([8618e3e](https://github.com/canonical/postgresql-single-kernel-library/commit/8618e3eeaacec0b7a1b39da6c182d17ffe977a6a)) did not carry that form over.
2. The explanation pages name the snap user `_daemon_`. That rename landed only on the 16 track of the charmed-postgresql snap ([DPE-7691, 2f1554d](https://github.com/canonical/charmed-postgresql-snap/commit/2f1554d0771ab5c3cbdf4803c5984e8dc925566d)); the 14 track never picked it up — its `snapcraft.yaml` still declares `system-usernames: snap_daemon: shared` — so everything there runs as `snap_daemon` and files stay owned by it.

## Solution

- Restore the snap-context invocation in every example (`cli-helpers`, `switchover-failover`) and correct the intro sentence back to the `snap_daemon` user. Provenance precision: the old charm-repo pages used `sudo -u snap_daemon patronictl ...` without `-H`; the `-H -u` variant adopted here is the exact form field-validated in canonical/postgresql-operator#1922, and `-H` (HOME=/home/snap_daemon) matches the home directory the charm prepares for that user on install.
- Replace every `_daemon_` reference with `snap_daemon`: the architecture caution box and the ownership columns of all `ls -alh` sample outputs in the logs page.

To review locally: check out this branch, then `grep -rn '_daemon_\|sudo patronictl' docs/` returns nothing while `grep -rn 'sudo -H -u snap_daemon' docs/ | wc -l` returns 9.

## Checklist
- [x] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
