### PR TITLE
[DPE-11014] fix(database): don't read the own application databag in status-cleanup scans

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "postgresql-charms-single-kernel"
 description = "Shared and reusable code for PostgreSQL-related charms"
-version = "16.3.6"
+version = "16.3.7"
 readme = "README.md"
 license = {file = "LICENSE"}
 authors = [

--- a/single_kernel_postgresql/managers/database.py
+++ b/single_kernel_postgresql/managers/database.py
@@ -570,7 +570,11 @@ class DatabaseManager(BaseManager):
         for relation in self.state.model.relations.get(self.relation_name, []):
             if relation.id == relation_id:
                 continue
-            for data in relation.data.values():
+            for entity, data in relation.data.items():
+                # Requested data only lives in remote databags; a non-leader unit
+                # cannot read its own application databag (ops forbids that read).
+                if entity in (self.state.model.app, self.state.model.unit):
+                    continue
                 for extra_user_role in self.sanitize_extra_roles(data.get("extra-user-roles")):
                     if (
                         extra_user_role not in valid_privileges
@@ -589,7 +593,11 @@ class DatabaseManager(BaseManager):
         for relation in self.state.model.relations.get(self.relation_name, []):
             if relation.id == relation_id:
                 continue
-            for data in relation.data.values():
+            for entity, data in relation.data.items():
+                # Requested data only lives in remote databags; a non-leader unit
+                # cannot read its own application databag (ops forbids that read).
+                if entity in (self.state.model.app, self.state.model.unit):
+                    continue
                 database = data.get("database")
                 if database is not None and (
                     len(database) > 49 or database in INVALID_DATABASE_NAMES

--- a/tests/unit/test_database_events.py
+++ b/tests/unit/test_database_events.py
@@ -14,6 +14,7 @@ from single_kernel_postgresql.lib.charms.data_platform_libs.v0.data_interfaces i
 )
 from single_kernel_postgresql.utils.postgresql import (
     ACCESS_GROUP_RELATION,
+    INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE,
     PostgreSQLCreateDatabaseError,
     PostgreSQLCreateUserError,
     PostgreSQLGetPostgreSQLVersionError,
@@ -402,6 +403,28 @@ def test_the_relation_departed_observer_flags_the_departing_unit(harness, events
     )
 
     assert "departing" in harness.get_relation_data(peer_rel_id, harness.charm.unit)
+
+
+def test_relation_broken_survives_on_a_blocked_follower(harness, events, postgresql):
+    """A non-leader unit carrying a qualifying Blocked status must survive relation-broken.
+
+    ops forbids a follower to read its own application databag; the post-broken
+    status cleanup must therefore only scan remote databags, which is also where
+    requested fields live. Emitted through the framework so the strict relation
+    data access rules apply.
+    """
+    with harness.hooks_disabled():
+        harness.add_relation(RELATION_NAME, "application2")
+        harness.set_leader(False)
+        harness.charm.unit.status = BlockedStatus(INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE)
+
+    rel = next(
+        r for r in harness.charm.model.relations[RELATION_NAME] if r.app.name == "application"
+    )
+    with cluster_ready(harness, postgresql):
+        harness.charm.on[RELATION_NAME].relation_broken.emit(rel)
+
+    assert isinstance(harness.charm.unit.status, ActiveStatus)
 
 
 def test_the_relation_broken_observer_deletes_the_user(harness, events, postgresql):

--- a/tests/unit/test_database_events.py
+++ b/tests/unit/test_database_events.py
@@ -18,6 +18,7 @@ from single_kernel_postgresql.managers.database import (
 )
 from single_kernel_postgresql.utils.postgresql import (
     ACCESS_GROUP_RELATION,
+    INVALID_DATABASE_NAME_BLOCKING_MESSAGE,
     INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE,
     PostgreSQLCreateDatabaseError,
     PostgreSQLCreateUserError,
@@ -413,6 +414,7 @@ def test_the_relation_departed_observer_flags_the_departing_unit(harness, events
     "blocked_message",
     [
         INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE,
+        INVALID_DATABASE_NAME_BLOCKING_MESSAGE,
         NO_ACCESS_TO_SECRET_MSG,
         FORBIDDEN_USER_MSG,
     ],

--- a/tests/unit/test_database_events.py
+++ b/tests/unit/test_database_events.py
@@ -12,6 +12,10 @@ from single_kernel_postgresql.config.literals import PEER_RELATION
 from single_kernel_postgresql.lib.charms.data_platform_libs.v0.data_interfaces import (
     DatabaseRequestedEvent,
 )
+from single_kernel_postgresql.managers.database import (
+    FORBIDDEN_USER_MSG,
+    NO_ACCESS_TO_SECRET_MSG,
+)
 from single_kernel_postgresql.utils.postgresql import (
     ACCESS_GROUP_RELATION,
     INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE,
@@ -405,18 +409,29 @@ def test_the_relation_departed_observer_flags_the_departing_unit(harness, events
     assert "departing" in harness.get_relation_data(peer_rel_id, harness.charm.unit)
 
 
-def test_relation_broken_survives_on_a_blocked_follower(harness, events, postgresql):
+@pytest.mark.parametrize(
+    "blocked_message",
+    [
+        INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE,
+        NO_ACCESS_TO_SECRET_MSG,
+        FORBIDDEN_USER_MSG,
+    ],
+)
+def test_relation_broken_survives_on_a_blocked_follower(
+    harness, events, postgresql, blocked_message
+):
     """A non-leader unit carrying a qualifying Blocked status must survive relation-broken.
 
     ops forbids a follower to read its own application databag; the post-broken
     status cleanup must therefore only scan remote databags, which is also where
     requested fields live. Emitted through the framework so the strict relation
-    data access rules apply.
+    data access rules apply. The three messages exercise both cleanup paths
+    (direct scan and unblock_custom_user_errors).
     """
     with harness.hooks_disabled():
         harness.add_relation(RELATION_NAME, "application2")
         harness.set_leader(False)
-        harness.charm.unit.status = BlockedStatus(INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE)
+        harness.charm.unit.status = BlockedStatus(blocked_message)
 
     rel = next(
         r for r in harness.charm.model.relations[RELATION_NAME] if r.app.name == "application"

--- a/uv.lock
+++ b/uv.lock
@@ -1156,7 +1156,7 @@ wheels = [
 
 [[package]]
 name = "postgresql-charms-single-kernel"
-version = "16.3.6"
+version = "16.3.7"
 source = { editable = "." }
 dependencies = [
     { name = "ops", version = "2.23.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Issue

A non-leader unit carrying one of the qualifying Blocked statuses (`invalid role(s) for extra user roles`, invalid database name, forbidden username, missing secret grant — all set only while the unit held leadership) crashes when a client relation breaks while at least one other client relation is still live. The post-broken status cleanup scans the remaining relations' data buckets, including the charm's own application databag, which ops forbids a follower to read, raising `RelationDataAccessError: <unit> is not leader and cannot read its own application databag`. The hook then fails and Juju keeps re-running it into the same deterministic crash, wedging the unit until an operator intervenes.

Reproduced on a live deployment built from the current `16/edge` charm code with this library at 16.3.6: staged a Blocked former leader, moved Juju leadership away (agent freeze → lease failover), broke one of two client relations, and captured the traceback through `events/database.py:_on_relation_broken` → `managers/database.py:update_unit_status` → `check_for_invalid_extra_user_roles` → `relation.data.values()`.

## Solution

`check_for_invalid_extra_user_roles()` and `check_for_invalid_database_name()` now iterate `relation.data.items()` and skip the own app and unit buckets. Requested fields (`extra-user-roles`, `database`) only ever live in remote databags, so the semantics of both scans are unchanged; only the forbidden own-app read disappears. This closes the crash for all four qualifying Blocked statuses: the first two enter the cleanup through the direct scan, and forbidden username / missing secret grant through `unblock_custom_user_errors()`, whose first statement is the same scan.

The regression test emits `relation_broken` through the framework on a blocked follower with a second client relation still live, parametrized over all four qualifying Blocked statuses on both the vm and k8s substrates, so ops' strict relation data access rules apply and every case fails with the production error before the fix.

## Checklist

- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
