### PR TITLE
fix(database): skip database request without a database name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "postgresql-charms-single-kernel"
 description = "Shared and reusable code for PostgreSQL-related charms"
-version = "16.3.6"
+version = "16.3.7"
 readme = "README.md"
 license = {file = "LICENSE"}
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "postgresql-charms-single-kernel"
 description = "Shared and reusable code for PostgreSQL-related charms"
-version = "16.3.7"
+version = "16.3.8"
 readme = "README.md"
 license = {file = "LICENSE"}
 authors = [

--- a/single_kernel_postgresql/managers/database.py
+++ b/single_kernel_postgresql/managers/database.py
@@ -307,8 +307,15 @@ class DatabaseManager(BaseManager):
         self, postgresql_client: PostgreSQLClient, user: str, request: DatabaseRequest
     ) -> tuple[str, list[str]] | None:
         """Resolve the requested database(s), or block and return None."""
-        database = request["database"] or ""
-        if database and database[-1] == "*":
+        # A request deferred while the cluster was not ready may replay after its
+        # relation died (e.g. a CMR removed during a Patroni outage); the request
+        # name then reads back as absent. Returning without deferring lets ops
+        # drop the stale notice.
+        database = request["database"]
+        if not database:
+            logger.warning("Database name is not set in the relation data, skipping.")
+            return None
+        if database[-1] == "*":
             if len(database) < MINIMUM_PREFIX_REQUEST_LENGTH:
                 self.set_unit_status(BlockedStatus(PREFIX_TOO_SHORT_MSG))
                 return None

--- a/single_kernel_postgresql/managers/database.py
+++ b/single_kernel_postgresql/managers/database.py
@@ -570,7 +570,11 @@ class DatabaseManager(BaseManager):
         for relation in self.state.model.relations.get(self.relation_name, []):
             if relation.id == relation_id:
                 continue
-            for data in relation.data.values():
+            for entity, data in relation.data.items():
+                # Requested data only lives in remote databags; a non-leader unit
+                # cannot read its own application databag (ops forbids that read).
+                if entity in (self.state.model.app, self.state.model.unit):
+                    continue
                 for extra_user_role in self.sanitize_extra_roles(data.get("extra-user-roles")):
                     if (
                         extra_user_role not in valid_privileges
@@ -589,7 +593,11 @@ class DatabaseManager(BaseManager):
         for relation in self.state.model.relations.get(self.relation_name, []):
             if relation.id == relation_id:
                 continue
-            for data in relation.data.values():
+            for entity, data in relation.data.items():
+                # Requested data only lives in remote databags; a non-leader unit
+                # cannot read its own application databag (ops forbids that read).
+                if entity in (self.state.model.app, self.state.model.unit):
+                    continue
                 database = data.get("database")
                 if database is not None and (
                     len(database) > 49 or database in INVALID_DATABASE_NAMES

--- a/tests/unit/test_database_events.py
+++ b/tests/unit/test_database_events.py
@@ -14,6 +14,7 @@ from single_kernel_postgresql.lib.charms.data_platform_libs.v0.data_interfaces i
 )
 from single_kernel_postgresql.utils.postgresql import (
     ACCESS_GROUP_RELATION,
+    INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE,
     PostgreSQLCreateDatabaseError,
     PostgreSQLCreateUserError,
     PostgreSQLGetPostgreSQLVersionError,
@@ -402,6 +403,28 @@ def test_the_relation_departed_observer_flags_the_departing_unit(harness, events
     )
 
     assert "departing" in harness.get_relation_data(peer_rel_id, harness.charm.unit)
+
+
+def test_relation_broken_survives_on_a_blocked_follower(harness, events, postgresql):
+    """A non-leader unit carrying a qualifying Blocked status must survive relation-broken.
+
+    ops forbids a follower to read its own application databag; the post-broken
+    status cleanup must therefore only scan remote databags, which is also where
+    requested fields live. Emitted through the framework so the strict relation
+    data access rules apply.
+    """
+    with harness.hooks_disabled():
+        harness.add_relation(RELATION_NAME, "application2")
+        harness.set_leader(False)
+        harness.charm.unit.status = BlockedStatus(INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE)
+
+    rel = next(
+        r for r in harness.charm.model.relations[RELATION_NAME] if r.app.name == "application"
+    )
+    with cluster_ready(harness, postgresql):
+        harness.charm.on[RELATION_NAME].relation_broken.emit(rel)
+
+    assert isinstance(harness.charm.unit.status, ActiveStatus)
 
 
 def test_the_relation_broken_observer_deletes_the_user(harness, events, postgresql):

--- a/tests/unit/test_database_events.py
+++ b/tests/unit/test_database_events.py
@@ -18,6 +18,7 @@ from single_kernel_postgresql.managers.database import (
 )
 from single_kernel_postgresql.utils.postgresql import (
     ACCESS_GROUP_RELATION,
+    INVALID_DATABASE_NAME_BLOCKING_MESSAGE,
     INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE,
     PostgreSQLCreateDatabaseError,
     PostgreSQLCreateUserError,
@@ -413,6 +414,7 @@ def test_the_relation_departed_observer_flags_the_departing_unit(harness, events
     "blocked_message",
     [
         INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE,
+        INVALID_DATABASE_NAME_BLOCKING_MESSAGE,
         NO_ACCESS_TO_SECRET_MSG,
         FORBIDDEN_USER_MSG,
     ],

--- a/tests/unit/test_database_events.py
+++ b/tests/unit/test_database_events.py
@@ -591,3 +591,24 @@ def test_update_unit_status_runs_before_the_departing_check(harness, events, pos
         events._on_relation_broken(event)
 
     assert harness.model.unit.status == ActiveStatus()
+
+
+def test_a_replayed_request_whose_request_data_is_gone_is_skipped(
+    substrate, harness, events, postgresql, caplog
+):
+    """A deferred notice replayed after its relation died reads the name back as absent."""
+    caplog.set_level(logging.WARNING, logger="single_kernel_postgresql.managers.database")
+    with (
+        cluster_ready(harness, postgresql) as update_endpoints,
+        patch("ops.framework.EventBase.defer") as _defer,
+    ):
+        rel = harness.model.get_relation(RELATION_NAME)
+        # The relation databag carries no request: that is what ops supplies when it
+        # re-emits a deferred notice for a relation removed while the request waited.
+        events.database_provides.on.database_requested.emit(rel, app=rel.app)
+
+    assert "Database name is not set in the relation data, skipping." in caplog.text
+    postgresql.create_database.assert_not_called()
+    postgresql.create_user.assert_not_called()
+    update_endpoints.assert_not_called()
+    _defer.assert_not_called()

--- a/tests/unit/test_database_events.py
+++ b/tests/unit/test_database_events.py
@@ -12,6 +12,10 @@ from single_kernel_postgresql.config.literals import PEER_RELATION
 from single_kernel_postgresql.lib.charms.data_platform_libs.v0.data_interfaces import (
     DatabaseRequestedEvent,
 )
+from single_kernel_postgresql.managers.database import (
+    FORBIDDEN_USER_MSG,
+    NO_ACCESS_TO_SECRET_MSG,
+)
 from single_kernel_postgresql.utils.postgresql import (
     ACCESS_GROUP_RELATION,
     INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE,
@@ -405,18 +409,29 @@ def test_the_relation_departed_observer_flags_the_departing_unit(harness, events
     assert "departing" in harness.get_relation_data(peer_rel_id, harness.charm.unit)
 
 
-def test_relation_broken_survives_on_a_blocked_follower(harness, events, postgresql):
+@pytest.mark.parametrize(
+    "blocked_message",
+    [
+        INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE,
+        NO_ACCESS_TO_SECRET_MSG,
+        FORBIDDEN_USER_MSG,
+    ],
+)
+def test_relation_broken_survives_on_a_blocked_follower(
+    harness, events, postgresql, blocked_message
+):
     """A non-leader unit carrying a qualifying Blocked status must survive relation-broken.
 
     ops forbids a follower to read its own application databag; the post-broken
     status cleanup must therefore only scan remote databags, which is also where
     requested fields live. Emitted through the framework so the strict relation
-    data access rules apply.
+    data access rules apply. The three messages exercise both cleanup paths
+    (direct scan and unblock_custom_user_errors).
     """
     with harness.hooks_disabled():
         harness.add_relation(RELATION_NAME, "application2")
         harness.set_leader(False)
-        harness.charm.unit.status = BlockedStatus(INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE)
+        harness.charm.unit.status = BlockedStatus(blocked_message)
 
     rel = next(
         r for r in harness.charm.model.relations[RELATION_NAME] if r.app.name == "application"

--- a/uv.lock
+++ b/uv.lock
@@ -1156,7 +1156,7 @@ wheels = [
 
 [[package]]
 name = "postgresql-charms-single-kernel"
-version = "16.3.6"
+version = "16.3.7"
 source = { editable = "." }
 dependencies = [
     { name = "ops", version = "2.23.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },

--- a/uv.lock
+++ b/uv.lock
@@ -1156,7 +1156,7 @@ wheels = [
 
 [[package]]
 name = "postgresql-charms-single-kernel"
-version = "16.3.7"
+version = "16.3.8"
 source = { editable = "." }
 dependencies = [
     { name = "ops", version = "2.23.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Issue

A `database_requested` event that was deferred while the cluster was not ready gets replayed by ops on every subsequent dispatch. If the relation has gone away in the meantime — e.g. a cross-model consumer removed during a Patroni outage — ops supplies the dead relation, the remote databag reads back without a `database` key, and `collect_databases` coerced the missing value to an empty string. The handler then indexed it in `create_relation_user_and_database`, raising an uncaught `IndexError: string index out of range`.

ops only drops a deferred notice once its handler returns, so the exception aborted every later hook on the unit — actions included — wedging the leader until the failed hook is resolved.

## Solution

Return early from `collect_databases` when the request carries no database name, logging a warning instead of coercing the missing value to an empty string. The handler already treats a `None` return as "nothing to do", so the stale notice drains on its next replay without deferring.

A live requirer can never request an empty name: Juju drops a databag key whose value is an empty string, and the provider library only emits `database_requested` when that key is added — the guard therefore only affects the replayed-stale-notice path.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
