### PR TITLE
[DPE-11043] feat(ldap): port the LDAP relation module from the charms (2/2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "postgresql-charms-single-kernel"
 description = "Shared and reusable code for PostgreSQL-related charms"
-version = "16.3.7"
+version = "16.3.8"
 readme = "README.md"
 license = {file = "LICENSE"}
 authors = [

--- a/single_kernel_postgresql/charms/abstract_charm.py
+++ b/single_kernel_postgresql/charms/abstract_charm.py
@@ -10,6 +10,7 @@ from ops.charm import CharmBase
 
 from single_kernel_postgresql.core.state import CharmState
 from single_kernel_postgresql.events.database import DatabaseEventsHandler
+from single_kernel_postgresql.events.ldap import LDAP
 from single_kernel_postgresql.events.postgresql import PostgreSQLEventsHandler
 from single_kernel_postgresql.events.tls import TLS
 from single_kernel_postgresql.lib.charms.data_platform_libs.v0.data_interfaces import (
@@ -40,6 +41,10 @@ class AbstractPostgreSQLCharm(CharmBase, ABC):
         # TLS manager so the manager can constructor-inject them for its live-fetch getters.
         self.tls = TLS(self, self.state)
 
+        # LDAP events handler owns the ldap requirer relation and the auth parameters
+        # the config manager renders into the Patroni hba section.
+        self.ldap = LDAP(self, self.state)
+
         # Managers
         self.tls_manager = TLSManager(
             state=self.state,
@@ -68,6 +73,7 @@ class AbstractPostgreSQLCharm(CharmBase, ABC):
             tls_manager=self.tls_manager,
             patroni_manager=self.patroni_manager,
             database_manager=self.database_manager,
+            ldap_handler=self.ldap,
             resource_provider=self.get_resource_provider,
             request_restart=self.request_restart,
             restart_services=self.restart_services,
@@ -116,7 +122,7 @@ class AbstractPostgreSQLCharm(CharmBase, ABC):
 
     # Charm-side bridges the lib calls back into. request_restart/restart_services are
     # substrate-tangled and stay until their own migration phases; update_config still
-    # supplies the ldap/async/watcher values those phases own; primary_endpoint is the
+    # supplies the async/watcher values those phases own; primary_endpoint is the
     # VM's Patroni-derived primary lookup. set_unit_status routes status writes through
     # the charm_refresh priority gate and stays until the refresh logic itself migrates
     # into the library, at which point the managers own their status writes.

--- a/single_kernel_postgresql/config/literals.py
+++ b/single_kernel_postgresql/config/literals.py
@@ -56,6 +56,9 @@ TLS_CA_BUNDLE_FILE = "peer_ca_bundle.pem"
 TLS_CLIENT_RELATION = "client-certificates"
 TLS_PEER_RELATION = "peer-certificates"
 
+# LDAP relation names
+LDAP_RELATION = "ldap"
+
 # Scopes
 SCOPES = Literal["app", "unit"]
 APP_SCOPE = "app"

--- a/single_kernel_postgresql/events/ldap.py
+++ b/single_kernel_postgresql/events/ldap.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""LDAP events handler — owns the ``ldap`` requirer relation and the LDAP auth parameters.
+
+Ported from the PostgreSQL VM and K8s charms' LDAP module. The substrate-specific
+LDAP-sync sidecar restart stays behind the charm's ``restart_services`` bridge.
+"""
+
+import logging
+from typing import Any
+
+from ops import Relation
+from ops.framework import Object
+from ops.model import ActiveStatus
+
+from single_kernel_postgresql.config.literals import LDAP_RELATION
+from single_kernel_postgresql.core.state import CharmState
+from single_kernel_postgresql.lib.charms.glauth_k8s.v0.ldap import (
+    LdapProviderData,
+    LdapReadyEvent,
+    LdapRequirer,
+    LdapUnavailableEvent,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class LDAP(Object):
+    """In this class, we manage PostgreSQL LDAP access."""
+
+    def __init__(self, charm, state: CharmState):
+        super().__init__(charm, "ldap")
+        self.charm = charm
+        self.state = state
+
+        # LDAP relation handles the config options for LDAP access
+        self.ldap = LdapRequirer(self.charm, LDAP_RELATION)
+        self.framework.observe(self.ldap.on.ldap_ready, self._on_ldap_ready)
+        self.framework.observe(self.ldap.on.ldap_unavailable, self._on_ldap_unavailable)
+
+    @property
+    def _relation(self) -> Relation | None:
+        """Return the relation object."""
+        return self.model.get_relation(LDAP_RELATION)
+
+    def _on_ldap_ready(self, _: LdapReadyEvent) -> None:
+        """Handler for the LDAP ready event."""
+        logger.debug("Enabling LDAP connection")
+        if self.charm.unit.is_leader():
+            self.state.application.data.update({"ldap_enabled": "True"})
+
+        self.charm.update_config()
+        self.charm.set_unit_status(ActiveStatus())
+
+    def _on_ldap_unavailable(self, _: LdapUnavailableEvent) -> None:
+        """Handler for the LDAP unavailable event."""
+        logger.debug("Disabling LDAP connection")
+        if self.charm.unit.is_leader():
+            self.state.application.data.update({"ldap_enabled": "False"})
+
+        self.charm.update_config()
+
+    def get_relation_data(self) -> LdapProviderData | None:
+        """Get the LDAP info from the LDAP Provider class."""
+        data = self.ldap.consume_ldap_relation_data(relation=self._relation)
+        if data is None:
+            logger.warning("LDAP relation is not ready")
+
+        if not self.state.peer.is_connectivity_enabled:
+            logger.warning("LDAP server will not be accessible")
+
+        return data
+
+    def get_ldap_parameters(self) -> dict[str, Any]:
+        """Returns the LDAP configuration to use."""
+        if not self.state.application.is_cluster_initialised:
+            return {}
+        if not self.state.application.is_ldap_charm_related:
+            logger.debug("LDAP is not enabled")
+            return {}
+
+        relation_data = self.get_relation_data()
+        if relation_data is None:
+            return {}
+
+        return {
+            "ldapbasedn": relation_data.base_dn,
+            "ldapbinddn": relation_data.bind_dn,
+            "ldapbindpasswd": relation_data.bind_password,
+            "ldaptls": relation_data.starttls,
+            "ldapurl": relation_data.urls[0],
+            # LDAP authentication parameters that are exclusive to
+            # one of the two supported modes (simple bind or search+bind)
+            # must be put at the very end of the parameters string
+            "ldapsearchfilter": self.state.config.ldap_search_filter,
+        }

--- a/single_kernel_postgresql/managers/config.py
+++ b/single_kernel_postgresql/managers/config.py
@@ -40,6 +40,7 @@ from single_kernel_postgresql.workload.base import BaseWorkload, ResourceProvide
 
 if TYPE_CHECKING:
     # Import-time only: the VM workload pulls the snap charm lib, which K8s does not ship.
+    from single_kernel_postgresql.events.ldap import LDAP
     from single_kernel_postgresql.managers.database import DatabaseManager
     from single_kernel_postgresql.workload.vm import VMWorkload
 
@@ -59,6 +60,7 @@ class ConfigManager(BaseManager):
         tls_manager: TLSManager,
         patroni_manager: PatroniManager,
         database_manager: "DatabaseManager",
+        ldap_handler: "LDAP",
         resource_provider: Callable[[], ResourceProvider],
         request_restart: Callable[[], None],
         restart_services: Callable[[], None],
@@ -66,6 +68,7 @@ class ConfigManager(BaseManager):
         super().__init__(state, workload, "config_manager")
         self.tls_manager = tls_manager
         self.patroni_manager = patroni_manager
+        self.ldap_handler = ldap_handler
         self.database_manager = database_manager
         # Resolved on use, not at construction: the K8s manager that provides it is built
         # after this manager in the charm's __init__.
@@ -470,8 +473,6 @@ class ConfigManager(BaseManager):
         # TODO add rel handler
         relations_user_databases_map: dict[str, Any] | None = None,
         # TODO add rel handler
-        ldap_parameters: dict[str, Any] | None = None,
-        # TODO add rel handler
         async_primary_cluster_endpoint: str | None = None,
         async_partner_addresses: list[str] | None = None,
         async_standby_endpoints: list[str] | None = None,
@@ -520,7 +521,7 @@ class ConfigManager(BaseManager):
             parameters=pg_parameters,
             user_databases_map=relations_user_databases_map,
             slots=replication_slots,
-            ldap_parameters=ldap_parameters,
+            ldap_parameters=self.ldap_handler.get_ldap_parameters(),
             async_primary_cluster_endpoint=async_primary_cluster_endpoint,
             async_partner_addresses=async_partner_addresses,
             async_standby_endpoints=async_standby_endpoints,

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -28,6 +28,7 @@ def config(substrate):
             resource_provider=Mock(),
             request_restart=Mock(),
             database_manager=Mock(),
+            ldap_handler=Mock(),
             restart_services=Mock(),
         )
     yield config
@@ -797,6 +798,15 @@ def test_update_config_threads_tls_flag_into_render(orchestrate, postgresql_clie
     orchestrate._is_tls.return_value = False
     orchestrate.update_config(postgresql_client, no_peers=True)
     assert orchestrate.render_patroni_yml_file.call_args.kwargs["enable_tls"] is False
+
+
+def test_update_config_sources_ldap_parameters_from_handler(orchestrate, postgresql_client):
+    """update_config pulls the LDAP auth parameters from the LDAP events handler."""
+    orchestrate.update_config(postgresql_client, no_peers=True)
+    assert (
+        orchestrate.render_patroni_yml_file.call_args.kwargs["ldap_parameters"]
+        == orchestrate.ldap_handler.get_ldap_parameters.return_value
+    )
 
 
 def test_update_config_workload_not_running_persists_tls_and_refreshes(

--- a/tests/unit/test_ldap.py
+++ b/tests/unit/test_ldap.py
@@ -1,0 +1,157 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""Tests for the LDAP events handler (single_kernel_postgresql/events/ldap.py)."""
+
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from ops.model import ActiveStatus
+from single_kernel_postgresql.lib.charms.glauth_k8s.v0.ldap import LdapProviderData
+
+
+def _set_leader(harness):
+    """Elect the unit as leader, skipping the incidental leader-elected side effects."""
+    charm = harness.charm
+    with (
+        patch.object(charm.cluster_manager, "configure_system_passwords"),
+        patch.object(charm.config_manager, "update_config"),
+    ):
+        harness.set_leader(True)
+
+
+def _add_secret(harness) -> str:
+    """Register the bind-account secret the provider would have created and grant it."""
+    secret_id = harness.add_model_secret(owner="glauth-k8s", content={"password": "password"})
+    harness.grant_secret(secret_id, harness.charm.app.name)
+    return secret_id
+
+
+def _set_provider_data(harness, rel_id: int, secret_id: str = "") -> None:
+    """Write the provider app databag the provider charm writes."""
+    with harness.hooks_disabled():
+        data = LdapProviderData(
+            auth_method="simple",
+            base_dn="dc=example,dc=net",
+            bind_dn="cn=serviceuser,dc=example,dc=net",
+            bind_password="password",
+            bind_password_secret=secret_id or None,
+            starttls=False,
+            ldaps_urls=[],
+            urls=["ldap://0.0.0.0:3893"],
+        ).model_dump(exclude_none=True)
+        harness.update_relation_data(rel_id, "glauth-k8s", data)
+
+
+def _add_ldap_relation(harness) -> int:
+    """Add an ``ldap`` relation."""
+    return harness.add_relation("ldap", "glauth-k8s")
+
+
+def _relate_provider(harness) -> int:
+    """Wire the full provider side: relation, granted secret, and provider databag."""
+    rel_id = _add_ldap_relation(harness)
+    secret_id = _add_secret(harness)
+    _set_provider_data(harness, rel_id, secret_id)
+    return rel_id
+
+
+def _patch_config(search_filter: str = "(uid=$username)"):
+    """Stub CharmState.config.
+
+    The harness fixture does not load config.yaml, so the required
+    plugin_/profile fields would fail validation on a real parse.
+    """
+    return patch(
+        "single_kernel_postgresql.core.state.CharmState.config",
+        new_callable=PropertyMock,
+        return_value=MagicMock(ldap_search_filter=search_filter),
+    )
+
+
+def test_on_ldap_ready_sets_flag_and_updates_config(harness, patch_crypto):
+    charm = harness.charm
+    _set_leader(harness)
+    with patch.object(charm.config_manager, "update_config") as update_config:
+        charm.ldap._on_ldap_ready(MagicMock())
+
+    assert charm.state.application.data["ldap_enabled"] == "True"
+    update_config.assert_called_once()
+    assert charm.unit.status == ActiveStatus()
+
+
+def test_on_ldap_ready_skips_flag_write_when_not_leader(harness):
+    charm = harness.charm
+    with patch.object(charm.config_manager, "update_config") as update_config:
+        charm.ldap._on_ldap_ready(MagicMock())
+
+    # only the leader writes the peer flag; the config update happens on every unit
+    update_config.assert_called_once()
+    assert "ldap_enabled" not in charm.state.application.data
+
+
+def test_on_ldap_unavailable_clears_flag_and_updates_config(harness, patch_crypto):
+    charm = harness.charm
+    _set_leader(harness)
+    charm.state.application.data.update({"ldap_enabled": "True"})
+    with patch.object(charm.config_manager, "update_config") as update_config:
+        charm.ldap._on_ldap_unavailable(MagicMock())
+
+    assert charm.state.application.data["ldap_enabled"] == "False"
+    update_config.assert_called_once()
+
+
+def test_get_relation_data_without_relation_is_none(harness):
+    assert harness.charm.ldap.get_relation_data() is None
+
+
+def test_get_relation_data_resolves_bind_password_from_secret(harness, patch_crypto):
+    charm = harness.charm
+    _set_leader(harness)
+    _relate_provider(harness)
+
+    data = charm.ldap.get_relation_data()
+
+    assert data is not None
+    assert data.base_dn == "dc=example,dc=net"
+    assert data.bind_dn == "cn=serviceuser,dc=example,dc=net"
+    assert data.bind_password == "password"
+    assert data.urls == ["ldap://0.0.0.0:3893"]
+    assert data.starttls is False
+
+
+def test_get_ldap_parameters_requires_initialised_cluster(harness, patch_crypto):
+    charm = harness.charm
+    _set_leader(harness)
+    charm.state.application.data.update({"ldap_enabled": "True"})
+    _relate_provider(harness)
+
+    assert charm.ldap.get_ldap_parameters() == {}
+
+
+def test_get_ldap_parameters_requires_flag(harness, patch_crypto):
+    charm = harness.charm
+    _set_leader(harness)
+    charm.state.application.data.update({"cluster_initialised": "True"})
+    _relate_provider(harness)
+
+    assert charm.ldap.get_ldap_parameters() == {}
+
+
+def test_get_ldap_parameters_maps_provider_data(harness, patch_crypto):
+    charm = harness.charm
+    _set_leader(harness)
+    charm.state.application.data.update({"cluster_initialised": "True", "ldap_enabled": "True"})
+    _relate_provider(harness)
+
+    with _patch_config() as config:
+        parameters = charm.ldap.get_ldap_parameters()
+
+    assert parameters == {
+        "ldapbasedn": "dc=example,dc=net",
+        "ldapbinddn": "cn=serviceuser,dc=example,dc=net",
+        "ldapbindpasswd": "password",
+        "ldaptls": False,
+        "ldapurl": "ldap://0.0.0.0:3893",
+        "ldapsearchfilter": config.return_value.ldap_search_filter,
+    }
+    # exclusive simple-bind/search+bind parameters must sit at the very end
+    assert list(parameters)[-1] == "ldapsearchfilter"

--- a/uv.lock
+++ b/uv.lock
@@ -1156,7 +1156,7 @@ wheels = [
 
 [[package]]
 name = "postgresql-charms-single-kernel"
-version = "16.3.7"
+version = "16.3.8"
 source = { editable = "." }
 dependencies = [
     { name = "ops", version = "2.23.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Issue

Part of the LDAP module migration from the PostgreSQL VM and K8s charms' 16/edge branches into this library. Stacks on #235.

## Solution

Ports the charms' LDAP module as a single substrate-neutral events handler: it owns the `ldap` requirer relation, flips the leader-only `ldap_enabled` peer flag on ready/unavailable, and maps the provider relation data to the Patroni LDAP auth parameters (`ldapbasedn`, `ldapbinddn`, `ldapbindpasswd`, `ldaptls`, `ldapurl`, `ldapsearchfilter` — the exclusive simple-bind/search+bind parameter last, matching the charms).

`ConfigManager.update_config` now sources the parameters from the injected handler instead of taking an `ldap_parameters` argument every charm had to thread through on each call, mirroring how the client-relation mapping caches were internalized in the config manager. The substrate-specific ldap-sync sidecar restart stays behind the existing `restart_services` charm bridge.

Tests ported from the charms' `test_ldap.py` onto this repo's dual-substrate harness fixture; the secret grant and config stubs are adapted to the harness fixture here (it does not load the test charms' `config.yaml`).

Also bumps the library patch version to 16.3.8 (`pyproject.toml` and `uv.lock`).

## Consumers

This PR is consumed by the charm-side LDAP work, which pins the library at this version:

- canonical/postgresql-k8s-operator#1723 (K8s charm, stacking on #1722)
- canonical/postgresql-operator#1936 (VM charm, stacking on #1935)

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
