### PR TITLE
fix(config): quote IPv6 hosts in URL authorities and render IPv6 pg_hba rules

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
   unit-test:
     name: Unit test charm
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/single_kernel_postgresql/core/state.py
+++ b/single_kernel_postgresql/core/state.py
@@ -40,7 +40,7 @@ from single_kernel_postgresql.lib.charms.data_platform_libs.v0.data_interfaces i
     DataPeerData,
     DataPeerUnitData,
 )
-from single_kernel_postgresql.utils import unit_name_to_pod_name
+from single_kernel_postgresql.utils import bracket_ipv6_host, unit_name_to_pod_name
 from single_kernel_postgresql.utils.secret import translate_field_to_secret_key
 from single_kernel_postgresql.utils.status import format_status
 
@@ -219,7 +219,7 @@ class CharmState(Object):
     @cached_property
     def patroni_url(self) -> str:
         """Patroni REST API URL."""
-        return f"https://{self.endpoint}:8008"
+        return f"https://{bracket_ipv6_host(self.endpoint)}:8008"
 
     @property
     def peer_members_ips(self) -> set[str]:

--- a/single_kernel_postgresql/managers/database.py
+++ b/single_kernel_postgresql/managers/database.py
@@ -35,7 +35,7 @@ from single_kernel_postgresql.lib.charms.data_platform_libs.v0.data_interfaces i
 )
 from single_kernel_postgresql.managers.base import BaseManager
 from single_kernel_postgresql.managers.patroni import ClusterMember
-from single_kernel_postgresql.utils import label2name, new_password
+from single_kernel_postgresql.utils import bracket_ipv6_host, label2name, new_password
 from single_kernel_postgresql.utils.postgresql import (
     ACCESS_GROUP_RELATION,
     ACCESS_GROUPS,
@@ -441,21 +441,23 @@ class DatabaseManager(BaseManager):
                 # A stale leader unit without a peer address publishes "None:5432",
                 # as the charm did.
                 primary_unit_ip = self.state.unit_database_address(unit, self.relation_name)
-                rw_endpoint = f"{primary_unit_ip}:{DATABASE_PORT}"
+                rw_endpoint = f"{bracket_ipv6_host(primary_unit_ip)}:{DATABASE_PORT}"
             else:
                 replica_ip = self.state.unit_database_address(unit, self.relation_name)
                 if not replica_ip:
                     continue
                 if ro_hosts:
-                    ro_hosts = f"{ro_hosts},{replica_ip}"
-                    ro_endpoints = f"{ro_endpoints},{replica_ip}:{DATABASE_PORT}"
+                    ro_hosts = f"{ro_hosts},{bracket_ipv6_host(replica_ip)}"
+                    ro_endpoints = (
+                        f"{ro_endpoints},{bracket_ipv6_host(replica_ip)}:{DATABASE_PORT}"
+                    )
                 else:
-                    ro_hosts = replica_ip
-                    ro_endpoints = f"{replica_ip}:{DATABASE_PORT}"
+                    ro_hosts = bracket_ipv6_host(replica_ip) or ""
+                    ro_endpoints = f"{bracket_ipv6_host(replica_ip)}:{DATABASE_PORT}"
         if not ro_hosts and primary_unit_ip:
             # If there are no replicas, fallback to primary
             ro_endpoints = rw_endpoint
-            ro_hosts = primary_unit_ip
+            ro_hosts = bracket_ipv6_host(primary_unit_ip) or ""
         return rw_endpoint, ro_endpoints, ro_hosts
 
     def _k8s_endpoints(self) -> tuple[str, str, str]:

--- a/single_kernel_postgresql/managers/patroni.py
+++ b/single_kernel_postgresql/managers/patroni.py
@@ -60,7 +60,12 @@ from single_kernel_postgresql.config.literals import (
 from single_kernel_postgresql.config.statuses import GeneralStatuses
 from single_kernel_postgresql.core.state import CharmState
 from single_kernel_postgresql.managers.base import BaseManager
-from single_kernel_postgresql.utils import _change_owner, label2name, parallel_patroni_get_request
+from single_kernel_postgresql.utils import (
+    _change_owner,
+    bracket_ipv6_host,
+    label2name,
+    parallel_patroni_get_request,
+)
 from single_kernel_postgresql.workload.base import BaseWorkload
 
 logger = logging.getLogger(__name__)
@@ -850,7 +855,7 @@ class PatroniManager(BaseManager):
             for attempt in Retrying(stop=stop_after_delay(10), wait=wait_fixed(1)):
                 with attempt:
                     r = requests.get(
-                        f"https://{self.state.primary_endpoint}:8008/health",
+                        f"https://{bracket_ipv6_host(self.state.primary_endpoint)}:8008/health",
                         verify=self.verify,
                         auth=self._patroni_auth,
                         timeout=API_REQUEST_TIMEOUT,

--- a/single_kernel_postgresql/templates/patroni.yml.j2
+++ b/single_kernel_postgresql/templates/patroni.yml.j2
@@ -168,7 +168,9 @@ bootstrap:
   {%- if not is_vm %}
   pg_hba:
   - {{ hba_type }} all all 0.0.0.0/0 {{ instance_password_encryption }}
+  - {{ hba_type }} all all ::/0 {{ instance_password_encryption }}
   - {{ hba_type }} replication replication 127.0.0.1/32 scram-sha-256
+  - {{ hba_type }} replication replication ::1/128 scram-sha-256
   {%- for endpoint in extra_replication_endpoints %}
   - {{ hba_type }} replication replication {{ endpoint }}/32 scram-sha-256
   {%- endfor %}
@@ -220,23 +222,31 @@ postgresql:
     - local all monitoring password
     {%- for role in ['charmed_stats', 'charmed_read', 'charmed_dml', 'charmed_backup', 'charmed_dba', 'charmed_admin', 'charmed_databases_owner'] %}
     - {{ hba_type }} all +{{ role }} 0.0.0.0/0 scram-sha-256
+    - {{ hba_type }} all +{{ role }} ::/0 scram-sha-256
     {%- endfor %}
     {%- if not connectivity %}
-    - {{ hba_type }} all all {{ self_ip ~ '/32' if is_vm else endpoint ~ '.' ~ namespace ~ '.svc.cluster.local' }} {{ instance_password_encryption }}
+    - {{ hba_type }} all all {{ self_ip ~ ('/128' if ':' in self_ip else '/32') if is_vm else endpoint ~ '.' ~ namespace ~ '.svc.cluster.local' }} {{ instance_password_encryption }}
     - {{ hba_type }} all all 0.0.0.0/0 reject
+    - {{ hba_type }} all all ::/0 reject
     {%- elif enable_ldap %}
     - {{ hba_type }} all +identity_access 0.0.0.0/0 ldap {{ ldap_parameters }}
+    - {{ hba_type }} all +identity_access ::/0 ldap {{ ldap_parameters }}
     - {{ hba_type }} all +internal_access 0.0.0.0/0 {{ instance_password_encryption }}
+    - {{ hba_type }} all +internal_access ::/0 {{ instance_password_encryption }}
     {%-   for user, databases in user_databases_map.items() %}
     - {{ hba_type }} {{ databases }} {{ user }} 0.0.0.0/0 {{ instance_password_encryption }}
+    - {{ hba_type }} {{ databases }} {{ user }} ::/0 {{ instance_password_encryption }}
     {%-   endfor %}
     {%- else %}
     - {{ hba_type }} all +internal_access 0.0.0.0/0 {{ instance_password_encryption }}
+    - {{ hba_type }} all +internal_access ::/0 {{ instance_password_encryption }}
     {%-   for user, databases in user_databases_map.items() %}
     {%-     if 'pgbouncer_auth_relation_' in user %}
     - {{ hba_type }} {{ databases }} {{ user }} 0.0.0.0/0 md5
+    - {{ hba_type }} {{ databases }} {{ user }} ::/0 md5
     {%-     else %}
     - {{ hba_type }} {{ databases }} {{ user }} 0.0.0.0/0 {{ instance_password_encryption }}
+    - {{ hba_type }} {{ databases }} {{ user }} ::/0 {{ instance_password_encryption }}
     {%-     endif %}
     {%-   endfor %}
     {%- endif %}
@@ -245,6 +255,7 @@ postgresql:
     - {{ hba_type }} postgres watcher {{ watcher_addr }}/32 scram-sha-256
     {%- endif %}
     - {{ hba_type }} replication replication 127.0.0.1/32 scram-sha-256
+    - {{ hba_type }} replication replication ::1/128 scram-sha-256
     {%- if not is_vm %}
     - {{ hba_type }} replication replication 127.0.0.6/32 scram-sha-256
     {%- endif %}

--- a/single_kernel_postgresql/utils/__init__.py
+++ b/single_kernel_postgresql/utils/__init__.py
@@ -108,6 +108,21 @@ def label2name(label: str) -> str:
     return "/".join(label.rsplit("-", 1))
 
 
+def bracket_ipv6_host(host: str | None) -> str | None:
+    """Quote an IPv6 literal so it is valid in a URL authority (RFC 3986).
+
+    An IPv6 literal in a URL must be bracketed, otherwise the client parses
+    the address at the first colon. Other hosts (and None) pass through.
+
+    Args:
+        host: a bare host name or address, or None.
+
+    Returns:
+        The host, bracketed when it is an IPv6 literal.
+    """
+    return f"[{host}]" if host and ":" in host else host
+
+
 def render_file(
     substrate: Substrates, path: str, content: str, mode: int, change_owner: bool = True
 ) -> None:
@@ -188,7 +203,9 @@ async def _async_get_request(
     uri: str, endpoints: list[str], cafile: str, auth: BasicAuth | None, verify: bool = True
 ) -> dict[str, Any] | None:
     tasks = [
-        create_task(_httpx_get_request(f"https://{ip}:8008{uri}", cafile, auth, verify))
+        create_task(
+            _httpx_get_request(f"https://{bracket_ipv6_host(ip)}:8008{uri}", cafile, auth, verify)
+        )
         for ip in endpoints
     ]
     for task in as_completed(tasks):

--- a/tests/fixtures/patroni_k8s_original.j2
+++ b/tests/fixtures/patroni_k8s_original.j2
@@ -92,7 +92,9 @@ bootstrap:
   {%- endif %}
   pg_hba:
   - {{ 'hostssl' if enable_tls else 'host' }} all all 0.0.0.0/0 {{ instance_password_encryption }}
+  - {{ 'hostssl' if enable_tls else 'host' }} all all ::/0 {{ instance_password_encryption }}
   - {{ 'hostssl' if enable_tls else 'host' }} replication replication 127.0.0.1/32 scram-sha-256
+  - {{ 'hostssl' if enable_tls else 'host' }} replication replication ::1/128 scram-sha-256
   {%- for endpoint in extra_replication_endpoints %}
   - {{ 'hostssl' if enable_tls else 'host' }} replication replication {{ endpoint }}/32 scram-sha-256
   {%- endfor %}
@@ -153,32 +155,47 @@ postgresql:
   - local all backup peer map=operator
   - local all monitoring password
   - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_stats 0.0.0.0/0 scram-sha-256
+  - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_stats ::/0 scram-sha-256
   - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_read 0.0.0.0/0 scram-sha-256
+  - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_read ::/0 scram-sha-256
   - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_dml 0.0.0.0/0 scram-sha-256
+  - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_dml ::/0 scram-sha-256
   - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_backup 0.0.0.0/0 scram-sha-256
+  - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_backup ::/0 scram-sha-256
   - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_dba 0.0.0.0/0 scram-sha-256
+  - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_dba ::/0 scram-sha-256
   - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_admin 0.0.0.0/0 scram-sha-256
+  - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_admin ::/0 scram-sha-256
   - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_databases_owner 0.0.0.0/0 scram-sha-256
+  - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_databases_owner ::/0 scram-sha-256
   {%- if not connectivity %}
   - {{ 'hostssl' if enable_tls else 'host' }} all all {{ endpoint }}.{{ namespace }}.svc.cluster.local {{ instance_password_encryption }}
   - {{ 'hostssl' if enable_tls else 'host' }} all all 0.0.0.0/0 reject
+  - {{ 'hostssl' if enable_tls else 'host' }} all all ::/0 reject
   {%- elif enable_ldap %}
   - {{ 'hostssl' if enable_tls else 'host' }} all +identity_access 0.0.0.0/0 ldap {{ ldap_parameters }}
+  - {{ 'hostssl' if enable_tls else 'host' }} all +identity_access ::/0 ldap {{ ldap_parameters }}
   - {{ 'hostssl' if enable_tls else 'host' }} all +internal_access 0.0.0.0/0 {{ instance_password_encryption }}
+  - {{ 'hostssl' if enable_tls else 'host' }} all +internal_access ::/0 {{ instance_password_encryption }}
   {%-   for user, databases in user_databases_map.items() %}
   - {{ 'hostssl' if enable_tls else 'host' }} {{ databases }} {{ user }} 0.0.0.0/0 {{ instance_password_encryption }}
+  - {{ 'hostssl' if enable_tls else 'host' }} {{ databases }} {{ user }} ::/0 {{ instance_password_encryption }}
   {%-   endfor %}
   {%- else %}
   - {{ 'hostssl' if enable_tls else 'host' }} all +internal_access 0.0.0.0/0 {{ instance_password_encryption }}
+  - {{ 'hostssl' if enable_tls else 'host' }} all +internal_access ::/0 {{ instance_password_encryption }}
   {%-   for user, databases in user_databases_map.items() %}
   {%-     if 'pgbouncer_auth_relation_' in user %}
   - {{ 'hostssl' if enable_tls else 'host' }} {{ databases }} {{ user }} 0.0.0.0/0 md5
+  - {{ 'hostssl' if enable_tls else 'host' }} {{ databases }} {{ user }} ::/0 md5
   {%-     else %}
   - {{ 'hostssl' if enable_tls else 'host' }} {{ databases }} {{ user }} 0.0.0.0/0 {{ instance_password_encryption }}
+  - {{ 'hostssl' if enable_tls else 'host' }} {{ databases }} {{ user }} ::/0 {{ instance_password_encryption }}
   {%-     endif %}
   {%-   endfor %}
   {%- endif %}
   - {{ 'hostssl' if enable_tls else 'host' }} replication replication 127.0.0.1/32 scram-sha-256
+  - {{ 'hostssl' if enable_tls else 'host' }} replication replication ::1/128 scram-sha-256
   - {{ 'hostssl' if enable_tls else 'host' }} replication replication 127.0.0.6/32 scram-sha-256
   {%- for endpoint in extra_replication_endpoints %}
   - {{ 'hostssl' if enable_tls else 'host' }} replication replication {{ endpoint }}/32 scram-sha-256

--- a/tests/fixtures/patroni_vm_original.j2
+++ b/tests/fixtures/patroni_vm_original.j2
@@ -178,28 +178,42 @@ postgresql:
     - local all operator scram-sha-256
     - local all monitoring password
     - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_stats 0.0.0.0/0 scram-sha-256
+    - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_stats ::/0 scram-sha-256
     - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_read 0.0.0.0/0 scram-sha-256
+    - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_read ::/0 scram-sha-256
     - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_dml 0.0.0.0/0 scram-sha-256
+    - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_dml ::/0 scram-sha-256
     - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_backup 0.0.0.0/0 scram-sha-256
+    - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_backup ::/0 scram-sha-256
     - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_dba 0.0.0.0/0 scram-sha-256
+    - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_dba ::/0 scram-sha-256
     - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_admin 0.0.0.0/0 scram-sha-256
+    - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_admin ::/0 scram-sha-256
     - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_databases_owner 0.0.0.0/0 scram-sha-256
+    - {{ 'hostssl' if enable_tls else 'host' }} all +charmed_databases_owner ::/0 scram-sha-256
     {%- if not connectivity %}
-    - {{ 'hostssl' if enable_tls else 'host' }} all all {{ self_ip }}/32 {{ instance_password_encryption }}
+    - {{ 'hostssl' if enable_tls else 'host' }} all all {{ self_ip ~ ('/128' if ':' in self_ip else '/32') }} {{ instance_password_encryption }}
     - {{ 'hostssl' if enable_tls else 'host' }} all all 0.0.0.0/0 reject
+    - {{ 'hostssl' if enable_tls else 'host' }} all all ::/0 reject
     {%- elif enable_ldap %}
     - {{ 'hostssl' if enable_tls else 'host' }} all +identity_access 0.0.0.0/0 ldap {{ ldap_parameters }}
+    - {{ 'hostssl' if enable_tls else 'host' }} all +identity_access ::/0 ldap {{ ldap_parameters }}
     - {{ 'hostssl' if enable_tls else 'host' }} all +internal_access 0.0.0.0/0 {{ instance_password_encryption }}
+    - {{ 'hostssl' if enable_tls else 'host' }} all +internal_access ::/0 {{ instance_password_encryption }}
     {%-   for user, databases in user_databases_map.items() %}
     - {{ 'hostssl' if enable_tls else 'host' }} {{ databases }} {{ user }} 0.0.0.0/0 {{ instance_password_encryption }}
+    - {{ 'hostssl' if enable_tls else 'host' }} {{ databases }} {{ user }} ::/0 {{ instance_password_encryption }}
     {%-   endfor %}
     {%- else %}
     - {{ 'hostssl' if enable_tls else 'host' }} all +internal_access 0.0.0.0/0 {{ instance_password_encryption }}
+    - {{ 'hostssl' if enable_tls else 'host' }} all +internal_access ::/0 {{ instance_password_encryption }}
     {%-   for user, databases in user_databases_map.items() %}
     {%-     if 'pgbouncer_auth_relation_' in user %}
     - {{ 'hostssl' if enable_tls else 'host' }} {{ databases }} {{ user }} 0.0.0.0/0 md5
+    - {{ 'hostssl' if enable_tls else 'host' }} {{ databases }} {{ user }} ::/0 md5
     {%-     else %}
     - {{ 'hostssl' if enable_tls else 'host' }} {{ databases }} {{ user }} 0.0.0.0/0 {{ instance_password_encryption }}
+    - {{ 'hostssl' if enable_tls else 'host' }} {{ databases }} {{ user }} ::/0 {{ instance_password_encryption }}
     {%-     endif %}
     {%-   endfor %}
     {%- endif %}
@@ -208,6 +222,7 @@ postgresql:
     - {{ 'hostssl' if enable_tls else 'host' }} postgres watcher {{ watcher_addr }}/32 scram-sha-256
     {%- endif %}
     - {{ 'hostssl' if enable_tls else 'host' }} replication replication 127.0.0.1/32 scram-sha-256
+    - {{ 'hostssl' if enable_tls else 'host' }} replication replication ::1/128 scram-sha-256
     # Allow replications connections from other cluster members.
     {%- for endpoint in extra_replication_endpoints %}
     - {{ 'hostssl' if enable_tls else 'host' }} replication replication {{ endpoint }}/32 scram-sha-256

--- a/tests/unit/test_database_manager.py
+++ b/tests/unit/test_database_manager.py
@@ -560,6 +560,34 @@ def test_update_endpoints_falls_back_to_the_primary_without_replicas(manager, ha
     assert data["read-only-endpoints"] == "1.1.1.1:5432"
 
 
+def test_update_endpoints_brackets_ipv6_addresses(manager, harness, substrate):
+    if substrate == "k8s":
+        pytest.skip("K8s endpoints are DNS names, not bare IPv6 literals")
+    rel_id = harness.model.get_relation(RELATION_NAME).id
+    peer_rel_id = harness.model.get_relation(PEER_RELATION).id
+    with harness.hooks_disabled():
+        harness.update_relation_data(rel_id, "application", {"database": "test_db"})
+        harness.update_relation_data(
+            peer_rel_id,
+            "postgresql-single-kernel/0",
+            {f"{RELATION_NAME}-address": "fd42:a615:ea50:2a68:216:3eff:fef1:6b2"},
+        )
+
+    with (
+        patch.object(
+            manager.database_provides,
+            "fetch_my_relation_data",
+            return_value={rel_id: {"username": "u", "password": "pw"}},
+        ),
+    ):
+        manager.update_endpoints(rel_id, online_members=CLUSTER_STATUS[:1])
+
+    data = harness.get_relation_data(rel_id, harness.charm.app.name)
+    assert data["endpoints"] == "[fd42:a615:ea50:2a68:216:3eff:fef1:6b2]:5432"
+    assert data["read-only-endpoints"] == "[fd42:a615:ea50:2a68:216:3eff:fef1:6b2]:5432"
+    assert data["uris"] == "postgresql://u:pw@[fd42:a615:ea50:2a68:216:3eff:fef1:6b2]:5432/test_db"
+
+
 def test_update_endpoints_publishes_the_primary_ip_verbatim(manager, harness, substrate):
     """A leader unit without a peer address publishes "None:5432", exactly as the charm did."""
     if substrate == "k8s":

--- a/tests/unit/test_patroni_manager.py
+++ b/tests/unit/test_patroni_manager.py
@@ -976,3 +976,40 @@ def test_primary_endpoint_ready(substrate, patroni):
         # Test with the primary endpoint ready.
         _get.return_value.json.return_value = {"state": "running"}
         assert patroni.primary_endpoint_ready
+
+
+def test_primary_endpoint_ready_brackets_ipv6(substrate, patroni):
+    if substrate == Substrates.VM:
+        pytest.skip("K8s only")
+        return
+    with (
+        patch(
+            "single_kernel_postgresql.managers.patroni.stop_after_delay",
+            return_value=stop_after_delay(0),
+        ),
+        patch(
+            "single_kernel_postgresql.managers.patroni.wait_fixed",
+            return_value=wait_fixed(0),
+        ),
+        patch(
+            "single_kernel_postgresql.core.state.CharmState.primary_endpoint",
+            new_callable=PropertyMock,
+            return_value="fd42:a615:ea50:2a68:216:3eff:fef1:6b2",
+        ),
+        patch(
+            "single_kernel_postgresql.core.peer_relation.PostgreSQLApplication.patroni_password",
+            new_callable=PropertyMock,
+            return_value="test-pass",
+        ),
+        patch("requests.get") as _get,
+    ):
+        _get.return_value.json.return_value = {"state": "running"}
+
+        assert patroni.primary_endpoint_ready
+
+        _get.assert_called_once_with(
+            "https://[fd42:a615:ea50:2a68:216:3eff:fef1:6b2]:8008/health",
+            verify=patroni.verify,
+            auth=patroni._patroni_auth,
+            timeout=API_REQUEST_TIMEOUT,
+        )

--- a/tests/unit/test_patroni_template.py
+++ b/tests/unit/test_patroni_template.py
@@ -202,6 +202,36 @@ def test_merged_template_matches_original(substrate, overrides):
     assert yaml.safe_load(actual) == yaml.safe_load(expected)
 
 
+def test_vm_pg_hba_matches_ipv6_clients():
+    """IPv6-bound units must render pg_hba rules matching IPv6 clients.
+
+    The bootstrap role creation connects over TCP from the unit's own IPv6
+    address; with IPv4-only rules PostgreSQL rejects it with FATAL 28000 and
+    Patroni cancels the bootstrap.
+    """
+    context = _base_context() | {
+        "connectivity": True,
+        "self_ip": "fd42:1928:642:0:216:3eff:fedc:283b",
+    }
+    rendered = yaml.safe_load(_MERGED_TEMPLATE.render(substrate="vm", **context))
+    hba = rendered["postgresql"]["pg_hba"]
+    assert "host all +internal_access ::/0 scram-sha-256" in hba
+    assert "host all +charmed_admin ::/0 scram-sha-256" in hba
+    assert "host replication replication ::1/128 scram-sha-256" in hba
+
+
+def test_vm_self_rule_uses_the_ipv6_prefix_length():
+    context = _base_context() | {
+        "connectivity": False,
+        "self_ip": "fd42:1928:642:0:216:3eff:fedc:283b",
+    }
+    rendered = yaml.safe_load(_MERGED_TEMPLATE.render(substrate="vm", **context))
+    hba = rendered["postgresql"]["pg_hba"]
+    assert any(
+        rule == "host all all fd42:1928:642:0:216:3eff:fedc:283b/128 scram-sha-256" for rule in hba
+    )
+
+
 def test_template_loads_via_importlib_resources():
     """The merged template must resolve as package data, independent of the CWD."""
     source = _merged_template_source()

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -1,0 +1,30 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from unittest.mock import Mock
+
+from single_kernel_postgresql.config.enums import Substrates
+from single_kernel_postgresql.core.state import CharmState
+
+
+def test_patroni_url_brackets_ipv6_endpoint():
+    """An IPv6 unit address must be bracketed in the Patroni REST API URL."""
+    mock_charm = Mock()
+    binding = Mock()
+    binding.network.bind_address = "fd42:a615:ea50:2a68:216:3eff:fef1:6b2"
+    mock_charm.framework.model.get_binding.return_value = binding
+
+    state = CharmState(charm=mock_charm, substrate=Substrates.VM)
+
+    assert state.patroni_url == "https://[fd42:a615:ea50:2a68:216:3eff:fef1:6b2]:8008"
+
+
+def test_patroni_url_keeps_ipv4_endpoint_unbracketed():
+    mock_charm = Mock()
+    binding = Mock()
+    binding.network.bind_address = "192.0.2.10"
+    mock_charm.framework.model.get_binding.return_value = binding
+
+    state = CharmState(charm=mock_charm, substrate=Substrates.VM)
+
+    assert state.patroni_url == "https://192.0.2.10:8008"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2,8 +2,9 @@
 # See LICENSE file for licensing details.
 
 import re
-from unittest.mock import mock_open, patch
+from unittest.mock import AsyncMock, mock_open, patch
 
+import httpx
 from single_kernel_postgresql.config.enums import Substrates
 from single_kernel_postgresql.utils import (
     any_cpu_to_cores,
@@ -11,6 +12,7 @@ from single_kernel_postgresql.utils import (
     create_directory,
     label2name,
     new_password,
+    parallel_patroni_get_request,
     render_file,
 )
 
@@ -105,3 +107,22 @@ def test_create_directory():
         _chmod.assert_called_once_with("test", 0o640)
         _chown.assert_called_once_with("test", uid=35, gid=35)
         _pwnam.assert_called_with("postgres")
+
+
+def test_parallel_patroni_get_request_brackets_ipv6_endpoints():
+    endpoints = ["fd42:a615:ea50:2a68:216:3eff:fef1:6b2", "192.0.2.10"]
+    with patch(
+        "single_kernel_postgresql.utils._httpx_get_request", new_callable=AsyncMock
+    ) as mock_get:
+        mock_get.return_value = {"members": []}
+        parallel_patroni_get_request("/_cluster", endpoints, "cafile")
+
+    urls = [call.args[0] for call in mock_get.await_args_list]
+    assert urls == [
+        "https://[fd42:a615:ea50:2a68:216:3eff:fef1:6b2]:8008/_cluster",
+        "https://192.0.2.10:8008/_cluster",
+    ]
+    # The unbracketed IPv6 form is rejected by the HTTP client (httpx.InvalidURL),
+    # which is not caught by the request helper's error handling.
+    for url in urls:
+        httpx.URL(url)


### PR DESCRIPTION
## Issue

On a Juju model whose peer relation binding resolves to an IPv6 address, the charm cannot deploy: `leader-elected` fails with `httpx.InvalidURL: Invalid port: '...:8008'` and the unit loops in hook-failed. Canonical issue: canonical/postgresql-operator#1928 (internal DPE-11019).

Two causes in the shared library:

1. URLs to the Patroni REST API are built by interpolating the bare address (`https://{ip}:8008/...`). An IPv6 literal must be bracketed in a URL authority; without brackets the client parses the address at the first colon and rejects the URL. httpx raises `InvalidURL`, which subclasses neither `HTTPError` nor `ValueError`, so the request helper's existing error handling does not contain it.
2. The rendered `pg_hba.conf` contains only IPv4 CIDRs (`0.0.0.0/0`, `127.0.0.1/32`). On an IPv6 deployment Patroni's own superuser connection (bootstrap role creation) arrives from the unit's IPv6 address, matches no rule, and PostgreSQL rejects it with `FATAL 28000` — Patroni's async bootstrap marks the task failed and the next HA cycle cancels the initialization, wiping the data dir and looping (~7 s cadence). IPv4 deployments never hit this because `0.0.0.0/0` matches any IPv4 client.

## Solution

- `bracket_ipv6_host()` in `utils`: quotes IPv6 literals (`/128`-safe) for URL authorities; applied at the Patroni REST request site, the `patroni_url` state property, the primary health check, and the client-facing endpoints/URIs. IPv4 addresses, hostnames and `None` pass through unchanged, preserving the intentional `"None:5432"` publication for stale leaders.
- `templates/patroni.yml.j2`: every IPv4 pg_hba rule now emits an IPv6 twin (`::/0`, `::1/128` for loopback), and the connectivity-off self rule uses family-aware prefix lengths (`/128` for IPv6 literals instead of the malformed `/32`).

Golden fixtures updated in lockstep; the render matrix asserts the IPv6 rules on both substrates, and both changes are covered by unit tests (URL bracketing: IPv6 bracketed, IPv4/hostname/`None` untouched; pg_hba: IPv6 client rules present per substrate and family-aware self masks).

## Checklist

- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
