### PR TITLE
feat(backups): workload run_cmd, by-name service control, and pgbackrest log paths (1/19)

### DIFF
--- a/single_kernel_postgresql/config/literals.py
+++ b/single_kernel_postgresql/config/literals.py
@@ -13,6 +13,7 @@ POSTGRESQL_STORAGE_PERMISSIONS = 0o700
 # Relations
 PEER_RELATION = "database-peers"
 STATUS_PEERS_RELATION = "status-peers"
+S3_RELATION_NAME = "s3-parameters"
 
 # Users.
 BACKUP_USER = "backup"
@@ -34,9 +35,11 @@ VM_DATA_PATH = "var/lib/postgresql"
 VM_ARCHIVE_PATH = "data/archive"
 VM_DATA_LOGS_PATH = "data/logs"
 VM_TEMP_PATH = "data/temp"
+VM_PGBACKREST_LOGS_PATH = "var/log/pgbackrest"
 
 ## K8s Paths
 K8S_DATA_PATH = "var/lib/pg/data"
+K8S_PGBACKREST_LOGS_PATH = "16/main/pgbackrest_logs"
 
 ## Shared Paths
 # NOTE: The paths don't have leading slahes since pathops
@@ -178,3 +181,4 @@ RAFT_PARTNER_PREFIX = "partner_node_status_server_"
 # VM services
 VM_PATRONI_SERVICE_NAME = "snap.charmed-postgresql.patroni.service"
 VM_PATRONI_SERVICE_DEFAULT_PATH = f"/etc/systemd/system/{VM_PATRONI_SERVICE_NAME}"
+VM_PGBACKREST_SERVICE_NAME = "pgbackrest-service"

--- a/single_kernel_postgresql/workload/base.py
+++ b/single_kernel_postgresql/workload/base.py
@@ -8,8 +8,8 @@ import pathlib
 from abc import ABC, abstractmethod
 from collections.abc import Generator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Protocol
 
 import tomli
@@ -21,6 +21,26 @@ from ops.pebble import Error as PebbleError
 from single_kernel_postgresql.config.exceptions import PostgreSQLFileOperationError
 from single_kernel_postgresql.config.literals import DIR_PERMISSIONS_READONLY
 from single_kernel_postgresql.workload.paths.base import Paths
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    """Normalized result of a workload command execution."""
+
+    return_code: int
+    stdout: str = ""
+    stderr: str = ""
+
+    @property
+    def ok(self) -> bool:
+        """Whether the command succeeded (return code 0)."""
+        return self.return_code == 0
+
+    def __repr__(self) -> str:
+        """Return a compact representation, truncating long streams."""
+        stdout = repr(self.stdout[:50]) if len(self.stdout) > 50 else repr(self.stdout)
+        stderr = repr(self.stderr[:50]) if len(self.stderr) > 50 else repr(self.stderr)
+        return f"CommandResult(return_code={self.return_code}, stdout={stdout}, stderr={stderr})"
 
 
 class ResourceProvider(Protocol):
@@ -249,8 +269,21 @@ class BaseWorkload(ABC):
         args: str | None = None,
         use_errors_replace: bool = False,
         stdin: str | None = None,
-    ) -> SimpleNamespace:
-        """Run Command in CLI."""
+        timeout: float | None = None,
+    ) -> CommandResult:
+        """Run a command on the workload.
+
+        Args:
+            command: the command to run.
+            args: optional space-separated arguments for the command.
+            use_errors_replace: return a result instead of raising when the
+                command fails (non-zero exit code or unrecoverable error).
+            stdin: optional input to feed the command's standard input.
+            timeout: optional timeout in seconds.
+
+        Returns:
+            A CommandResult carrying return_code, stdout, and stderr.
+        """
         pass
 
     @abstractmethod
@@ -264,8 +297,34 @@ class BaseWorkload(ABC):
         pass
 
     @abstractmethod
-    def start_service(self):
-        """Start the PostgreSQL service."""
+    def start_service(self, service: str) -> None:
+        """Start a named service on the workload."""
+        pass
+
+    @abstractmethod
+    def stop_service(self, service: str) -> None:
+        """Stop a named service on the workload."""
+        pass
+
+    @abstractmethod
+    def restart_service(self, service: str) -> None:
+        """Restart a named service on the workload."""
+        pass
+
+    @abstractmethod
+    def reload_service(self, service: str) -> None:
+        """Reload a named service on the workload.
+
+        Sends SIGHUP where the substrate supports it; restarts otherwise.
+        """
+        pass
+
+    @abstractmethod
+    def service_is_running(self, service: str) -> bool:
+        """Check whether a named service is running on the workload.
+
+        Missing services read as not running; this never raises.
+        """
         pass
 
     @abstractmethod

--- a/single_kernel_postgresql/workload/k8s.py
+++ b/single_kernel_postgresql/workload/k8s.py
@@ -4,23 +4,24 @@
 """Kubernetes Workload."""
 
 import logging
+import shlex
+import signal
 import uuid
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
-from types import SimpleNamespace
 
 from charmlibs import pathops
 from charmlibs.pathops import PathProtocol
 from ops import Container, ModelError
-from ops.pebble import Plan, ServiceStatus
+from ops.pebble import ExecError, Plan, ServiceStatus
 
 from single_kernel_postgresql.config.exceptions import PostgreSQLFileOperationError
 from single_kernel_postgresql.config.literals import (
     DIR_PERMISSIONS_READONLY,
     K8S_POSTGRESQL_SERVICE_NAME,
 )
-from single_kernel_postgresql.workload.base import BaseWorkload
+from single_kernel_postgresql.workload.base import BaseWorkload, CommandResult
 from single_kernel_postgresql.workload.paths.base import Paths as BasePaths
 from single_kernel_postgresql.workload.paths.k8s import K8sPaths
 
@@ -93,9 +94,31 @@ class K8sWorkload(BaseWorkload):
         args: str | None = None,
         use_errors_replace: bool = False,
         stdin: str | None = None,
-    ) -> SimpleNamespace:
-        """Run Command in CLI."""
-        raise NotImplementedError
+        timeout: float | None = None,
+    ) -> CommandResult:
+        """Run a command in the workload container as the workload user and group."""
+        command_list = shlex.split(command)
+        if args:
+            command_list += shlex.split(args)
+        logger.debug("Running command %s", " ".join(command_list))
+        process = self.container.exec(
+            command_list,
+            user=self.user,
+            group=self.group,
+            timeout=timeout,
+            stdin=stdin,
+        )
+        try:
+            stdout, stderr = process.wait_output()
+        except ExecError as e:
+            if not use_errors_replace:
+                raise
+            return CommandResult(
+                return_code=e.exit_code,
+                stdout=e.stdout or "",
+                stderr=e.stderr or "",
+            )
+        return CommandResult(return_code=0, stdout=stdout, stderr=stderr)
 
     def is_failed(self) -> bool:
         """Check if snap service failed."""
@@ -105,9 +128,42 @@ class K8sWorkload(BaseWorkload):
         """Stop the PostgreSQL service."""
         ...
 
-    def start_service(self):
-        """Start the PostgreSQL service."""
-        ...
+    def start_service(self, service: str) -> None:
+        """Start a named Pebble service."""
+        self.container.start(service)
+
+    def stop_service(self, service: str) -> None:
+        """Stop a named Pebble service."""
+        self.container.stop(service)
+
+    def restart_service(self, service: str) -> None:
+        """Restart a named Pebble service."""
+        self.container.restart(service)
+
+    def reload_service(self, service: str) -> None:
+        """Reload a named Pebble service.
+
+        Sends SIGHUP to the service when it is running; restarts it otherwise.
+        """
+        if self.service_is_running(service):
+            logger.debug("Sending SIGHUP to %s to reload configuration", service)
+            self.container.send_signal(signal.SIGHUP, service)
+        else:
+            self.container.restart(service)
+
+    def service_is_running(self, service: str) -> bool:
+        """Check whether a named Pebble service is running.
+
+        A layer revision predating the service omits it from the plan; and
+        Pebble cannot be asked before the container connects. Both read as
+        not running.
+        """
+        if not self.container.can_connect():
+            return False
+        services = self.container.pebble.get_services(names=[service])
+        if len(services) == 0:
+            return False
+        return services[0].current == ServiceStatus.ACTIVE
 
     def get_workload_version(self) -> str:
         """Get the workload version."""

--- a/single_kernel_postgresql/workload/paths/base.py
+++ b/single_kernel_postgresql/workload/paths/base.py
@@ -90,6 +90,12 @@ class Paths(ABC):
 
     @property
     @abstractmethod
+    def pgbackrest_logs(self) -> PathProtocol:
+        """Path to the pgbackrest logs."""
+        pass
+
+    @property
+    @abstractmethod
     def tls(self) -> PathProtocol:
         """Directory where TLS files are written for this substrate."""
         pass

--- a/single_kernel_postgresql/workload/paths/k8s.py
+++ b/single_kernel_postgresql/workload/paths/k8s.py
@@ -6,6 +6,7 @@ from charmlibs.pathops import PathProtocol
 
 from single_kernel_postgresql.config.literals import (
     K8S_DATA_PATH,
+    K8S_PGBACKREST_LOGS_PATH,
     PATRONI_LOGS_PATH,
     PGBACKREST_CONF_PATH,
     POSTGRESQL_CONF_FILE,
@@ -82,6 +83,11 @@ class K8sPaths(Paths):
     def patroni_logs(self) -> PathProtocol:
         """Path to the patroni logs."""
         return self.logs / PATRONI_LOGS_PATH
+
+    @property
+    def pgbackrest_logs(self) -> PathProtocol:
+        """Path to the pgbackrest logs."""
+        return self.logs / K8S_PGBACKREST_LOGS_PATH
 
     @property
     def pgbackrest_conf(self) -> PathProtocol:

--- a/single_kernel_postgresql/workload/paths/vm.py
+++ b/single_kernel_postgresql/workload/paths/vm.py
@@ -17,6 +17,7 @@ from single_kernel_postgresql.config.literals import (
     VM_DATA_LOGS_PATH,
     VM_DATA_PATH,
     VM_LOGS_PATH,
+    VM_PGBACKREST_LOGS_PATH,
     VM_TEMP_PATH,
 )
 from single_kernel_postgresql.workload.paths.base import Paths
@@ -83,6 +84,11 @@ class VMPaths(Paths):
     def patroni_logs(self) -> PathProtocol:
         """Path to the patroni logs."""
         return self.snap_common / PATRONI_LOGS_PATH
+
+    @property
+    def pgbackrest_logs(self) -> PathProtocol:
+        """Path to the pgbackrest logs."""
+        return self.snap_common / VM_PGBACKREST_LOGS_PATH
 
     @property
     def data(self) -> PathProtocol:

--- a/single_kernel_postgresql/workload/vm.py
+++ b/single_kernel_postgresql/workload/vm.py
@@ -7,19 +7,19 @@ import logging
 import os
 import pathlib
 import platform
+import shlex
 import subprocess
 import tempfile
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
-from types import SimpleNamespace
 
 import charm_refresh
 import tomli
 from charmlibs import pathops, snap
 from charmlibs.pathops import PathProtocol
 
-from single_kernel_postgresql.workload.base import BaseWorkload
+from single_kernel_postgresql.workload.base import BaseWorkload, CommandResult
 from single_kernel_postgresql.workload.paths.base import Paths as BasePaths
 from single_kernel_postgresql.workload.paths.vm import VMPaths
 
@@ -137,9 +137,37 @@ class VMWorkload(BaseWorkload):
         args: str | None = None,
         use_errors_replace: bool = False,
         stdin: str | None = None,
-    ) -> SimpleNamespace:
-        """Run Command in CLI."""
-        raise NotImplementedError
+        timeout: float | None = None,
+    ) -> CommandResult:
+        """Run a command on the machine via subprocess.
+
+        The charm runs as root on VM, so the command is not executed as a
+        specific user or group.
+        """
+        cmd = shlex.split(command)
+        if args:
+            cmd += shlex.split(args)
+        try:
+            process = subprocess.run(  # noqa: S603
+                cmd,
+                input=stdin.encode() if stdin else None,
+                capture_output=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired as e:
+            if not use_errors_replace:
+                raise
+            return CommandResult(
+                return_code=124,
+                stdout=(e.stdout or b"").decode(errors="replace"),
+                stderr=(e.stderr or b"").decode(errors="replace"),
+            )
+        decode_errors = "replace" if use_errors_replace else "strict"
+        return CommandResult(
+            return_code=process.returncode,
+            stdout=process.stdout.decode(errors=decode_errors),
+            stderr=process.stderr.decode(errors=decode_errors),
+        )
 
     def is_failed(self) -> bool:
         """Check if snap service failed."""
@@ -149,9 +177,36 @@ class VMWorkload(BaseWorkload):
         """Stop the PostgreSQL service."""
         ...
 
-    def start_service(self):
-        """Start the PostgreSQL service."""
-        ...
+    def start_service(self, service: str) -> None:
+        """Start a named snap service."""
+        snap.SnapCache()["charmed-postgresql"].start(services=[service])
+
+    def stop_service(self, service: str) -> None:
+        """Stop a named snap service."""
+        snap.SnapCache()["charmed-postgresql"].stop(services=[service])
+
+    def restart_service(self, service: str) -> None:
+        """Restart a named snap service."""
+        snap.SnapCache()["charmed-postgresql"].restart(services=[service])
+
+    def reload_service(self, service: str) -> None:
+        """Reload a named snap service.
+
+        Snap has no signal channel, so a restart is the only reload.
+        """
+        self.restart_service(service)
+
+    def service_is_running(self, service: str) -> bool:
+        """Check whether a named snap service is running.
+
+        A snap revision predating the service omits it from the services
+        mapping; that reads as not running.
+        """
+        try:
+            services = snap.SnapCache()["charmed-postgresql"].services
+        except (snap.SnapError, snap.SnapNotFoundError):
+            return False
+        return services.get(service, {}).get("active", False)
 
     def get_workload_version(self) -> str:
         """Get the workload version."""

--- a/tests/unit/test_workload_services.py
+++ b/tests/unit/test_workload_services.py
@@ -1,0 +1,282 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""Tests for run_cmd, by-name service control, and pgbackrest logs paths."""
+
+import signal
+from subprocess import TimeoutExpired
+from unittest.mock import Mock, patch
+
+import pytest
+from charmlibs import pathops, snap
+from ops.pebble import ExecError, ServiceStatus
+from single_kernel_postgresql.config.enums import Substrates
+from single_kernel_postgresql.workload.base import CommandResult
+from single_kernel_postgresql.workload.k8s import K8sWorkload
+from single_kernel_postgresql.workload.paths.k8s import K8sPaths
+from single_kernel_postgresql.workload.paths.vm import VMPaths
+from single_kernel_postgresql.workload.vm import VMWorkload
+
+PGBACKREST_SERVICE = "pgbackrest-service"
+
+
+@pytest.fixture
+def workload(substrate):
+    """A workload for the substrate: real VMWorkload, K8sWorkload with a mocked container."""
+    if substrate == Substrates.VM:
+        return VMWorkload(".")
+    return K8sWorkload(".", Mock(name="container"))
+
+
+# --- run_cmd
+
+
+@patch("single_kernel_postgresql.workload.vm.subprocess.run")
+def test_vm_run_cmd_returns_code_stdout_stderr(mock_run, substrate, workload):
+    if substrate == Substrates.K8S:
+        pytest.skip("VM only")
+        return
+    mock_run.return_value = Mock(returncode=3, stdout=b"out", stderr=b"err")
+    result = workload.run_cmd("pgbackrest", args="--stanza=db info")
+    assert result == CommandResult(return_code=3, stdout="out", stderr="err")
+    assert not result.ok
+    mock_run.assert_called_once_with(
+        ["pgbackrest", "--stanza=db", "info"],
+        input=None,
+        capture_output=True,
+        timeout=None,
+    )
+
+
+@patch("single_kernel_postgresql.workload.vm.subprocess.run")
+def test_vm_run_cmd_passes_stdin_and_timeout(mock_run, substrate, workload):
+    if substrate == Substrates.K8S:
+        pytest.skip("VM only")
+        return
+    mock_run.return_value = Mock(returncode=0, stdout=b"", stderr=b"")
+    workload.run_cmd("cat", stdin="hello", timeout=30)
+    assert mock_run.call_args.kwargs["input"] == b"hello"
+    assert mock_run.call_args.kwargs["timeout"] == 30
+
+
+@patch("single_kernel_postgresql.workload.vm.subprocess.run")
+def test_vm_run_cmd_timeout_raises_without_replace(mock_run, substrate, workload):
+    if substrate == Substrates.K8S:
+        pytest.skip("VM only")
+        return
+    mock_run.side_effect = TimeoutExpired(cmd="pgbackrest", timeout=5)
+    with pytest.raises(TimeoutExpired):
+        workload.run_cmd("pgbackrest", timeout=5)
+
+
+@patch("single_kernel_postgresql.workload.vm.subprocess.run")
+def test_vm_run_cmd_timeout_replaced_with_result(mock_run, substrate, workload):
+    if substrate == Substrates.K8S:
+        pytest.skip("VM only")
+        return
+    mock_run.side_effect = TimeoutExpired(
+        cmd="pgbackrest", timeout=5, output=b"partial", stderr=b"too slow"
+    )
+    result = workload.run_cmd("pgbackrest", timeout=5, use_errors_replace=True)
+    assert result == CommandResult(return_code=124, stdout="partial", stderr="too slow")
+
+
+def test_k8s_run_cmd_success(substrate, workload):
+    if substrate == Substrates.VM:
+        pytest.skip("K8s only")
+        return
+    process = Mock()
+    process.wait_output.return_value = ("info output", "warning")
+    workload.container.exec.return_value = process
+    result = workload.run_cmd("pgbackrest", args="info --output=json", timeout=30)
+    assert result == CommandResult(return_code=0, stdout="info output", stderr="warning")
+    assert result.ok
+    workload.container.exec.assert_called_once_with(
+        ["pgbackrest", "info", "--output=json"],
+        user=workload.user,
+        group=workload.group,
+        timeout=30,
+        stdin=None,
+    )
+
+
+def test_k8s_run_cmd_runs_as_workload_user_and_group(substrate, workload):
+    if substrate == Substrates.VM:
+        pytest.skip("K8s only")
+        return
+    process = Mock()
+    process.wait_output.return_value = ("", "")
+    workload.container.exec.return_value = process
+    workload.run_cmd("pgbackrest")
+    assert workload.container.exec.call_args.kwargs["user"] == "postgres"
+    assert workload.container.exec.call_args.kwargs["group"] == "postgres"
+
+
+def test_k8s_run_cmd_exec_error_raises(substrate, workload):
+    if substrate == Substrates.VM:
+        pytest.skip("K8s only")
+        return
+    process = Mock()
+    process.wait_output.side_effect = ExecError(
+        command=["pgbackrest", "backup"], exit_code=1, stdout="", stderr="boom"
+    )
+    workload.container.exec.return_value = process
+    with pytest.raises(ExecError):
+        workload.run_cmd("pgbackrest", "backup")
+
+
+def test_k8s_run_cmd_exec_error_replaced_with_result(substrate, workload):
+    if substrate == Substrates.VM:
+        pytest.skip("K8s only")
+        return
+    process = Mock()
+    process.wait_output.side_effect = ExecError(
+        command=["pgbackrest", "backup"], exit_code=1, stdout="progress", stderr="boom"
+    )
+    workload.container.exec.return_value = process
+    result = workload.run_cmd("pgbackrest", "backup", use_errors_replace=True)
+    assert result == CommandResult(return_code=1, stdout="progress", stderr="boom")
+    assert not result.ok
+
+
+def test_k8s_run_cmd_passes_stdin(substrate, workload):
+    if substrate == Substrates.VM:
+        pytest.skip("K8s only")
+        return
+    process = Mock()
+    process.wait_output.return_value = ("", "")
+    workload.container.exec.return_value = process
+    workload.run_cmd("cat", stdin="hello")
+    assert workload.container.exec.call_args.kwargs["stdin"] == "hello"
+
+
+# --- service control: VM
+
+
+def _mock_vm_snap(**services):
+    """Patch SnapCache in the VM workload module with a snap exposing the given services."""
+    selected_snap = Mock()
+    selected_snap.services = services
+    cache = Mock()
+    cache.__getitem__ = Mock(return_value=selected_snap)
+    return patch("single_kernel_postgresql.workload.vm.snap.SnapCache", return_value=cache)
+
+
+def test_vm_service_control_uses_snap_by_name(substrate, workload):
+    if substrate == Substrates.K8S:
+        pytest.skip("VM only")
+        return
+    with _mock_vm_snap() as mock_cache:
+        workload.start_service(PGBACKREST_SERVICE)
+        workload.stop_service(PGBACKREST_SERVICE)
+        workload.restart_service(PGBACKREST_SERVICE)
+        workload.reload_service(PGBACKREST_SERVICE)
+    selected_snap = mock_cache.return_value.__getitem__.return_value
+    selected_snap.start.assert_called_once_with(services=[PGBACKREST_SERVICE])
+    selected_snap.stop.assert_called_once_with(services=[PGBACKREST_SERVICE])
+    # Snap has no signal channel: reload is a restart.
+    assert selected_snap.restart.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "services,expected",
+    [
+        pytest.param({PGBACKREST_SERVICE: {"active": True}}, True, id="running"),
+        pytest.param({PGBACKREST_SERVICE: {"active": False}}, False, id="inactive"),
+        pytest.param({}, False, id="missing-from-snap-revision"),
+    ],
+)
+def test_vm_service_is_running(substrate, workload, services, expected):
+    if substrate == Substrates.K8S:
+        pytest.skip("VM only")
+        return
+    with _mock_vm_snap(**services):
+        assert workload.service_is_running(PGBACKREST_SERVICE) is expected
+
+
+def test_vm_service_is_running_snap_error_reads_as_not_running(substrate, workload):
+    if substrate == Substrates.K8S:
+        pytest.skip("VM only")
+        return
+    with patch(
+        "single_kernel_postgresql.workload.vm.snap.SnapCache",
+        side_effect=snap.SnapNotFoundError("no snap"),
+    ):
+        assert workload.service_is_running(PGBACKREST_SERVICE) is False
+
+
+# --- service control: K8s
+
+
+def test_k8s_service_control_uses_container_by_name(substrate, workload):
+    if substrate == Substrates.VM:
+        pytest.skip("K8s only")
+        return
+    workload.start_service(PGBACKREST_SERVICE)
+    workload.stop_service(PGBACKREST_SERVICE)
+    workload.restart_service(PGBACKREST_SERVICE)
+    workload.container.start.assert_called_once_with(PGBACKREST_SERVICE)
+    workload.container.stop.assert_called_once_with(PGBACKREST_SERVICE)
+    workload.container.restart.assert_called_once_with(PGBACKREST_SERVICE)
+
+
+def test_k8s_reload_running_service_sends_sighup(substrate, workload):
+    if substrate == Substrates.VM:
+        pytest.skip("K8s only")
+        return
+    workload.container.can_connect.return_value = True
+    service = Mock(current=ServiceStatus.ACTIVE)
+    workload.container.pebble.get_services.return_value = [service]
+    workload.reload_service(PGBACKREST_SERVICE)
+    workload.container.send_signal.assert_called_once_with(signal.SIGHUP, PGBACKREST_SERVICE)
+    workload.container.restart.assert_not_called()
+
+
+def test_k8s_reload_stopped_service_restarts(substrate, workload):
+    if substrate == Substrates.VM:
+        pytest.skip("K8s only")
+        return
+    workload.container.can_connect.return_value = True
+    service = Mock(current=ServiceStatus.INACTIVE)
+    workload.container.pebble.get_services.return_value = [service]
+    workload.reload_service(PGBACKREST_SERVICE)
+    workload.container.restart.assert_called_once_with(PGBACKREST_SERVICE)
+    workload.container.send_signal.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "get_services,expected",
+    [
+        pytest.param([Mock(current=ServiceStatus.ACTIVE)], True, id="active"),
+        pytest.param([Mock(current=ServiceStatus.ERROR)], False, id="error"),
+        pytest.param([], False, id="missing-from-plan"),
+    ],
+)
+def test_k8s_service_is_running(substrate, workload, get_services, expected):
+    if substrate == Substrates.VM:
+        pytest.skip("K8s only")
+        return
+    workload.container.can_connect.return_value = True
+    workload.container.pebble.get_services.return_value = get_services
+    assert workload.service_is_running(PGBACKREST_SERVICE) is expected
+
+
+def test_k8s_service_is_running_before_connect_reads_as_not_running(substrate, workload):
+    if substrate == Substrates.VM:
+        pytest.skip("K8s only")
+        return
+    workload.container.can_connect.return_value = False
+    assert workload.service_is_running(PGBACKREST_SERVICE) is False
+    workload.container.pebble.get_services.assert_not_called()
+
+
+# --- pgbackrest_logs paths
+
+
+def test_vm_pgbackrest_logs_path():
+    paths = VMPaths(pathops.LocalPath("/"), "16")
+    assert str(paths.pgbackrest_logs) == ("/var/snap/charmed-postgresql/common/var/log/pgbackrest")
+
+
+def test_k8s_pgbackrest_logs_path():
+    paths = K8sPaths(pathops.LocalPath("/"), "16")
+    assert str(paths.pgbackrest_logs) == str(paths.logs / "16/main/pgbackrest_logs")


### PR DESCRIPTION
## Issue

Part of the backups module migration from the PostgreSQL VM and K8s charms' 16/edge branches into this library. The backup manager cannot port until the workload layer can run pgBackRest commands, address services by name, and resolve the pgBackRest log directory; the `run_cmd` abstract has been an unimplemented stub and `Paths` has no pgBackRest entry.

## Solution

Implements `run_cmd` on both substrates over a shared frozen `CommandResult` (return code, stdout, stderr): VM runs subprocess as root with timeout-to-result semantics, K8s runs `container.exec` as the workload user and group, raising `ExecError` on failure unless the caller asked for a result instead. Adds by-name service control (start, stop, restart, reload, is-running): Pebble reload sends SIGHUP to a running service and restarts otherwise, while the snap layer has no signal channel so reload is a restart; a service a layer revision predates reads as not running rather than raising. Adds the pgBackRest log directory to `Paths` per substrate — the snap keeps it unversioned beside the other workload logs, the K8s charm scopes it under the versioned subtree of the mounted logs storage — and the few literals the above need (`S3_RELATION_NAME`, `VM_PGBACKREST_SERVICE_NAME`, per-substrate pgbackrest log paths).

Provenance: behavior ported from `src/backups.py` `@ 03494fb7b7` (VM) and `@ dec4b9602d` (K8s) into `single_kernel_postgresql/workload/`. The no-argument `start_service` stub becomes by-name; it had zero callers.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
