### PR TITLE
feat(backups): vendor the data_platform_libs s3 interface library (2/19)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ postgresql = [
     "pydantic>=2.0; python_version >= '3.12'",
     "jinja2 >=3.1.6; python_version >= '3.12'",
     "charmlibs-rollingops>=1.1.1; python_version >= '3.12'",
+    "boto3>=1.43.85; python_version >= '3.12'",
+    "botocore>=1.40; python_version >= '3.12'",
 ]
 vm = [
     "pysyncobj>=0.3.15; python_version >= '3.12'",

--- a/single_kernel_postgresql/lib/charms/data_platform_libs/v0/s3.py
+++ b/single_kernel_postgresql/lib/charms/data_platform_libs/v0/s3.py
@@ -1,0 +1,792 @@
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""A library for communicating with the S3 credentials providers and consumers.
+
+This library provides the relevant interface code implementing the communication
+specification for fetching, retrieving, triggering, and responding to events related to
+the S3 provider charm and its consumers.
+
+### Provider charm
+
+The provider is implemented in the `s3-provider` charm which is meant to be deployed
+alongside one or more consumer charms. The provider charm is serving the s3 credentials and
+metadata needed to communicate and work with an S3 compatible backend.
+
+Example:
+```python
+
+from charms.data_platform_libs.v0.s3 import CredentialRequestedEvent, S3Provider
+
+
+class ExampleProviderCharm(CharmBase):
+    def __init__(self, *args) -> None:
+        super().__init__(*args)
+        self.s3_provider = S3Provider(self, "s3-credentials")
+
+        self.framework.observe(self.s3_provider.on.credentials_requested,
+            self._on_credential_requested)
+
+    def _on_credential_requested(self, event: CredentialRequestedEvent):
+        if not self.unit.is_leader():
+            return
+
+        # get relation id
+        relation_id = event.relation.id
+
+        # get bucket name
+        bucket = event.bucket
+
+        # S3 configuration parameters
+        desired_configuration = {"access-key": "your-access-key", "secret-key":
+            "your-secret-key", "bucket": "your-bucket"}
+
+        # update the configuration
+        self.s3_provider.update_connection_info(relation_id, desired_configuration)
+
+        # or it is possible to set each field independently
+
+        self.s3_provider.set_secret_key(relation_id, "your-secret-key")
+
+
+if __name__ == "__main__":
+    main(ExampleProviderCharm)
+
+
+### Requirer charm
+
+The requirer charm is the charm requiring the S3 credentials.
+An example of requirer charm is the following:
+
+Example:
+```python
+
+from charms.data_platform_libs.v0.s3 import (
+    CredentialsChangedEvent,
+    CredentialsGoneEvent,
+    S3Requirer
+)
+
+class ExampleRequirerCharm(CharmBase):
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+         bucket_name = "test-bucket"
+        # if bucket name is not provided the bucket name will be generated
+        # e.g., ('relation-{relation.id}')
+
+        self.s3_client = S3Requirer(self, "s3-credentials", bucket_name)
+
+        self.framework.observe(self.s3_client.on.credentials_changed, self._on_credential_changed)
+        self.framework.observe(self.s3_client.on.credentials_gone, self._on_credential_gone)
+
+    def _on_credential_changed(self, event: CredentialsChangedEvent):
+
+        # access single parameter credential
+        secret_key = event.secret_key
+        access_key = event.access_key
+
+        # or as alternative all credentials can be collected as a dictionary
+        credentials = self.s3_client.get_s3_credentials()
+
+    def _on_credential_gone(self, event: CredentialsGoneEvent):
+        # credentials are removed
+        pass
+
+ if __name__ == "__main__":
+    main(ExampleRequirerCharm)
+```
+
+"""
+
+import json
+import logging
+from collections import namedtuple
+from typing import Dict, List, Optional, Union
+
+import ops.charm
+import ops.framework
+import ops.model
+from ops.charm import (
+    CharmBase,
+    CharmEvents,
+    RelationBrokenEvent,
+    RelationChangedEvent,
+    RelationEvent,
+    RelationJoinedEvent,
+)
+from ops.framework import EventSource, Object, ObjectEvents
+from ops.model import Application, Relation, RelationDataContent, Unit
+
+# The unique Charmhub library identifier, never change it
+LIBID = "fca396f6254246c9bfa565b1f85ab528"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 6
+
+logger = logging.getLogger(__name__)
+
+Diff = namedtuple("Diff", "added changed deleted")
+Diff.__doc__ = """
+A tuple for storing the diff between two data mappings.
+
+added - keys that were added
+changed - keys that still exist but have new values
+deleted - key that were deleted"""
+
+
+def diff(event: RelationChangedEvent, bucket: Union[Unit, Application]) -> Diff:
+    """Retrieves the diff of the data in the relation changed databag.
+
+    Args:
+        event: relation changed event.
+        bucket: bucket of the databag (app or unit)
+
+    Returns:
+        a Diff instance containing the added, deleted and changed
+            keys from the event relation databag.
+    """
+    # Retrieve the old data from the data key in the application relation databag.
+    old_data = json.loads(event.relation.data[bucket].get("data", "{}"))
+    # Retrieve the new data from the event relation databag.
+    new_data = (
+        {key: value for key, value in event.relation.data[event.app].items() if key != "data"}
+        if event.app
+        else {}
+    )
+
+    # These are the keys that were added to the databag and triggered this event.
+    added = new_data.keys() - old_data.keys()
+    # These are the keys that were removed from the databag and triggered this event.
+    deleted = old_data.keys() - new_data.keys()
+    # These are the keys that already existed in the databag,
+    # but had their values changed.
+    changed = {key for key in old_data.keys() & new_data.keys() if old_data[key] != new_data[key]}
+
+    # TODO: evaluate the possibility of losing the diff if some error
+    # happens in the charm before the diff is completely checked (DPE-412).
+    # Convert the new_data to a serializable format and save it for a next diff check.
+    event.relation.data[bucket].update({"data": json.dumps(new_data)})
+
+    # Return the diff with all possible changes.
+    return Diff(added, changed, deleted)
+
+
+class BucketEvent(RelationEvent):
+    """Base class for bucket events."""
+
+    @property
+    def bucket(self) -> Optional[str]:
+        """Returns the bucket was requested."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("bucket", "")
+
+
+class CredentialRequestedEvent(BucketEvent):
+    """Event emitted when a set of credential is requested for use on this relation."""
+
+
+class S3CredentialEvents(CharmEvents):
+    """Event descriptor for events raised by S3Provider."""
+
+    credentials_requested = EventSource(CredentialRequestedEvent)
+
+
+class S3Provider(Object):
+    """A provider handler for communicating S3 credentials to consumers."""
+
+    on = S3CredentialEvents()  # pyright: ignore [reportAssignmentType]
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str,
+    ):
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.local_app = self.charm.model.app
+        self.local_unit = self.charm.unit
+        self.relation_name = relation_name
+
+        # monitor relation changed event for changes in the credentials
+        self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        """React to the relation changed event by consuming data."""
+        if not self.charm.unit.is_leader():
+            return
+        diff = self._diff(event)
+        # emit on credential requested if bucket is provided by the requirer application
+        if "bucket" in diff.added:
+            getattr(self.on, "credentials_requested").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+    def _load_relation_data(self, raw_relation_data: dict) -> dict:
+        """Loads relation data from the relation data bag.
+
+        Args:
+            raw_relation_data: Relation data from the databag
+        Returns:
+            dict: Relation data in dict format.
+        """
+        connection_data = {}
+        for key in raw_relation_data:
+            try:
+                connection_data[key] = json.loads(raw_relation_data[key])
+            except (json.decoder.JSONDecodeError, TypeError):
+                connection_data[key] = raw_relation_data[key]
+        return connection_data
+
+    # def _diff(self, event: RelationChangedEvent) -> Diff:
+    #     """Retrieves the diff of the data in the relation changed databag.
+
+    #     Args:
+    #         event: relation changed event.
+
+    #     Returns:
+    #         a Diff instance containing the added, deleted and changed
+    #             keys from the event relation databag.
+    #     """
+    #     # Retrieve the old data from the data key in the application relation databag.
+    #     old_data = json.loads(event.relation.data[self.local_app].get("data", "{}"))
+    #     # Retrieve the new data from the event relation databag.
+    #     new_data = {
+    #         key: value for key, value in event.relation.data[event.app].items() if key != "data"
+    #     }
+
+    #     # These are the keys that were added to the databag and triggered this event.
+    #     added = new_data.keys() - old_data.keys()
+    #     # These are the keys that were removed from the databag and triggered this event.
+    #     deleted = old_data.keys() - new_data.keys()
+    #     # These are the keys that already existed in the databag,
+    #     # but had their values changed.
+    #     changed = {
+    #         key for key in old_data.keys() & new_data.keys() if old_data[key] != new_data[key]
+    #     }
+
+    #     # TODO: evaluate the possibility of losing the diff if some error
+    #     # happens in the charm before the diff is completely checked (DPE-412).
+    #     # Convert the new_data to a serializable format and save it for a next diff check.
+    #     event.relation.data[self.local_app].update({"data": json.dumps(new_data)})
+
+    #     # Return the diff with all possible changes.
+    #     return Diff(added, changed, deleted)
+
+    def _diff(self, event: RelationChangedEvent) -> Diff:
+        """Retrieves the diff of the data in the relation changed databag.
+
+        Args:
+            event: relation changed event.
+
+        Returns:
+            a Diff instance containing the added, deleted and changed
+                keys from the event relation databag.
+        """
+        return diff(event, self.local_app)
+
+    def fetch_relation_data(self) -> dict:
+        """Retrieves data from relation.
+
+        This function can be used to retrieve data from a relation
+        in the charm code when outside an event callback.
+
+        Returns:
+            a dict of the values stored in the relation data bag
+                for all relation instances (indexed by the relation id).
+        """
+        data = {}
+        for relation in self.relations:
+            data[relation.id] = (
+                {key: value for key, value in relation.data[relation.app].items() if key != "data"}
+                if relation.app
+                else {}
+            )
+        return data
+
+    def update_connection_info(self, relation_id: int, connection_data: dict) -> None:
+        """Updates the credential data as set of key-value pairs in the relation.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            connection_data: dict containing the key-value pairs
+                that should be updated.
+        """
+        # check and write changes only if you are the leader
+        if not self.local_unit.is_leader():
+            return
+
+        relation = self.charm.model.get_relation(self.relation_name, relation_id)
+
+        if not relation:
+            return
+
+        # configuration options that are list
+        s3_list_options = ["attributes", "tls-ca-chain"]
+
+        # update the databag, if connection data did not change with respect to before
+        # the relation changed event is not triggered
+        updated_connection_data = {}
+        for configuration_option, configuration_value in connection_data.items():
+            if configuration_option in s3_list_options:
+                updated_connection_data[configuration_option] = json.dumps(configuration_value)
+            else:
+                updated_connection_data[configuration_option] = configuration_value
+
+        relation.data[self.local_app].update(updated_connection_data)
+        logger.debug("Updated S3 connection info.")
+
+    @property
+    def relations(self) -> List[Relation]:
+        """The list of Relation instances associated with this relation_name."""
+        return list(self.charm.model.relations[self.relation_name])
+
+    def set_bucket(self, relation_id: int, bucket: str) -> None:
+        """Sets bucket name in application databag.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            bucket: the bucket name.
+        """
+        self.update_connection_info(relation_id, {"bucket": bucket})
+
+    def set_access_key(self, relation_id: int, access_key: str) -> None:
+        """Sets access-key value in application databag.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            access_key: the access-key value.
+        """
+        self.update_connection_info(relation_id, {"access-key": access_key})
+
+    def set_secret_key(self, relation_id: int, secret_key: str) -> None:
+        """Sets the secret key value in application databag.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            secret_key: the value of the secret key.
+        """
+        self.update_connection_info(relation_id, {"secret-key": secret_key})
+
+    def set_path(self, relation_id: int, path: str) -> None:
+        """Sets the path value in application databag.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            path: the path value.
+        """
+        self.update_connection_info(relation_id, {"path": path})
+
+    def set_endpoint(self, relation_id: int, endpoint: str) -> None:
+        """Sets the endpoint address in application databag.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            endpoint: the endpoint address.
+        """
+        self.update_connection_info(relation_id, {"endpoint": endpoint})
+
+    def set_region(self, relation_id: int, region: str) -> None:
+        """Sets the region location in application databag.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            region: the region address.
+        """
+        self.update_connection_info(relation_id, {"region": region})
+
+    def set_s3_uri_style(self, relation_id: int, s3_uri_style: str) -> None:
+        """Sets the S3 URI style in application databag.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            s3_uri_style: the s3 URI style.
+        """
+        self.update_connection_info(relation_id, {"s3-uri-style": s3_uri_style})
+
+    def set_storage_class(self, relation_id: int, storage_class: str) -> None:
+        """Sets the storage class in application databag.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            storage_class: the storage class.
+        """
+        self.update_connection_info(relation_id, {"storage-class": storage_class})
+
+    def set_tls_ca_chain(self, relation_id: int, tls_ca_chain: List[str]) -> None:
+        """Sets the tls_ca_chain value in application databag.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            tls_ca_chain: the TLS Chain value.
+        """
+        self.update_connection_info(relation_id, {"tls-ca-chain": tls_ca_chain})
+
+    def set_s3_api_version(self, relation_id: int, s3_api_version: str) -> None:
+        """Sets the S3 API version in application databag.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            s3_api_version: the S3 version value.
+        """
+        self.update_connection_info(relation_id, {"s3-api-version": s3_api_version})
+
+    def set_delete_older_than_days(self, relation_id: int, days: int) -> None:
+        """Sets the retention days for full backups in application databag.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            days: the value.
+        """
+        self.update_connection_info(relation_id, {"delete-older-than-days": str(days)})
+
+    def set_attributes(self, relation_id: int, attributes: List[str]) -> None:
+        """Sets the connection attributes in application databag.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            attributes: the attributes value.
+        """
+        self.update_connection_info(relation_id, {"attributes": attributes})
+
+
+class S3Event(RelationEvent):
+    """Base class for S3 storage events."""
+
+    @property
+    def bucket(self) -> Optional[str]:
+        """Returns the bucket name."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("bucket")
+
+    @property
+    def access_key(self) -> Optional[str]:
+        """Returns the access key."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("access-key")
+
+    @property
+    def secret_key(self) -> Optional[str]:
+        """Returns the secret key."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("secret-key")
+
+    @property
+    def path(self) -> Optional[str]:
+        """Returns the path where data can be stored."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("path")
+
+    @property
+    def endpoint(self) -> Optional[str]:
+        """Returns the endpoint address."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("endpoint")
+
+    @property
+    def region(self) -> Optional[str]:
+        """Returns the region."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("region")
+
+    @property
+    def s3_uri_style(self) -> Optional[str]:
+        """Returns the s3 uri style."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("s3-uri-style")
+
+    @property
+    def storage_class(self) -> Optional[str]:
+        """Returns the storage class name."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("storage-class")
+
+    @property
+    def tls_ca_chain(self) -> Optional[List[str]]:
+        """Returns the TLS CA chain."""
+        if not self.relation.app:
+            return None
+
+        tls_ca_chain = self.relation.data[self.relation.app].get("tls-ca-chain")
+        if tls_ca_chain is not None:
+            return json.loads(tls_ca_chain)
+        return None
+
+    @property
+    def s3_api_version(self) -> Optional[str]:
+        """Returns the S3 API version."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("s3-api-version")
+
+    @property
+    def delete_older_than_days(self) -> Optional[int]:
+        """Returns the retention days for full backups."""
+        if not self.relation.app:
+            return None
+
+        days = self.relation.data[self.relation.app].get("delete-older-than-days")
+        if days is None:
+            return None
+        return int(days)
+
+    @property
+    def attributes(self) -> Optional[List[str]]:
+        """Returns the attributes."""
+        if not self.relation.app:
+            return None
+
+        attributes = self.relation.data[self.relation.app].get("attributes")
+        if attributes is not None:
+            return json.loads(attributes)
+        return None
+
+
+class CredentialsChangedEvent(S3Event):
+    """Event emitted when S3 credential are changed on this relation."""
+
+
+class CredentialsGoneEvent(RelationEvent):
+    """Event emitted when S3 credential are removed from this relation."""
+
+
+class S3CredentialRequiresEvents(ObjectEvents):
+    """Event descriptor for events raised by the S3Provider."""
+
+    credentials_changed = EventSource(CredentialsChangedEvent)
+    credentials_gone = EventSource(CredentialsGoneEvent)
+
+
+S3_REQUIRED_OPTIONS = ["access-key", "secret-key"]
+
+
+class S3Requirer(Object):
+    """Requires-side of the s3 relation."""
+
+    on = S3CredentialRequiresEvents()  # pyright: ignore[reportAssignmentType]
+
+    def __init__(
+        self, charm: ops.charm.CharmBase, relation_name: str, bucket_name: Optional[str] = None
+    ):
+        """Manager of the s3 client relations."""
+        super().__init__(charm, relation_name)
+
+        self.relation_name = relation_name
+        self.charm = charm
+        self.local_app = self.charm.model.app
+        self.local_unit = self.charm.unit
+        self.bucket = bucket_name
+
+        self.framework.observe(
+            self.charm.on[self.relation_name].relation_changed, self._on_relation_changed
+        )
+
+        self.framework.observe(
+            self.charm.on[self.relation_name].relation_joined, self._on_relation_joined
+        )
+
+        self.framework.observe(
+            self.charm.on[self.relation_name].relation_broken,
+            self._on_relation_broken,
+        )
+
+    def _generate_bucket_name(self, event: RelationJoinedEvent):
+        """Returns the bucket name generated from relation id."""
+        return f"relation-{event.relation.id}"
+
+    def _on_relation_joined(self, event: RelationJoinedEvent) -> None:
+        """Event emitted when the application joins the s3 relation."""
+        if self.bucket is None:
+            self.bucket = self._generate_bucket_name(event)
+        self.update_connection_info(event.relation.id, {"bucket": self.bucket})
+
+    def fetch_relation_data(self) -> dict:
+        """Retrieves data from relation.
+
+        This function can be used to retrieve data from a relation
+        in the charm code when outside an event callback.
+
+        Returns:
+            a dict of the values stored in the relation data bag
+                for all relation instances (indexed by the relation id).
+        """
+        data = {}
+
+        for relation in self.relations:
+            data[relation.id] = self._load_relation_data(relation.data[self.charm.app])
+        return data
+
+    def update_connection_info(self, relation_id: int, connection_data: dict) -> None:
+        """Updates the credential data as set of key-value pairs in the relation.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            connection_data: dict containing the key-value pairs
+                that should be updated.
+        """
+        # check and write changes only if you are the leader
+        if not self.local_unit.is_leader():
+            return
+
+        relation = self.charm.model.get_relation(self.relation_name, relation_id)
+
+        if not relation:
+            return
+
+        # update the databag, if connection data did not change with respect to before
+        # the relation changed event is not triggered
+        # configuration options that are list
+        s3_list_options = ["attributes", "tls-ca-chain"]
+        updated_connection_data = {}
+        for configuration_option, configuration_value in connection_data.items():
+            if configuration_option in s3_list_options:
+                updated_connection_data[configuration_option] = json.dumps(configuration_value)
+            else:
+                updated_connection_data[configuration_option] = configuration_value
+
+        relation.data[self.local_app].update(updated_connection_data)
+        logger.debug("Updated S3 credentials.")
+
+    def _load_relation_data(self, raw_relation_data: RelationDataContent) -> Dict[str, str]:
+        """Loads relation data from the relation data bag.
+
+        Args:
+            raw_relation_data: Relation data from the databag
+        Returns:
+            dict: Relation data in dict format.
+        """
+        connection_data = {}
+        for key in raw_relation_data:
+            try:
+                connection_data[key] = json.loads(raw_relation_data[key])
+            except (json.decoder.JSONDecodeError, TypeError):
+                connection_data[key] = raw_relation_data[key]
+        return connection_data
+
+    def _diff(self, event: RelationChangedEvent) -> Diff:
+        """Retrieves the diff of the data in the relation changed databag.
+
+        Args:
+            event: relation changed event.
+
+        Returns:
+            a Diff instance containing the added, deleted and changed
+                keys from the event relation databag.
+        """
+        return diff(event, self.local_unit)
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Notify the charm about the presence of S3 credentials."""
+        # check if the mandatory options are in the relation data
+        contains_required_options = True
+        # get current credentials data
+        credentials = self.get_s3_connection_info()
+        # records missing options
+        missing_options = []
+        for configuration_option in S3_REQUIRED_OPTIONS:
+            if configuration_option not in credentials:
+                contains_required_options = False
+                missing_options.append(configuration_option)
+        # emit credential change event only if all mandatory fields are present
+        if contains_required_options:
+            getattr(self.on, "credentials_changed").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+        else:
+            logger.warning(
+                f"Some mandatory fields: {missing_options} are not present, do not emit credential change event!"
+            )
+
+    def get_s3_connection_info(self) -> Dict[str, str]:
+        """Return the s3 credentials as a dictionary."""
+        for relation in self.relations:
+            if relation and relation.app:
+                return self._load_relation_data(relation.data[relation.app])
+
+        return {}
+
+    def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
+        """Notify the charm about a broken S3 credential store relation."""
+        getattr(self.on, "credentials_gone").emit(event.relation, app=event.app, unit=event.unit)
+
+    @property
+    def relations(self) -> List[Relation]:
+        """The list of Relation instances associated with this relation_name."""
+        return list(self.charm.model.relations[self.relation_name])

--- a/tests/unit/test_s3_lib_vendored.py
+++ b/tests/unit/test_s3_lib_vendored.py
@@ -1,0 +1,11 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""The vendored s3 charm lib stays importable through the package namespace."""
+
+import single_kernel_postgresql.lib.charms.data_platform_libs.v0.s3 as s3_lib
+
+
+def test_vendored_s3_lib_exposes_the_requirer():
+    assert hasattr(s3_lib, "S3Requirer")
+    assert hasattr(s3_lib, "CredentialsChangedEvent")
+    assert hasattr(s3_lib, "CredentialsGoneEvent")

--- a/uv.lock
+++ b/uv.lock
@@ -35,6 +35,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.43.87"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/0c/b14374e9458030076cd22ff9381cf86d170f31b648fd901db1d88011094b/boto3-1.43.87.tar.gz", hash = "sha256:8d9521c7c292194b8ce9fb61043d52e45cdba29b5f690981f3eb5e75103ba57d", size = 112691, upload-time = "2026-09-02T19:23:13.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/a9/7dd7cc1a2387f3c78f66e49682957b7e7d590706dc6552d108b48125022d/boto3-1.43.87-py3-none-any.whl", hash = "sha256:671cf88a353f887774603980898bc34249d05a994e1c5e24aba4f4e1bbef0951", size = 140026, upload-time = "2026-09-02T19:23:12.044Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.87"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/97/c4/64ebb159810a9840c57659f3ed98439bbc5680dc9708e3b08212deea301a/botocore-1.43.87.tar.gz", hash = "sha256:928598e7275fa70385d7f694d60d59afe115a0b914cc699dbf3eb60954c23bf1", size = 16064894, upload-time = "2026-09-02T19:23:08.777Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/5c/f15aa7a5da42fc85254f0150df7d377bb965b0c130c68f9701fba88e0df4/botocore-1.43.87-py3-none-any.whl", hash = "sha256:01e1e2255a8f4b959c19b210d74a5a916d13841c0344ceee15d8a3eaa4daa892", size = 15755750, upload-time = "2026-09-02T19:23:05.937Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
@@ -854,6 +882,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
 name = "lightkube"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1176,6 +1213,8 @@ k8s = [
     { name = "lightkube-models", marker = "python_full_version >= '3.12'" },
 ]
 postgresql = [
+    { name = "boto3", marker = "python_full_version >= '3.12'" },
+    { name = "botocore", marker = "python_full_version >= '3.12'" },
     { name = "charm-refresh", marker = "python_full_version >= '3.12'" },
     { name = "charmlibs-interfaces-tls-certificates", marker = "python_full_version >= '3.12'" },
     { name = "charmlibs-pathops", marker = "python_full_version >= '3.12'" },
@@ -1209,6 +1248,8 @@ unit = [
 
 [package.metadata]
 requires-dist = [
+    { name = "boto3", marker = "python_full_version >= '3.12' and extra == 'postgresql'", specifier = ">=1.43.85" },
+    { name = "botocore", marker = "python_full_version >= '3.12' and extra == 'postgresql'", specifier = ">=1.40" },
     { name = "charm-refresh", marker = "python_full_version >= '3.12' and extra == 'postgresql'" },
     { name = "charmlibs-interfaces-tls-certificates", marker = "python_full_version >= '3.12' and extra == 'postgresql'", specifier = ">=1.8.3" },
     { name = "charmlibs-pathops", marker = "python_full_version >= '3.12' and extra == 'postgresql'", specifier = ">=1.0.1" },
@@ -1495,6 +1536,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1628,12 +1681,33 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/43/35e4d8aa320bffe8287fe8f65f578fa2d2db0a64212f0e710dce58267854/s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993", size = 165592, upload-time = "2026-07-22T19:30:44.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl", hash = "sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25", size = 90216, upload-time = "2026-07-22T19:30:43.251Z" },
+]
+
+[[package]]
 name = "shortuuid"
 version = "1.0.13"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/e2/bcf761f3bff95856203f9559baf3741c416071dd200c0fc19fad7f078f86/shortuuid-1.0.13.tar.gz", hash = "sha256:3bb9cf07f606260584b1df46399c0b87dd84773e7b25912b7e391e30797c5e72", size = 9662, upload-time = "2024-03-11T20:11:06.879Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/44/21d6bf170bf40b41396480d8d49ad640bca3f2b02139cd52aa1e272830a5/shortuuid-1.0.13-py3-none-any.whl", hash = "sha256:a482a497300b49b4953e15108a7913244e1bb0d41f9d332f5e9925dba33a3c5a", size = 10529, upload-time = "2024-03-11T20:11:04.807Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Issue

Part of the backups module migration from the PostgreSQL VM and K8s charms' 16/edge branches into this library. The backup module owns the `s3-parameters` relation through the `data_platform_libs` s3 charm library, so the library must carry it before the manager ports.

## Solution

Vendors `lib/charms/data_platform_libs/v0/s3.py` from the charms into `single_kernel_postgresql/lib/charms/data_platform_libs/v0/s3.py` verbatim and unformatted — the VM and K8s copies are byte-identical — following the `data_interfaces` and `glauth_k8s` ldap vendoring precedent, and adds boto3/botocore as minimum-version dependencies of the `postgresql` extra: the S3 client added in the next PR talks to the bucket directly. Most of this PR's line count is the untouched vendored copy.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
