### PR TITLE
feat(backups): typed stanza and restore coordination state (3/19)

### DIFF
--- a/single_kernel_postgresql/config/exceptions.py
+++ b/single_kernel_postgresql/config/exceptions.py
@@ -77,3 +77,7 @@ class UpdateSyncNodeCountError(Exception):
 
 class DeployedWithoutTrustError(Exception):
     """Raised when the K8s API denies access because the app wasn't deployed with --trust."""
+
+
+class ListBackupsError(PostgreSQLBaseError):
+    """Raised when pgBackRest fails to list backups."""

--- a/single_kernel_postgresql/config/literals.py
+++ b/single_kernel_postgresql/config/literals.py
@@ -48,6 +48,7 @@ POSTGRESQL_CONF_FILE = "postgresql.conf"
 ## Pgbackreest Paths
 PGBACKREST_CONF_PATH = "etc/pgbackrest"
 PGBACKREST_CONF_FILE = "pgbackrest.conf"
+S3_RELATION_NAME = "s3-parameters"
 
 ## TLS Paths
 TLS_CA_BUNDLE_FILE = "peer_ca_bundle.pem"

--- a/single_kernel_postgresql/core/peer_relation.py
+++ b/single_kernel_postgresql/core/peer_relation.py
@@ -73,6 +73,11 @@ class PostgreSQLPeer(RelationState):
         return isinstance(self.unit.status, BlockedStatus)
 
     @property
+    def status_message(self) -> str:
+        """Returns the current unit status message, if any."""
+        return self.unit.status.message
+
+    @property
     def internal_cert(self) -> str | None:
         """Get internal certificate.
 

--- a/single_kernel_postgresql/core/peer_relation.py
+++ b/single_kernel_postgresql/core/peer_relation.py
@@ -225,6 +225,55 @@ class PostgreSQLPeer(RelationState):
             return True
         return self.relation.data[self.unit].get("connectivity", "on") == "on"
 
+    @is_connectivity_enabled.setter
+    def is_connectivity_enabled(self, value: bool) -> None:
+        """Enable or disable external connectivity to this unit."""
+        if not self.relation:
+            return
+        self.relation.data[self.unit]["connectivity"] = "on" if value else "off"
+
+    @property
+    def stanza(self) -> str | None:
+        """Get the pgBackRest stanza name from the unit peer relation data."""
+        if not self.relation:
+            return None
+        return self.relation.data[self.unit].get("stanza")
+
+    @stanza.setter
+    def stanza(self, value: str) -> None:
+        """Set the pgBackRest stanza name in the unit peer relation data."""
+        if not self.relation:
+            return
+        self.relation.data[self.unit]["stanza"] = value
+
+    @property
+    def s3_initialization_done(self) -> str | None:
+        """Get the s3-initialization-done marker from the unit peer relation data."""
+        if not self.relation:
+            return None
+        return self.relation.data[self.unit].get("s3-initialization-done")
+
+    @s3_initialization_done.setter
+    def s3_initialization_done(self, value: str) -> None:
+        """Set the s3-initialization-done marker in the unit peer relation data."""
+        if not self.relation:
+            return
+        self.relation.data[self.unit]["s3-initialization-done"] = value
+
+    @property
+    def s3_initialization_block_message(self) -> str | None:
+        """Get the s3 initialization block message from the unit peer relation data."""
+        if not self.relation:
+            return None
+        return self.relation.data[self.unit].get("s3-initialization-block-message")
+
+    @s3_initialization_block_message.setter
+    def s3_initialization_block_message(self, value: str) -> None:
+        """Set the s3 initialization block message in the unit peer relation data."""
+        if not self.relation:
+            return
+        self.relation.data[self.unit]["s3-initialization-block-message"] = value
+
     @property
     def config_hash(self) -> str | None:
         """Get the last-applied PostgreSQL config hash from the peer relation data."""
@@ -473,6 +522,118 @@ class PostgreSQLApplication(RelationState):
         if not self.relation:
             return
         self.relation.data[self.app]["user_hash"] = value
+
+    @property
+    def stanza(self) -> str | None:
+        """Get the pgBackRest stanza name from the app peer relation data."""
+        if not self.relation:
+            return None
+        return self.relation.data[self.app].get("stanza")
+
+    @stanza.setter
+    def stanza(self, value: str) -> None:
+        """Set the pgBackRest stanza name in the app peer relation data."""
+        if not self.relation:
+            return
+        self.relation.data[self.app]["stanza"] = value
+
+    @property
+    def s3_initialization_start(self) -> str | None:
+        """Get the s3-initialization-start timestamp from the app peer relation data."""
+        if not self.relation:
+            return None
+        return self.relation.data[self.app].get("s3-initialization-start")
+
+    @s3_initialization_start.setter
+    def s3_initialization_start(self, value: str) -> None:
+        """Set the s3-initialization-start timestamp in the app peer relation data."""
+        if not self.relation:
+            return
+        self.relation.data[self.app]["s3-initialization-start"] = value
+
+    @property
+    def s3_initialization_block_message(self) -> str | None:
+        """Get the s3 initialization block message from the app peer relation data."""
+        if not self.relation:
+            return None
+        return self.relation.data[self.app].get("s3-initialization-block-message")
+
+    @s3_initialization_block_message.setter
+    def s3_initialization_block_message(self, value: str) -> None:
+        """Set the s3 initialization block message in the app peer relation data."""
+        if not self.relation:
+            return
+        self.relation.data[self.app]["s3-initialization-block-message"] = value
+
+    @property
+    def s3_initialization_done(self) -> str | None:
+        """Get the s3-initialization-done marker from the app peer relation data."""
+        if not self.relation:
+            return None
+        return self.relation.data[self.app].get("s3-initialization-done")
+
+    @s3_initialization_done.setter
+    def s3_initialization_done(self, value: str) -> None:
+        """Set the s3-initialization-done marker in the app peer relation data."""
+        if not self.relation:
+            return
+        self.relation.data[self.app]["s3-initialization-done"] = value
+
+    @property
+    def restoring_backup(self) -> str | None:
+        """Get the restoring-backup marker from the app peer relation data."""
+        if not self.relation:
+            return None
+        return self.relation.data[self.app].get("restoring-backup")
+
+    @restoring_backup.setter
+    def restoring_backup(self, value: str) -> None:
+        """Set the restoring-backup marker in the app peer relation data."""
+        if not self.relation:
+            return
+        self.relation.data[self.app]["restoring-backup"] = value
+
+    @property
+    def restore_stanza(self) -> str | None:
+        """Get the restore-stanza name from the app peer relation data."""
+        if not self.relation:
+            return None
+        return self.relation.data[self.app].get("restore-stanza")
+
+    @restore_stanza.setter
+    def restore_stanza(self, value: str) -> None:
+        """Set the restore-stanza name in the app peer relation data."""
+        if not self.relation:
+            return
+        self.relation.data[self.app]["restore-stanza"] = value
+
+    @property
+    def restore_timeline(self) -> str | None:
+        """Get the restore-timeline from the app peer relation data."""
+        if not self.relation:
+            return None
+        return self.relation.data[self.app].get("restore-timeline")
+
+    @restore_timeline.setter
+    def restore_timeline(self, value: str) -> None:
+        """Set the restore-timeline in the app peer relation data."""
+        if not self.relation:
+            return
+        self.relation.data[self.app]["restore-timeline"] = value
+
+    @property
+    def restore_to_time(self) -> str | None:
+        """Get the restore-to-time target from the app peer relation data."""
+        if not self.relation:
+            return None
+        return self.relation.data[self.app].get("restore-to-time")
+
+    @restore_to_time.setter
+    def restore_to_time(self, value: str) -> None:
+        """Set the restore-to-time target in the app peer relation data."""
+        if not self.relation:
+            return
+        self.relation.data[self.app]["restore-to-time"] = value
 
     def get_secret(self, key: str) -> str | None:
         """Get the secret value for 'key' from the peer relation data."""

--- a/single_kernel_postgresql/core/state.py
+++ b/single_kernel_postgresql/core/state.py
@@ -325,6 +325,22 @@ class CharmState(Object):
             ips.append(self.replication_consumer_ip)
         return ips
 
+    @property
+    def cluster_stanza(self) -> str | None:
+        """Return the pgBackRest stanza of the cluster, whichever unit published it.
+
+        The stanza is written by the primary into its unit databag during S3
+        initialization and only later adopted by the leader into app data, so
+        while a cluster is mid-initialization (or mid-restore) the authoritative
+        copy may still live on a unit. Fetched live on every access.
+        """
+        if stanza := self.application.stanza:
+            return stanza
+        for peer in self.application_peers:
+            if stanza := peer.stanza:
+                return stanza
+        return None
+
     # -- Secrets
     # TODO: This is temporary till data interfaces v1 is integrated
     def get_secret(self, scope: SCOPES, key: str) -> str | None:

--- a/tests/unit/test_backup_state.py
+++ b/tests/unit/test_backup_state.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Tests for the backup coordination state on peer relation data.
+
+These accessors port the backup module's app_peer_data / unit_peer_data fields
+verbatim (same databag labels the charms wrote): stanza initialization and
+restore coordination on PostgreSQLApplication, per-unit stanza/S3 markers on
+PostgreSQLPeer, and the CharmState cross-scope stanza reader that survives
+clusters whose stanza was only published by the primary unit so far.
+"""
+
+import pytest
+from single_kernel_postgresql.compat.postgresql import PostgreSQLBaseError
+from single_kernel_postgresql.config.exceptions import ListBackupsError
+
+
+def _get_unit_db(harness, key):
+    rel_id = harness.model.get_relation("database-peers").id
+    return harness.get_relation_data(rel_id, harness.charm.unit.name).get(key)
+
+
+def _get_app_db(harness, key):
+    rel_id = harness.model.get_relation("database-peers").id
+    return harness.get_relation_data(rel_id, harness.charm.app.name).get(key)
+
+
+def _add_remote_unit(harness, unit_name):
+    rel_id = harness.model.get_relation("database-peers").id
+    harness.add_relation_unit(rel_id, unit_name)
+    return rel_id
+
+
+# -- PostgreSQLApplication backup accessors -----------------------------------
+
+
+@pytest.mark.parametrize(
+    "accessor,label",
+    [
+        ("stanza", "stanza"),
+        ("s3_initialization_start", "s3-initialization-start"),
+        ("s3_initialization_block_message", "s3-initialization-block-message"),
+        ("s3_initialization_done", "s3-initialization-done"),
+        ("restoring_backup", "restoring-backup"),
+        ("restore_stanza", "restore-stanza"),
+        ("restore_timeline", "restore-timeline"),
+        ("restore_to_time", "restore-to-time"),
+    ],
+)
+def test_app_backup_accessor_writes_charm_label(harness, accessor, label):
+    """Every app accessor writes the exact label the charms wrote."""
+    application = harness.charm.state.application
+    setattr(application, accessor, "value")
+    assert _get_app_db(harness, label) == "value"
+
+
+@pytest.mark.parametrize(
+    "accessor",
+    [
+        "stanza",
+        "s3_initialization_start",
+        "s3_initialization_block_message",
+        "s3_initialization_done",
+        "restoring_backup",
+        "restore_stanza",
+        "restore_timeline",
+        "restore_to_time",
+    ],
+)
+def test_app_backup_accessor_unset_is_none(harness, accessor):
+    assert getattr(harness.charm.state.application, accessor) is None
+
+
+@pytest.mark.parametrize(
+    "accessor",
+    [
+        "stanza",
+        "s3_initialization_start",
+        "s3_initialization_block_message",
+        "s3_initialization_done",
+        "restoring_backup",
+        "restore_stanza",
+        "restore_timeline",
+        "restore_to_time",
+    ],
+)
+def test_app_backup_accessor_roundtrip_and_clear(harness, accessor):
+    """Set → get → clear; the charm clears by writing "", which ops drops."""
+    application = harness.charm.state.application
+    setattr(application, accessor, "value")
+    assert getattr(application, accessor) == "value"
+    setattr(application, accessor, "")
+    assert getattr(application, accessor) is None
+
+
+# -- PostgreSQLPeer backup accessors ------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "accessor,label",
+    [
+        ("stanza", "stanza"),
+        ("s3_initialization_done", "s3-initialization-done"),
+        ("s3_initialization_block_message", "s3-initialization-block-message"),
+    ],
+)
+def test_peer_backup_accessor_writes_charm_label(harness, accessor, label):
+    """Every unit accessor writes the exact label the charms wrote."""
+    peer = harness.charm.state.peer
+    setattr(peer, accessor, "value")
+    assert _get_unit_db(harness, label) == "value"
+
+
+@pytest.mark.parametrize(
+    "accessor",
+    [
+        "stanza",
+        "s3_initialization_done",
+        "s3_initialization_block_message",
+    ],
+)
+def test_peer_backup_accessor_roundtrip_and_clear(harness, accessor):
+    peer = harness.charm.state.peer
+    setattr(peer, accessor, "value")
+    assert getattr(peer, accessor) == "value"
+    setattr(peer, accessor, "")
+    assert getattr(peer, accessor) is None
+
+
+# -- Connectivity --------------------------------------------------------------
+
+
+def test_connectivity_enabled_by_default(harness):
+    assert harness.charm.state.peer.is_connectivity_enabled is True
+    assert _get_unit_db(harness, "connectivity") is None
+
+
+def test_connectivity_setter_disables(harness):
+    harness.charm.state.peer.is_connectivity_enabled = False
+    assert _get_unit_db(harness, "connectivity") == "off"
+    assert harness.charm.state.peer.is_connectivity_enabled is False
+
+
+def test_connectivity_setter_reenables(harness):
+    peer = harness.charm.state.peer
+    peer.is_connectivity_enabled = False
+    peer.is_connectivity_enabled = True
+    assert _get_unit_db(harness, "connectivity") == "on"
+    assert peer.is_connectivity_enabled is True
+
+
+# -- CharmState.cluster_stanza (cross-scope reader) ----------------------------
+
+
+def test_cluster_stanza_none_when_unset(harness):
+    assert harness.charm.state.cluster_stanza is None
+
+
+def test_cluster_stanza_prefers_app_databag(harness):
+    """Once the leader adopted the stanza, the app copy wins over unit copies."""
+    rel_id = _add_remote_unit(harness, "postgresql-single-kernel/1")
+    harness.update_relation_data(rel_id, "postgresql-single-kernel/1", {"stanza": "unit-stanza"})
+    harness.charm.state.application.stanza = "app-stanza"
+    assert harness.charm.state.cluster_stanza == "app-stanza"
+
+
+def test_cluster_stanza_falls_back_to_publishing_unit(harness):
+    """Mid-initialization the stanza lives only on the primary's unit databag."""
+    rel_id = _add_remote_unit(harness, "postgresql-single-kernel/1")
+    harness.update_relation_data(rel_id, "postgresql-single-kernel/1", {"stanza": "unit-stanza"})
+    assert harness.charm.state.cluster_stanza == "unit-stanza"
+
+
+def test_cluster_stanza_reads_own_unit_databag(harness):
+    harness.charm.state.peer.stanza = "own-unit-stanza"
+    assert harness.charm.state.cluster_stanza == "own-unit-stanza"
+
+
+def test_cluster_stanza_ignores_units_without_stanza(harness):
+    """A unit carrying only S3 markers (no stanza yet) is skipped."""
+    rel_id = _add_remote_unit(harness, "postgresql-single-kernel/1")
+    harness.update_relation_data(
+        rel_id, "postgresql-single-kernel/1", {"s3-initialization-done": "True"}
+    )
+    assert harness.charm.state.cluster_stanza is None
+
+
+# -- ListBackupsError ----------------------------------------------------------
+
+
+def test_list_backups_error_inherits_postgresql_base_error():
+    assert issubclass(ListBackupsError, PostgreSQLBaseError)
+
+
+def test_list_backups_error_is_raisable_and_catchable_as_base():
+    with pytest.raises(PostgreSQLBaseError):
+        raise ListBackupsError("pgbackrest list failed")


### PR DESCRIPTION
## Issue

Part of the backups module migration from the PostgreSQL VM and K8s charms' 16/edge branches into this library. Every stanza and restore coordination field is read through untyped databag access with the key spelled out at each call site.

## Solution

Typed accessors name each key once, with the charm labels kept verbatim so a cluster mid-restore survives adoption: stanza, the three s3-initialization fields, and the restore fields on the app databag; stanza, the initialization-done marker and block message on the unit databag; and a matching connectivity setter next to the existing getter. A cross-scope `cluster_stanza` reader covers the publish-on-primary, adopt-on-leader flow the charms implement by hand. `ListBackupsError` joins `config/exceptions.py` on the `PostgreSQLBaseError` hierarchy. One behavior note: the charms clear fields by writing empty strings, which ops stores as absent keys — the accessors write exactly what the charms write and reads return None, matching the existing TLS accessor convention.

Provenance: labels extracted from `src/backups.py` `@ 03494fb7b7` (VM) and `@ dec4b9602d` (K8s); identical in both charms at every read and written site.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
