### PR TITLE
feat(backups): S3 connection info view and boto3 S3 client (4/19)

### DIFF
--- a/single_kernel_postgresql/config/literals.py
+++ b/single_kernel_postgresql/config/literals.py
@@ -48,6 +48,7 @@ POSTGRESQL_CONF_FILE = "postgresql.conf"
 ## Pgbackreest Paths
 PGBACKREST_CONF_PATH = "etc/pgbackrest"
 PGBACKREST_CONF_FILE = "pgbackrest.conf"
+S3_RELATION_NAME = "s3-parameters"
 
 ## TLS Paths
 TLS_CA_BUNDLE_FILE = "peer_ca_bundle.pem"

--- a/single_kernel_postgresql/core/s3.py
+++ b/single_kernel_postgresql/core/s3.py
@@ -1,0 +1,62 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Live-fetch view over the S3 (s3-parameters) relation data."""
+
+import logging
+
+from single_kernel_postgresql.lib.charms.data_platform_libs.v0.s3 import S3Requirer
+
+logger = logging.getLogger(__name__)
+
+
+class S3ConnectionInfo:
+    """Reads and normalizes S3 connection parameters from the s3-parameters relation."""
+
+    def __init__(self, s3_requirer: S3Requirer):
+        """Initialize the S3 connection info with the requirer bound to the relation."""
+        self.s3_requirer = s3_requirer
+
+    def retrieve_s3_parameters(self) -> tuple[dict, list[str]]:
+        """Retrieve S3 parameters from the S3 integrator relation.
+
+        Returns:
+            a tuple of (parameters, missing_required_parameters). If any required
+            parameter is missing, parameters is empty and missing lists the absent
+            keys. Otherwise parameters has defaults applied and values normalized.
+        """
+        s3_parameters = self.s3_requirer.get_s3_connection_info()
+        required_parameters = [
+            "bucket",
+            "access-key",
+            "secret-key",
+        ]
+        missing_required_parameters = [
+            param for param in required_parameters if param not in s3_parameters
+        ]
+        if missing_required_parameters:
+            logger.warning(
+                f"Missing required S3 parameters in relation with S3 integrator: {missing_required_parameters}"
+            )
+            return {}, missing_required_parameters
+
+        # Add some sensible defaults (as expected by the code) for missing optional parameters
+        s3_parameters.setdefault("endpoint", "https://s3.amazonaws.com")
+        s3_parameters.setdefault("path", "")
+        s3_parameters.setdefault("s3-uri-style", "host")
+        s3_parameters.setdefault("delete-older-than-days", "9999999")
+
+        # Strip whitespaces from all parameters.
+        for key, value in s3_parameters.items():
+            if isinstance(value, str):
+                s3_parameters[key] = value.strip()
+
+        # Clean up extra slash symbols to avoid issues on 3rd-party storages
+        # like Ceph Object Gateway (radosgw).
+        s3_parameters["endpoint"] = s3_parameters["endpoint"].rstrip("/")
+        s3_parameters["path"] = (
+            f"/{s3_parameters['path'].strip('/')}"  # The slash in the beginning is required by pgBackRest.
+        )
+        s3_parameters["bucket"] = s3_parameters["bucket"].strip("/")
+
+        return s3_parameters, []

--- a/single_kernel_postgresql/core/state.py
+++ b/single_kernel_postgresql/core/state.py
@@ -31,15 +31,18 @@ from single_kernel_postgresql.config.literals import (
     PEER_RELATION,
     REPLICATION_CONSUMER_RELATION,
     REPLICATION_OFFER_RELATION,
+    S3_RELATION_NAME,
     SCOPES,
     STATUS_PEERS_RELATION,
 )
 from single_kernel_postgresql.core.config import CharmConfig
 from single_kernel_postgresql.core.peer_relation import PostgreSQLApplication, PostgreSQLPeer
+from single_kernel_postgresql.core.s3 import S3ConnectionInfo
 from single_kernel_postgresql.lib.charms.data_platform_libs.v0.data_interfaces import (
     DataPeerData,
     DataPeerUnitData,
 )
+from single_kernel_postgresql.lib.charms.data_platform_libs.v0.s3 import S3Requirer
 from single_kernel_postgresql.utils import unit_name_to_pod_name
 from single_kernel_postgresql.utils.secret import translate_field_to_secret_key
 from single_kernel_postgresql.utils.status import format_status
@@ -60,6 +63,7 @@ class CharmState(Object):
         self.peer_unit_interface = DataPeerUnitData(model=charm.model, relation_name=PEER_RELATION)
 
         self.statuses = StatusesState(self, STATUS_PEERS_RELATION)
+        self._charm = charm
 
     # -- Charm Config
     @cached_property
@@ -92,6 +96,11 @@ class CharmState(Object):
     def status_peers_relation(self) -> Relation | None:
         """Get status peers relation."""
         return self.model.get_relation(STATUS_PEERS_RELATION)
+
+    @property
+    def s3_relation(self) -> Relation | None:
+        """Get the S3 parameters relation."""
+        return self.model.get_relation(S3_RELATION_NAME)
 
     # -- Core State Components
 
@@ -132,6 +141,16 @@ class CharmState(Object):
             component=self.model.app,
             substrate=self.substrate,
         )
+
+    @cached_property
+    def s3_requirer(self) -> S3Requirer:
+        """Get the S3 requirer, which observes the s3-parameters relation events."""
+        return S3Requirer(self._charm, S3_RELATION_NAME)
+
+    @property
+    def s3_connection_info(self) -> S3ConnectionInfo:
+        """Get the S3 connection info state."""
+        return S3ConnectionInfo(self.s3_requirer)
 
     # -- Cluster state utilities
     def _get_hostname_from_unit(self, member: str) -> str:

--- a/single_kernel_postgresql/managers/s3_client.py
+++ b/single_kernel_postgresql/managers/s3_client.py
@@ -1,0 +1,172 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""boto3-based client for reading from and writing to an S3 bucket."""
+
+import logging
+import os
+import tempfile
+from io import BytesIO
+
+from boto3.session import Session
+from botocore.client import Config
+from botocore.exceptions import ClientError, ConnectTimeoutError, SSLError
+from botocore.loaders import create_loader
+from botocore.regions import EndpointResolver
+
+logger = logging.getLogger(__name__)
+
+
+class S3Client:
+    """Client for uploading to and downloading from an S3 bucket.
+
+    The only construction-time input is the TLS CA-chain path used to verify the
+    S3 endpoint; the rest is passed per call as an ``s3_parameters`` dict, as
+    produced by ``core.s3.S3ConnectionInfo.retrieve_s3_parameters``.
+    """
+
+    def __init__(self, tls_ca_chain_filename: str | None = None):
+        """Initialize the S3 client with the TLS CA-chain path, or None for the system trust store."""
+        self._tls_ca_chain_filename = tls_ca_chain_filename
+
+    def _construct_endpoint(self, s3_parameters: dict) -> str:
+        """Construct the S3 endpoint using the region, needed for AWS endpoints without one."""
+        # Use the provided endpoint unless it is an AWS endpoint missing the region.
+        endpoint = s3_parameters["endpoint"]
+
+        # Construct the endpoint using the region, and use it for AWS endpoints.
+        loader = create_loader()
+        data = loader.load_data("endpoints")
+        resolver = EndpointResolver(data)
+        endpoint_data = resolver.construct_endpoint("s3", s3_parameters.get("region"))
+        if endpoint_data and endpoint.endswith(endpoint_data["dnsSuffix"]):
+            endpoint = f"{endpoint.split('://')[0]}://{endpoint_data['hostname']}"
+
+        return endpoint
+
+    def _get_s3_session_resource(self, s3_parameters: dict):
+        kwargs = {
+            "aws_access_key_id": s3_parameters["access-key"],
+            "aws_secret_access_key": s3_parameters["secret-key"],
+        }
+        if "region" in s3_parameters:
+            kwargs["region_name"] = s3_parameters["region"]
+        session = Session(**kwargs)
+        return session.resource(
+            "s3",
+            endpoint_url=self._construct_endpoint(s3_parameters),
+            verify=(self._tls_ca_chain_filename or None),
+            config=Config(
+                # https://github.com/boto/boto3/issues/4400#issuecomment-2600742103
+                request_checksum_calculation="when_required",
+                response_checksum_validation="when_required",
+            ),
+        )
+
+    def upload_content(self, content: str, s3_path: str, s3_parameters: dict) -> bool:
+        """Upload ``content`` to ``s3_path`` relative to the configured path; returns success."""
+        bucket_name = s3_parameters["bucket"]
+        processed_s3_path = os.path.join(s3_parameters["path"], s3_path).lstrip("/")
+        location = f"bucket={bucket_name}, path={processed_s3_path}"
+        try:
+            logger.debug(f"Uploading content to {location}")
+            s3 = self._get_s3_session_resource(s3_parameters)
+            bucket = s3.Bucket(bucket_name)
+
+            with tempfile.NamedTemporaryFile() as temp_file:
+                temp_file.write(content.encode("utf-8"))
+                temp_file.flush()
+                bucket.upload_file(temp_file.name, processed_s3_path)
+        except Exception as e:
+            logger.exception(f"Failed to upload content to S3 {location}", exc_info=e)
+            return False
+
+        return True
+
+    def read_content(self, s3_path: str, s3_parameters: dict) -> str | None:
+        """Read ``s3_path`` relative to the configured path, or None if it does not exist."""
+        if not (bucket_name := s3_parameters.get("bucket")):
+            logger.debug("No bucket set")
+            return None
+        processed_s3_path = os.path.join(s3_parameters["path"], s3_path).lstrip("/")
+        location = f"bucket={bucket_name}, path={processed_s3_path}"
+        try:
+            logger.debug(f"Reading content from {location}")
+            s3 = self._get_s3_session_resource(s3_parameters)
+            bucket = s3.Bucket(bucket_name)
+            with BytesIO() as buf:
+                bucket.download_fileobj(processed_s3_path, buf)
+                return buf.getvalue().decode("utf-8")
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "404":
+                logger.info(f"No such object to read from S3 {location}")
+            else:
+                logger.exception(f"Failed to read content from S3 {location}", exc_info=e)
+        except Exception as e:
+            logger.exception(f"Failed to read content from S3 {location}", exc_info=e)
+
+        return None
+
+    def create_bucket_if_not_exists(self, s3_parameters: dict) -> None:
+        """Create the configured bucket if it does not already exist.
+
+        ConnectTimeoutError and SSLError are re-raised so the user can fix the
+        network/TLS problem and call ``juju resolve`` to re-trigger the hook.
+
+        Missing required parameters are a no-op, exactly as the charms'
+        ``_create_bucket_if_not_exists`` early return: the initialization flow
+        degrades into the graceful stanza block message downstream.
+        """
+        missing_parameters = [
+            param for param in ("bucket", "access-key", "secret-key") if param not in s3_parameters
+        ]
+        if missing_parameters:
+            logger.warning(
+                f"Missing required S3 parameters in relation with S3 integrator: {missing_parameters}"
+            )
+            return
+        bucket_name = s3_parameters["bucket"]
+        region = s3_parameters.get("region", "")
+
+        try:
+            s3 = self._get_s3_session_resource(s3_parameters)
+        except ValueError:
+            logger.exception("Failed to create a session '%s' in region=%s.", bucket_name, region)
+            raise
+        bucket = s3.Bucket(bucket_name)
+        try:
+            bucket.meta.client.head_bucket(Bucket=bucket_name)
+            logger.debug("Bucket %s exists.", bucket_name)
+            return
+        except ConnectTimeoutError as e:
+            # Re-raise the error if the connection timeouts, so the user has the possibility to
+            # fix network issues and call juju resolve to re-trigger the hook that calls
+            # this method.
+            logger.error(f"error: {e!s} - please fix the error and call juju resolve on this unit")
+            raise
+        except SSLError as e:
+            logger.error(f"error: {e!s} - Is TLS enabled and CA chain set on S3?")
+            raise
+        except ClientError:
+            logger.warning("Bucket %s doesn't exist or you don't have access to it.", bucket_name)
+
+        try:
+            bucket.create(CreateBucketConfiguration={"LocationConstraint": region})
+            bucket.wait_until_exists()
+            logger.info("Created bucket '%s' in region=%s", bucket_name, region)
+        except ClientError as error:
+            if error.response["Error"]["Code"] != "InvalidLocationConstraint":
+                logger.exception(
+                    "Couldn't create bucket named '%s' in region=%s.", bucket_name, region
+                )
+                raise
+            logger.info("Specified location-constraint is not valid, trying create without it")
+            try:
+                bucket.create()
+                bucket.wait_until_exists()
+                logger.info("Created bucket '%s', ignored region=%s", bucket_name, region)
+            except ClientError:
+                logger.exception(
+                    "Couldn't create bucket named '%s' in region=%s.", bucket_name, region
+                )
+                raise


### PR DESCRIPTION
## Issue

Part of the backups module migration from the PostgreSQL VM and K8s charms' 16/edge branches into this library. Stacks on the vendored s3 charm library. The S3 plumbing (parameter normalization, boto3 session, bucket handling) lives inline in both charms' backup modules.

## Solution

`S3ConnectionInfo` is a live-fetch state view over the vendored `S3Requirer` whose `retrieve_s3_parameters` returns the same `(parameters, missing)` tuple as the charm method, defaults and whitespace and slash normalization included — VM and K8s are identical here, and the K8s `read_content` path is reconciled to the VM's missing-bucket guard. `S3Client` ports the boto3 wrapper: AWS endpoint rewrite via `EndpointResolver`, session resource with the CA-chain verify path and `when_required` checksums, upload, read (404 reads as None), and bucket creation with the connection-timeout and TLS-error re-raises that keep the juju resolve recovery path working. `CharmState` owns the requirer lazily and exposes the view; hot-path progress logs are demoted to debug.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
