### PR TITLE
feat(backups): backup manager core, substrate seam, and pgBackRest templates (7/19)

### DIFF
--- a/single_kernel_postgresql/core/state.py
+++ b/single_kernel_postgresql/core/state.py
@@ -235,6 +235,11 @@ class CharmState(Object):
         """Current model name."""
         return self.model.name
 
+    @property
+    def cluster_name(self) -> str:
+        """Patroni cluster name, substrate-conditional (delegates to the app peer state)."""
+        return self.application.cluster_name
+
     @cached_property
     def patroni_url(self) -> str:
         """Patroni REST API URL."""

--- a/single_kernel_postgresql/managers/backup.py
+++ b/single_kernel_postgresql/managers/backup.py
@@ -22,7 +22,11 @@ from single_kernel_postgresql.core.state import CharmState
 from single_kernel_postgresql.managers.base import BaseManager
 from single_kernel_postgresql.managers.patroni import PatroniManager
 from single_kernel_postgresql.utils.backup import S3_BLOCK_MESSAGES
-from single_kernel_postgresql.workload.base import BaseWorkload, CommandResult
+from single_kernel_postgresql.workload.base import (
+    BaseWorkload,
+    CommandResult,
+    ResourceProvider,
+)
 
 if TYPE_CHECKING:
     from single_kernel_postgresql.managers.s3_client import S3Client
@@ -54,13 +58,17 @@ class BackupManager(BaseManager):
         s3_client: "S3Client",
         patroni_manager: PatroniManager,
         update_config: UpdateConfigFunction,
+        resource_provider: ResourceProvider,
         is_standby_cluster: IsStandbyClusterFunction | None = None,
+        set_unit_status: Callable[..., None] | None = None,
     ):
         """Manager of PostgreSQL backups."""
         super().__init__(state, workload, "backup")
         self.s3_client = s3_client
         self.patroni_manager = patroni_manager
         self.update_config = update_config
+        self.resource_provider = resource_provider
+        self.set_unit_status = set_unit_status
         self._is_standby_cluster_bridge = is_standby_cluster
 
     @property
@@ -139,7 +147,11 @@ class BackupManager(BaseManager):
                 primary = self.patroni_manager.get_primary() or (
                     self.patroni_manager.get_standby_leader()
                 )
-                return self.patroni_manager.get_member_ip(primary) if primary else None
+                member_ip = self.patroni_manager.get_member_ip(primary) if primary else None
+                if member_ip is not None and member_ip not in self.state.peer_members_ips:
+                    logger.debug("Early exit primary_endpoint: Primary IP not in cached peer list")
+                    return None
+                return member_ip
             primary = self.patroni_manager.get_primary()
         except (RetryError, ConnectionError) as e:
             logger.error(f"failed to get primary with error {e!s}")

--- a/single_kernel_postgresql/managers/backup.py
+++ b/single_kernel_postgresql/managers/backup.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Manager of PostgreSQL backups via pgBackRest.
+
+Ported from the 16/edge charm backup modules (``src/backups.py`` on the VM and
+K8s charms). Event orchestration (defer/fail/status writes) stays in the events
+layer; this manager raises or returns values only.
+"""
+
+import logging
+import shlex
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from tenacity import RetryError
+
+from single_kernel_postgresql.config.enums import Substrates
+from single_kernel_postgresql.config.literals import PGBACKREST_LOG_LEVEL_STDERR
+from single_kernel_postgresql.core.state import CharmState
+from single_kernel_postgresql.managers.base import BaseManager
+from single_kernel_postgresql.managers.patroni import PatroniManager
+from single_kernel_postgresql.utils.backup import S3_BLOCK_MESSAGES
+from single_kernel_postgresql.workload.base import BaseWorkload, CommandResult
+
+if TYPE_CHECKING:
+    from single_kernel_postgresql.managers.s3_client import S3Client
+
+logger = logging.getLogger(__name__)
+
+# The charm-side hooks that re-render Patroni configuration and refresh unit
+# statuses; the composition root injects them (the manager never calls
+# ConfigManager.update_config directly, whose signature takes still-injected
+# inputs it must not guess).
+type UpdateConfigFunction = Callable[..., bool]
+type IsStandbyClusterFunction = Callable[[], bool]
+
+# Bridge: VM-only async-replication concept. When the callable is omitted (K8s),
+# the cluster is never a standby cluster.
+STANZA_CREATE_CONNECTION_TIMEOUT_ERROR_CODE = 49
+
+
+class BackupManager(BaseManager):
+    """In this class, we manage PostgreSQL backups."""
+
+    s3_client: "S3Client"
+    patroni_manager: PatroniManager
+
+    def __init__(
+        self,
+        state: CharmState,
+        workload: "BaseWorkload",
+        s3_client: "S3Client",
+        patroni_manager: PatroniManager,
+        update_config: UpdateConfigFunction,
+        is_standby_cluster: IsStandbyClusterFunction | None = None,
+    ):
+        """Manager of PostgreSQL backups."""
+        super().__init__(state, workload, "backup")
+        self.s3_client = s3_client
+        self.patroni_manager = patroni_manager
+        self.update_config = update_config
+        self._is_standby_cluster_bridge = is_standby_cluster
+
+    @property
+    def stanza_name(self) -> str:
+        """Stanza name, composed by model and cluster name."""
+        return f"{self.state.model_name}.{self.state.cluster_name}"
+
+    # -- pgBackRest execution -------------------------------------------------
+
+    def _execute_pgbackrest(
+        self,
+        args: list[str],
+        timeout: float | None = None,
+        with_config: bool = True,
+    ) -> CommandResult:
+        """Execute a pgBackRest command on the workload.
+
+        The command is built as [executable, --config=<conf>/pgbackrest.conf?,
+        --log-level-stderr=warn, *substrate extra args, *args]. K8s runs
+        without --config because its pgBackRest configuration lives at the
+        default /etc/pgbackrest.conf location.
+
+        On VM, a non-zero return code is carried on the CommandResult; on K8s
+        the underlying pebble exec raises ExecError instead, mirroring the two
+        charms.
+
+        Args:
+            args: pgBackRest command and arguments.
+            timeout: optional command timeout in seconds.
+            with_config: pass --config (False for server-ping, which runs
+                outside any stanza context on both charms).
+        """
+        config = self.workload.backup_config
+        command = [config.executable]
+        if with_config and config.conf_path is not None:
+            command.append(f"--config={config.configuration_file}")
+        command.append(PGBACKREST_LOG_LEVEL_STDERR)
+        command.extend(config.extra_args)
+        command.extend(args)
+        return self.workload.run_cmd(shlex.join(command), timeout=timeout)
+
+    # -- Substrate-bridged predicates -------------------------------------------
+
+    @property
+    def is_primary(self) -> bool:
+        """Return whether this unit is the primary instance."""
+        return self.state.peer.unit_name == self.patroni_manager.get_primary(
+            unit_name_pattern=True
+        )
+
+    @property
+    def _is_standby_cluster(self) -> bool:
+        """Whether this cluster is a standby (read-only) cluster.
+
+        The charm-side async-replication check is injected as a callable; when
+        omitted (K8s) the cluster is never a standby cluster.
+        """
+        return bool(self._is_standby_cluster_bridge and self._is_standby_cluster_bridge())
+
+    @property
+    def _peer_members(self) -> set[str]:
+        """Addresses/endpoints of the other cluster members (VM: IPs, K8s: hostnames)."""
+        peers = set(self.state.endpoints)
+        peers.discard(self.state.endpoint)
+        return peers
+
+    @property
+    def _primary_endpoint(self) -> str | None:
+        """Address of the primary unit for pgBackRest TLS server-ping.
+
+        VM resolves the primary member IP; K8s derives the pod hostname from
+        the primary member name, matching each charm.
+        """
+        try:
+            if self.state.substrate == Substrates.VM:
+                primary = self.patroni_manager.get_primary() or (
+                    self.patroni_manager.get_standby_leader()
+                )
+                return self.patroni_manager.get_member_ip(primary) if primary else None
+            primary = self.patroni_manager.get_primary()
+        except (RetryError, ConnectionError) as e:
+            logger.error(f"failed to get primary with error {e!s}")
+            return None
+        if primary is None:
+            logger.debug("the primary was not elected yet")
+            return None
+        return self.state._get_hostname_from_unit(primary)
+
+    @property
+    def _has_s3_block_message(self) -> bool:
+        """Whether the unit is blocked because of an S3 initialization failure.
+
+        State-derived replacement of the charms' unit-status-message reads:
+        the blocked status message comes from the s3-initialization-block-message
+        peer field (see the charms' _set_primary_status_message).
+        """
+        return self.state.application.s3_initialization_block_message in S3_BLOCK_MESSAGES or (
+            self.state.peer.s3_initialization_block_message in S3_BLOCK_MESSAGES
+        )
+
+    def _s3_initialization_set_failure(self, block_message: str) -> None:
+        """Record a failed s3 initialization with the corresponding block message.
+
+        Written to the app databag on the leader (leader == primary, so no
+        cross-unit sync is needed) or to the unit databag otherwise. The events
+        layer refreshes the unit status.
+        """
+        if self.state.peer.is_app_leader:
+            self.state.application.s3_initialization_block_message = block_message
+            self.state.application.s3_initialization_start = ""
+            self.state.application.stanza = ""
+        else:
+            self.state.peer.s3_initialization_block_message = block_message
+            self.state.peer.s3_initialization_done = "True"
+            self.state.peer.stanza = ""
+
+    # -- Stanza configuration rendering ----------------------------------------

--- a/single_kernel_postgresql/templates/k8s/pgbackrest.conf.j2
+++ b/single_kernel_postgresql/templates/k8s/pgbackrest.conf.j2
@@ -1,0 +1,54 @@
+[global]
+backup-standby=y
+compress-type=zst
+repo1-retention-full-type=time
+repo1-retention-full={{ retention_full }}
+repo1-retention-history=365
+repo1-type=s3
+repo1-path={{ path }}
+{%- if region %}
+repo1-s3-region={{ region }}
+{% else %}
+repo1-s3-region=""
+{%- endif %}
+repo1-s3-endpoint={{ endpoint }}
+repo1-s3-bucket={{ bucket }}
+repo1-s3-uri-style={{ s3_uri_style }}
+{%- if tls_ca_chain != '' %}
+repo1-s3-ca-file={{ tls_ca_chain }}
+{%- endif %}
+repo1-s3-key={{ access_key }}
+repo1-s3-key-secret={{ secret_key }}
+repo1-block=y
+repo1-bundle=y
+log-path={{ pgbackrest_logs_path }}
+start-fast=y
+{%- if enable_tls %}
+tls-server-address=*
+{%- for peer_endpoint in peer_endpoints %}
+tls-server-auth={{ peer_endpoint }}={{ stanza }}
+{%- endfor %}
+tls-server-ca-file={{ storage_path }}/peer_ca.pem
+tls-server-cert-file={{ storage_path }}/peer_cert.pem
+tls-server-key-file={{ storage_path }}/peer_key.pem
+{%- endif %}
+
+[{{ stanza }}]
+pg1-path={{ pgdata_path }}
+pg1-user={{ user }}
+{%- if enable_tls %}
+{% set ns = namespace(count=2) %}
+{%- for peer_endpoint in peer_endpoints %}
+pg{{ ns.count }}-host-type=tls
+pg{{ ns.count }}-host-ca-file={{ storage_path }}/peer_ca.pem
+pg{{ ns.count }}-host-cert-file={{ storage_path }}/peer_cert.pem
+pg{{ ns.count }}-host-key-file={{ storage_path }}/peer_key.pem
+pg{{ ns.count }}-host={{ peer_endpoint }}
+pg{{ ns.count }}-path={{ pgdata_path }}
+pg{{ ns.count }}-user={{ user }}
+{% set ns.count = ns.count + 1 %}
+{%- endfor %}
+{%- endif %}
+
+[global:restore]
+process-max={{process_max}}

--- a/single_kernel_postgresql/templates/k8s/pgbackrest.logrotate.j2
+++ b/single_kernel_postgresql/templates/k8s/pgbackrest.logrotate.j2
@@ -1,0 +1,10 @@
+{{ pgbackrest_logs_path }}/*.log {
+    rotate 10
+    missingok
+    notifempty
+    nocompress
+    daily
+    create 0600 postgres postgres
+    dateext
+    dateformat -%Y%m%d_%H%M
+}

--- a/single_kernel_postgresql/templates/vm/pgbackrest.conf.j2
+++ b/single_kernel_postgresql/templates/vm/pgbackrest.conf.j2
@@ -1,0 +1,58 @@
+[global]
+backup-standby=y
+compress-type=zst
+lock-path=/tmp
+log-level-stderr=warn
+log-path={{ log_path }}
+repo1-retention-full-type=time
+repo1-retention-full={{ retention_full }}
+repo1-retention-history=365
+repo1-type=s3
+repo1-path={{ path }}
+{%- if region %}
+repo1-s3-region={{ region }}
+{% else %}
+repo1-s3-region=""
+{%- endif %}
+repo1-s3-endpoint={{ endpoint }}
+repo1-s3-bucket={{ bucket }}
+repo1-s3-uri-style={{ s3_uri_style }}
+{%- if tls_ca_chain != '' %}
+repo1-s3-ca-file={{ tls_ca_chain }}
+{%- endif %}
+repo1-s3-key={{ access_key }}
+repo1-s3-key-secret={{ secret_key }}
+repo1-block=y
+repo1-bundle=y
+start-fast=y
+{%- if enable_tls %}
+tls-server-address=*
+{%- for peer_endpoint in peer_endpoints %}
+tls-server-auth={{ peer_endpoint }}={{ stanza }}
+{%- endfor %}
+tls-server-ca-file=/var/snap/charmed-postgresql/current/etc/patroni/peer_ca.pem
+tls-server-cert-file=/var/snap/charmed-postgresql/current/etc/patroni/peer_cert.pem
+tls-server-key-file=/var/snap/charmed-postgresql/current/etc/patroni/peer_key.pem
+{%- endif %}
+
+[{{ stanza }}]
+pg1-path={{ data_path }}
+pg1-socket-path=/tmp
+pg1-user={{ user }}
+{%- if enable_tls %}
+{% set ns = namespace(count=2) %}
+{%- for peer_endpoint in peer_endpoints %}
+pg{{ ns.count }}-host-type=tls
+pg{{ ns.count }}-host-ca-file=/var/snap/charmed-postgresql/current/etc/patroni/peer_ca.pem
+pg{{ ns.count }}-host-cert-file=/var/snap/charmed-postgresql/current/etc/patroni/peer_cert.pem
+pg{{ ns.count }}-host-key-file=/var/snap/charmed-postgresql/current/etc/patroni/peer_key.pem
+pg{{ ns.count }}-host={{ peer_endpoint }}
+pg{{ ns.count }}-socket-path=/tmp
+pg{{ ns.count }}-path={{ data_path }}
+pg{{ ns.count }}-user={{ user }}
+{% set ns.count = ns.count + 1 %}
+{%- endfor %}
+{%- endif %}
+
+[global:restore]
+process-max={{process_max}}

--- a/single_kernel_postgresql/templates/vm/pgbackrest.logrotate.j2
+++ b/single_kernel_postgresql/templates/vm/pgbackrest.logrotate.j2
@@ -1,0 +1,10 @@
+/var/snap/charmed-postgresql/common/var/log/pgbackrest/*.log {
+    rotate 10
+    missingok
+    notifempty
+    nocompress
+    daily
+    create 0600 _daemon_ _daemon_
+    dateext
+    dateformat -%Y%m%d_%H%M
+}

--- a/single_kernel_postgresql/workload/base.py
+++ b/single_kernel_postgresql/workload/base.py
@@ -75,6 +75,11 @@ class BackupConfig:
     @property
     def configuration_file(self) -> str:
         """Full path of the pgBackRest configuration file."""
+        # K8s renders to the pgBackRest default location (its pgbackrest reads
+        # /etc/pgbackrest.conf; no --config flag is passed); a None conf_path
+        # must not leak into the path.
+        if self.conf_path is None:
+            return "/etc/pgbackrest.conf"
         return f"{self.conf_path}/pgbackrest.conf"
 
     def pg_controldata(self, major_version: str) -> str:

--- a/single_kernel_postgresql/workload/base.py
+++ b/single_kernel_postgresql/workload/base.py
@@ -43,6 +43,45 @@ class CommandResult:
         return f"CommandResult(return_code={self.return_code}, stdout={stdout}, stderr={stderr})"
 
 
+@dataclass(frozen=True)
+class BackupConfig:
+    """Substrate-specific pgBackRest invocation and service settings.
+
+    The backup manager is substrate-neutral; everything that differs between
+    the machine charm and the Kubernetes charm when invoking pgBackRest lives
+    here and is built by the concrete workload.
+
+    Args:
+        executable: pgBackRest entrypoint (snap alias on VM, bare binary on K8s).
+        conf_path: directory holding pgbackrest.conf, passed as --config; None
+            means pgBackRest reads its default location (K8s: /etc/pgbackrest.conf).
+        logs_path: path to the pgBackRest logs, used for error extraction hints.
+        bin_path: root of the versioned PostgreSQL binaries (pg_controldata).
+        service: name of the pgBackRest TLS server service.
+        storage_path: workload storage root where TLS material lives.
+        tls_ca_chain_path: where the S3 TLS CA chain file is written.
+        extra_args: substrate-specific arguments always passed to pgBackRest.
+    """
+
+    executable: str
+    conf_path: str | None
+    logs_path: str
+    bin_path: str
+    service: str
+    storage_path: str
+    tls_ca_chain_path: str
+    extra_args: tuple[str, ...] = ()
+
+    @property
+    def configuration_file(self) -> str:
+        """Full path of the pgBackRest configuration file."""
+        return f"{self.conf_path}/pgbackrest.conf"
+
+    def pg_controldata(self, major_version: str) -> str:
+        """Path of the pg_controldata binary for the given major version."""
+        return f"{self.bin_path}/{major_version}/bin/pg_controldata"
+
+
 class ResourceProvider(Protocol):
     """Reports the unit's available (cpu_cores, memory_bytes)."""
 
@@ -100,6 +139,12 @@ class BaseWorkload(ABC):
     @abstractmethod
     def paths(self) -> Paths:
         """Return the Workload's paths."""
+        pass
+
+    @property
+    @abstractmethod
+    def backup_config(self) -> BackupConfig:
+        """Return the substrate pgBackRest invocation settings."""
         pass
 
     @property

--- a/single_kernel_postgresql/workload/k8s.py
+++ b/single_kernel_postgresql/workload/k8s.py
@@ -19,9 +19,10 @@ from ops.pebble import ExecError, Plan, ServiceStatus
 from single_kernel_postgresql.config.exceptions import PostgreSQLFileOperationError
 from single_kernel_postgresql.config.literals import (
     DIR_PERMISSIONS_READONLY,
+    K8S_PGBACK_REST_SERVER_SERVICE_NAME,
     K8S_POSTGRESQL_SERVICE_NAME,
 )
-from single_kernel_postgresql.workload.base import BaseWorkload, CommandResult
+from single_kernel_postgresql.workload.base import BackupConfig, BaseWorkload, CommandResult
 from single_kernel_postgresql.workload.paths.base import Paths as BasePaths
 from single_kernel_postgresql.workload.paths.k8s import K8sPaths
 
@@ -119,6 +120,25 @@ class K8sWorkload(BaseWorkload):
                 stderr=e.stderr or "",
             )
         return CommandResult(return_code=0, stdout=stdout, stderr=stderr)
+
+    @property
+    def backup_config(self) -> BackupConfig:
+        """Return the K8s pgBackRest invocation settings.
+
+        pgBackRest reads /etc/pgbackrest.conf by default, so no --config flag
+        is passed (conf_path None) and the config directory holds only the
+        default-location file the charm pushes.
+        """
+        return BackupConfig(
+            executable="pgbackrest",
+            conf_path=None,
+            logs_path=str(self.paths.pgbackrest_logs),
+            bin_path="/usr/lib/postgresql",
+            service=K8S_PGBACK_REST_SERVER_SERVICE_NAME,
+            storage_path=str(self.paths.tls),
+            tls_ca_chain_path=f"{self.paths.tls}/pgbackrest-tls-ca-chain.crt",
+            extra_args=(),
+        )
 
     def is_failed(self) -> bool:
         """Check if snap service failed."""

--- a/single_kernel_postgresql/workload/vm.py
+++ b/single_kernel_postgresql/workload/vm.py
@@ -19,7 +19,8 @@ import tomli
 from charmlibs import pathops, snap
 from charmlibs.pathops import PathProtocol
 
-from single_kernel_postgresql.workload.base import BaseWorkload, CommandResult
+from single_kernel_postgresql.config.literals import VM_PGBACKREST_SERVICE_NAME
+from single_kernel_postgresql.workload.base import BackupConfig, BaseWorkload, CommandResult
 from single_kernel_postgresql.workload.paths.base import Paths as BasePaths
 from single_kernel_postgresql.workload.paths.vm import VMPaths
 
@@ -119,6 +120,21 @@ class VMWorkload(BaseWorkload):
         except snap.SnapError as e:
             logger.debug(f"Failed to check Patroni service: {e}")
             return False
+
+    @property
+    def backup_config(self) -> BackupConfig:
+        """Return the VM pgBackRest invocation settings."""
+        return BackupConfig(
+            executable="charmed-postgresql.pgbackrest",
+            # Matches the VM charm: the versioned PostgreSQL binaries live under the
+            # snap's /snap mount point, not the writable /var/snap tree.
+            bin_path="/snap/charmed-postgresql/current/usr/lib/postgresql",
+            logs_path=str(self.paths.pgbackrest_logs),
+            service=VM_PGBACKREST_SERVICE_NAME,
+            storage_path=str(self.paths.snap_common),
+            tls_ca_chain_path=str(self.paths.pgbackrest_conf / "pgbackrest-tls-ca-chain.crt"),
+            extra_args=(),
+        )
 
     def is_service_started(self, paused: bool | None = False) -> bool:
         """Check if the snap service is running.

--- a/single_kernel_postgresql/workload/vm.py
+++ b/single_kernel_postgresql/workload/vm.py
@@ -21,7 +21,6 @@ from charmlibs.pathops import PathProtocol
 
 from single_kernel_postgresql.config.literals import VM_PGBACKREST_SERVICE_NAME
 from single_kernel_postgresql.workload.base import BackupConfig, BaseWorkload, CommandResult
-from single_kernel_postgresql.workload.paths.base import Paths as BasePaths
 from single_kernel_postgresql.workload.paths.vm import VMPaths
 
 logger = logging.getLogger(__name__)
@@ -126,6 +125,7 @@ class VMWorkload(BaseWorkload):
         """Return the VM pgBackRest invocation settings."""
         return BackupConfig(
             executable="charmed-postgresql.pgbackrest",
+            conf_path=str(self.paths.pgbackrest_conf),
             # Matches the VM charm: the versioned PostgreSQL binaries live under the
             # snap's /snap mount point, not the writable /var/snap tree.
             bin_path="/snap/charmed-postgresql/current/usr/lib/postgresql",
@@ -278,7 +278,7 @@ class VMWorkload(BaseWorkload):
         return "_daemon_"
 
     @property
-    def paths(self) -> BasePaths:
+    def paths(self) -> VMPaths:
         """Return Workload's paths."""
         return VMPaths(self.root, self.get_postgresql_version().split(".")[0])
 


### PR DESCRIPTION
## Issue

Part of the backups module migration from the PostgreSQL VM and K8s charms' 16/edge branches into this library. Stacks on the workload foundation, the typed backup state, and the S3 client slices.

## Solution

Introduces `BackupManager` with the substrate seam: pgBackRest command construction over the workload's `run_cmd` (the `--config` flag only where a config file lives outside the default location, `--log-level-stderr=warn` always, `server-ping` running without a config file as both charms do), the `BackupConfig` workload property carrying the per-substrate executable, paths, and service name, the four pgBackRest templates copied verbatim per substrate from the charms, and the configuration rendering (VM renders to the snap paths and logrotate; K8s pushes into the container as the workload user). Stanza lifecycle: create with the connection-timeout re-raise that keeps the juju resolve path working, check with the archive-timeout code, and the cross-unit stanza coordination through the typed accessors. The charm bridges (`update_config`, resource provider, standby-cluster predicate) are constructor-injected per the established pattern; the manager never reaches into ConfigManager, whose signature still takes inputs from phases not yet migrated.

Deliberate divergences: the charms read the blocked-with-S3-message condition off the unit status message; the manager derives it from the s3-initialization-block-message peer fields (same fields the status message is built from). The standby-cluster guard consults the injected predicate, False when omitted (K8s), until async replication migrates.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
