### PR TITLE
feat(backups): restore manager pre-checks and PITR target resolution (12/19)

### DIFF
--- a/single_kernel_postgresql/core/peer_relation.py
+++ b/single_kernel_postgresql/core/peer_relation.py
@@ -252,6 +252,20 @@ class PostgreSQLPeer(RelationState):
         self.relation.data[self.unit]["stanza"] = value
 
     @property
+    def s3_initialization_start(self) -> str | None:
+        """Get the s3-initialization-start timestamp from the unit peer relation data."""
+        if not self.relation:
+            return None
+        return self.relation.data[self.unit].get("s3-initialization-start")
+
+    @s3_initialization_start.setter
+    def s3_initialization_start(self, value: str) -> None:
+        """Set the s3-initialization-start timestamp in the unit peer relation data."""
+        if not self.relation:
+            return
+        self.relation.data[self.unit]["s3-initialization-start"] = value
+
+    @property
     def s3_initialization_done(self) -> str | None:
         """Get the s3-initialization-done marker from the unit peer relation data."""
         if not self.relation:

--- a/single_kernel_postgresql/managers/backup.py
+++ b/single_kernel_postgresql/managers/backup.py
@@ -9,7 +9,7 @@ K8s charms). Event orchestration (defer/fail/status writes) stays in the events
 layer; this manager raises or returns values only.
 """
 
-import importlib
+import importlib.resources
 import json
 import logging
 import re
@@ -261,7 +261,7 @@ class BackupManager(BaseManager):
             .joinpath(self.state.substrate.name.lower(), "pgbackrest.conf.j2")
             .read_text()
         )
-        cpu_count, _ = self.workload.get_available_resources()
+        cpu_count, _ = self.resource_provider.get_available_resources()
         rendered = template.render(
             enable_tls=len(self._peer_members) > 0,
             peer_endpoints=self._peer_members,
@@ -645,7 +645,7 @@ class BackupManager(BaseManager):
         if system_identifier_from_instance is None:
             raise Exception("Database system identifier not found in pg_controldata output")
         system_identifier_from_instance = system_identifier_from_instance.split(" ")[-1]
-        stanza_dbs = stanza.get("db")
+        stanza_dbs = stanza.get("db") or []
         system_identifier_from_stanza = (
             str(stanza_dbs[0]["system-id"]) if len(stanza_dbs) else None
         )
@@ -846,7 +846,7 @@ Stderr:
         stderr: str,
         s3_parameters: dict,
         backup_type: str,
-        error: str,
+        error: str = "",
     ) -> tuple[bool, str]:
         """Uploads the failed backup logs and reports the failure message."""
         logger.error(stderr)

--- a/single_kernel_postgresql/managers/restore.py
+++ b/single_kernel_postgresql/managers/restore.py
@@ -1,0 +1,319 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Manager of PostgreSQL backup restores via pgBackRest.
+
+``RestoreManager`` holds the restore-side business logic ported from the charms
+(``src/backups.py`` on both substrates plus the PITR helpers from the charm
+bodies). Validation, timeline/PITR target resolution and the Patroni
+reconfiguration handshake return values instead of writing statuses or deferring
+events; the events layer (``events/backup.py``) maps those results onto action
+results and unit statuses. Repository reads (backups, timelines, nearest
+timeline) are consumed from the constructor-injected ``BackupManager``.
+"""
+
+import logging
+import re
+import time
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from single_kernel_postgresql.config.enums import Substrates
+from single_kernel_postgresql.config.literals import (
+    REPLICATION_CONSUMER_RELATION,
+    REPLICATION_OFFER_RELATION,
+)
+from single_kernel_postgresql.managers.backup import (
+    IsStandbyClusterFunction,
+    UpdateConfigFunction,
+)
+from single_kernel_postgresql.managers.base import BaseManager
+from single_kernel_postgresql.managers.patroni import PatroniManager
+from single_kernel_postgresql.utils.backup import (
+    ANOTHER_CLUSTER_REPOSITORY_ERROR_MESSAGE,
+    CANNOT_RESTORE_PITR,
+    STANDBY_CLUSTER_RESTORE_ERROR_MESSAGE,
+    fetch_backup_from_id,
+    get_nearest_timeline,
+    is_psql_timestamp,
+)
+
+if TYPE_CHECKING:
+    from single_kernel_postgresql.core.state import CharmState
+    from single_kernel_postgresql.managers.backup import BackupManager
+    from single_kernel_postgresql.workload.base import BaseWorkload
+
+logger = logging.getLogger(__name__)
+
+# Bootstrap-failure markers scanned in the Patroni logs during a PITR restore.
+# The VM charm greps the snap service logs; the K8s charm greps the pebble logs
+# of the postgresql service, with a Juju-2 fallback reading the patroni log
+# files (whose format carries a different line).
+PITR_VM_BOOTSTRAP_FAILURE_PATTERN = (
+    r"^([0-9-:TZ]+).*patroni\.exceptions\.PatroniFatalException: Failed to bootstrap cluster$"
+)
+PITR_K8S_BOOTSTRAP_FAILURE_PATTERN = (
+    r"^([0-9-:TZ.]+) \[postgresql] patroni\.exceptions\.PatroniFatalException:"
+    r" Failed to bootstrap cluster$"
+)
+PITR_K8S_JUJU2_BOOTSTRAP_FAILURE_PATTERN = (
+    r"^([0-9- :]+) UTC \[[0-9]+\]: INFO: removing initialize key after failed attempt"
+    r" to bootstrap the cluster"
+)
+
+
+class RestoreManager(BaseManager):
+    """In this class, we manage PostgreSQL backup restores."""
+
+    patroni_manager: PatroniManager
+
+    def __init__(
+        self,
+        state: "CharmState",
+        workload: "BaseWorkload",
+        patroni_manager: PatroniManager,
+        update_config: UpdateConfigFunction,
+        backup_manager: "BackupManager",
+        is_standby_cluster: IsStandbyClusterFunction | None = None,
+        update_pebble_layers: Callable[[], None] | None = None,
+    ):
+        """Manager of PostgreSQL backup restores.
+
+        The bridge callables mirror ``BackupManager``: the charm wrapper
+        re-rendering the Patroni configuration (``update_config``), the VM-only
+        standby-cluster check (``is_standby_cluster``, None on K8s) and, for
+        K8s, the pebble-layer refresh that applies the on-failure condition
+        override (``update_pebble_layers``).
+        """
+        super().__init__(state, workload, "restore")
+        self.patroni_manager = patroni_manager
+        self.update_config = update_config
+        self.backup_manager = backup_manager
+        self._is_standby_cluster_bridge = is_standby_cluster
+        self._update_pebble_layers_bridge = update_pebble_layers
+
+    # -- Substrate-bridged predicates -------------------------------------------
+
+    @property
+    def _is_standby_cluster(self) -> bool:
+        """Whether this cluster is a standby (read-only) cluster.
+
+        The charm-side async-replication check is injected as a callable; when
+        omitted (K8s) the cluster is never a standby cluster.
+        """
+        return bool(self._is_standby_cluster_bridge and self._is_standby_cluster_bridge())
+
+    # -- PITR failure inspection -------------------------------------------------
+
+    def is_pitr_failed(self) -> tuple[bool, bool]:
+        """Check if Patroni service failed to bootstrap cluster during point-in-time-recovery.
+
+        Typically, this means that database service failed to reach point-in-time-recovery target or has been
+        supplied with bad PITR parameter. Also, remembers last state and can provide info is it new event, or
+        it belongs to previous action. Executes only on current unit.
+
+        Returns:
+            Tuple[bool, bool]:
+                - Is patroni service failed to bootstrap cluster.
+                - Is it new fail, that wasn't observed previously.
+        """
+        patroni_exceptions = []
+        count = 0
+        while len(patroni_exceptions) == 0 and count < 10:
+            if count > 0:
+                time.sleep(3)
+            if self.state.substrate == Substrates.VM:
+                patroni_logs = self.patroni_manager.patroni_logs(num_lines="all")
+                patroni_exceptions = re.findall(
+                    PITR_VM_BOOTSTRAP_FAILURE_PATTERN,
+                    patroni_logs,
+                    re.MULTILINE,
+                )
+            else:
+                patroni_logs, juju2 = self.workload.pitr_bootstrap_failure_logs()
+                patroni_exceptions = re.findall(
+                    PITR_K8S_JUJU2_BOOTSTRAP_FAILURE_PATTERN
+                    if juju2
+                    else PITR_K8S_BOOTSTRAP_FAILURE_PATTERN,
+                    patroni_logs,
+                    re.MULTILINE,
+                )
+            count += 1
+
+        if len(patroni_exceptions) > 0:
+            logger.debug("Failures to bootstrap cluster detected on Patroni service logs")
+            old_pitr_fail_id = self.state.peer.data.get("last_pitr_fail_id", None)
+            self.state.peer.data["last_pitr_fail_id"] = patroni_exceptions[-1]
+            return True, patroni_exceptions[-1] != old_pitr_fail_id
+
+        logger.debug("No failures detected on Patroni service logs")
+        return False, False
+
+    def log_pitr_last_transaction_time(self) -> None:
+        """Log to user last completed transaction time acquired from postgresql logs."""
+        postgresql_logs = self.patroni_manager.last_postgresql_logs()
+        log_time = re.findall(
+            r"last completed transaction was at log time (.*)$",
+            postgresql_logs,
+            re.MULTILINE,
+        )
+        if len(log_time) > 0:
+            logger.info(f"Last completed transaction was at {log_time[-1]}")
+        else:
+            logger.error("Can't tell last completed transaction time")
+
+    # -- Pre-restore checks --------------------------------------------------------
+
+    def _pre_restore_checks(
+        self, backup_id: str | None, restore_to_time: str | None
+    ) -> tuple[bool, str]:
+        """Run some checks before starting the restore.
+
+        Returns:
+            a (can_restore, message) tuple; message is the rejection reason when
+            the restore cannot start, and empty when it can.
+        """
+        if self._is_standby_cluster:
+            logger.error(f"Restore failed: {STANDBY_CLUSTER_RESTORE_ERROR_MESSAGE}")
+            return False, STANDBY_CLUSTER_RESTORE_ERROR_MESSAGE
+
+        are_backup_settings_ok, validation_message = self.backup_manager._are_backup_settings_ok()
+        if not are_backup_settings_ok:
+            logger.error(f"Restore failed: {validation_message}")
+            return False, validation_message
+
+        if not backup_id and restore_to_time is None:
+            error_message = (
+                "Either backup-id or restore-to-time parameters need to be provided to be able"
+                " to do restore"
+            )
+            logger.error(f"Restore failed: {error_message}")
+            return False, error_message
+
+        # Quick check for timestamp format
+        if (
+            restore_to_time
+            and restore_to_time != "latest"
+            and not is_psql_timestamp(restore_to_time)
+        ):
+            error_message = "Bad restore-to-time format"
+            logger.error(f"Restore failed: {error_message}")
+            return False, error_message
+
+        if self.state.substrate == Substrates.K8S and not self.workload.workload_present:
+            error_message = "Workload container not ready yet!"
+            logger.error(f"Restore failed: {error_message}")
+            return False, error_message
+
+        error_message = self._pre_restore_cluster_checks()
+        if error_message:
+            return False, error_message
+
+        return True, ""
+
+    def _pre_restore_cluster_checks(self) -> str:
+        """Run the cluster-level guards of the pre-restore checks.
+
+        Returns:
+            the rejection reason, or an empty string when the cluster state allows
+            a restore.
+        """
+        logger.info("Checking if cluster is in blocked state")
+        if self.state.peer.is_blocked and self.state.model.unit.status.message not in [
+            ANOTHER_CLUSTER_REPOSITORY_ERROR_MESSAGE,
+            CANNOT_RESTORE_PITR,
+        ]:
+            error_message = "Cluster or unit is in a blocking state"
+            logger.error(f"Restore failed: {error_message}")
+            return error_message
+
+        logger.info("Checking that the cluster does not have more than one unit")
+        if self.state.application.planned_units > 1:
+            error_message = (
+                "Unit cannot restore backup as there are more than one unit in the cluster"
+            )
+            logger.error(f"Restore failed: {error_message}")
+            return error_message
+
+        logger.info("Checking that cluster does not have an active async replication relation")
+        for relation in [
+            self.state.model.get_relation(REPLICATION_CONSUMER_RELATION),
+            self.state.model.get_relation(REPLICATION_OFFER_RELATION),
+        ]:
+            if not relation:
+                continue
+            error_message = "Unit cannot restore backup with an active async replication relation"
+            logger.error(f"Restore failed: {error_message}")
+            return error_message
+
+        logger.info("Checking that this unit was already elected the leader unit")
+        if not self.state.peer.is_app_leader:
+            error_message = "Unit cannot restore backup as it was not elected the leader unit yet"
+            logger.error(f"Restore failed: {error_message}")
+            return error_message
+
+        return ""
+
+    # -- Restore target resolution ---------------------------------------------------
+
+    def _resolve_restore_target(
+        self, backup_id: str | None, restore_to_time: str | None
+    ) -> tuple[tuple[str, str] | None, bool, str]:
+        """Validate the backup id / restore-to-time and resolve the (stanza, timeline).
+
+        Returns:
+            (restore_stanza_timeline, is_backup_id_real, error_message). On failure
+            restore_stanza_timeline is None and error_message is non-empty.
+
+        Raises:
+            ListBackupsError: if pgBackRest fails to enumerate backups or timelines.
+        """
+        backups = self.backup_manager._list_backups(show_failed=False)
+        timelines = self.backup_manager._list_timelines()
+        is_backup_id_real = bool(backup_id and backup_id in backups)
+        is_backup_id_timeline = bool(
+            backup_id and not is_backup_id_real and backup_id in timelines
+        )
+        if backup_id and not is_backup_id_real and not is_backup_id_timeline:
+            return None, False, f"Invalid backup-id: {backup_id}"
+        if is_backup_id_timeline and not restore_to_time:
+            return None, False, "Cannot restore to the timeline without restore-to-time parameter"
+        if is_backup_id_real:
+            return backups[backup_id], True, ""
+        if is_backup_id_timeline:
+            return timelines[backup_id], False, ""
+
+        backups_list = list(backups.values())
+        # Faithful copy of the charms' "latest" base-backup check: the
+        # ``backups_list[0]`` fallback is only evaluated when there are no timelines; an
+        # empty repository (no backups and no timelines) is rejected upstream, so it
+        # cannot IndexError here.
+        if (
+            restore_to_time == "latest"
+            and timelines is not None
+            and max(timelines.values() or [backups_list[0]]) not in backups_list
+        ):
+            return None, False, "There is no base backup created from the latest timeline"
+
+        # Reuse the already-fetched lists rather than re-listing (the charms'
+        # _get_nearest_timeline re-runs _list_backups | _list_timelines internally).
+        # restore_to_time is always non-None here (the no-target case is rejected in
+        # _pre_restore_checks); use `or ""` to satisfy the type checker.
+        restore_stanza_timeline = get_nearest_timeline(backups | timelines, restore_to_time or "")
+        if not restore_stanza_timeline:
+            return (
+                None,
+                False,
+                (f"Can't find the nearest timeline before timestamp {restore_to_time} to restore"),
+            )
+        logger.info(
+            f"Chosen timeline {restore_stanza_timeline[1]} as nearest for the"
+            f" specified timestamp {restore_to_time}"
+        )
+        return restore_stanza_timeline, False, ""
+
+    def _fetch_backup_from_id(self, backup_id: str) -> str | None:
+        """Fetches backup's pgbackrest label from backup id."""
+        return fetch_backup_from_id(
+            backup_id, self.backup_manager._list_backups(show_failed=False, parse=False).keys()
+        )

--- a/tests/unit/test_backup_manager.py
+++ b/tests/unit/test_backup_manager.py
@@ -13,6 +13,7 @@ bracketing, and the S3 initialization flow — no tautological asserts.
 """
 
 import json
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -119,6 +120,32 @@ def test_execute_pgbackrest_uses_config_flag_only_on_vm(backup_manager, substrat
         assert "--config" not in command
     assert "--log-level-stderr=warn" in command
     assert "stanza-create" in command
+
+
+def test_k8s_render_writes_default_configuration_file(backup_manager, substrate):
+    """The K8s render targets /etc/pgbackrest.conf; a None conf_path must not leak."""
+    if substrate != "k8s":
+        pytest.skip("K8s renders to the default location")
+    backup_manager.workload.root = Path("/")
+    backup_manager.workload.write_text = MagicMock()
+    backup_manager.state.s3_connection_info.retrieve_s3_parameters = MagicMock(
+        return_value=(
+            {
+                "bucket": "b",
+                "access-key": "k",
+                "secret-key": "s",
+                "endpoint": "https://s3.amazonaws.com",
+                "s3-uri-style": "host",
+                "path": "",
+                "delete-older-than-days": "9999999",
+            },
+            [],
+        )
+    )
+    backup_manager._tls_ca_chain_filename = ""
+    assert backup_manager._render_pgbackrest_conf_file() is True
+    written = [c.args[1] for c in backup_manager.workload.write_text.call_args_list]
+    assert Path("/etc/pgbackrest.conf") in written
 
 
 def test_execute_pgbackrest_server_ping_runs_without_config(backup_manager, substrate):

--- a/tests/unit/test_backup_manager.py
+++ b/tests/unit/test_backup_manager.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Tests for the BackupManager (utils-free manager behavior).
+
+The manager is exercised with the real harness-provided CharmState per
+substrate plus mocks for the workload / S3 client / Patroni manager /
+update-config bridge. Focus: substrate-conditional pgBackRest invocation,
+stanza lifecycle peer-data writes, backup permission gates, creation
+bracketing, and the S3 initialization flow — no tautological asserts.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from ops import BlockedStatus
+from single_kernel_postgresql.config.exceptions import ListBackupsError
+from single_kernel_postgresql.config.literals import S3_RELATION_NAME
+from single_kernel_postgresql.managers.backup import BackupManager
+from single_kernel_postgresql.utils.backup import (
+    ANOTHER_CLUSTER_REPOSITORY_ERROR_MESSAGE,
+    FAILED_TO_ACCESS_CREATE_BUCKET_ERROR_MESSAGE,
+    STANDBY_CLUSTER_CREATE_BACKUP_ERROR_MESSAGE,
+)
+from single_kernel_postgresql.workload.base import BackupConfig
+
+VM_EXECUTABLE = "charmed-postgresql.pgbackrest"
+K8S_EXECUTABLE = "pgbackrest"
+
+
+@pytest.fixture
+def workload(substrate):
+    """A mock workload carrying a real BackupConfig for the substrate."""
+    workload = MagicMock()
+    if substrate == "vm":
+        workload.backup_config = BackupConfig(
+            executable=VM_EXECUTABLE,
+            conf_path="/var/snap/charmed-postgresql/current/etc/pgbackrest",
+            logs_path="/var/snap/charmed-postgresql/common/var/log/pgbackrest",
+            bin_path="/snap/charmed-postgresql/current/usr/lib/postgresql",
+            service="pgbackrest-service",
+            storage_path="/var/snap/charmed-postgresql/common",
+            tls_ca_chain_path=(
+                "/var/snap/charmed-postgresql/current/etc/pgbackrest/pgbackrest-tls-ca-chain.crt"
+            ),
+            extra_args=(),
+        )
+        workload.get_available_resources.return_value = (4, 1000)
+        workload.user = "_daemon_"
+        workload.group = "_daemon_"
+    else:
+        workload.backup_config = BackupConfig(
+            executable=K8S_EXECUTABLE,
+            conf_path=None,
+            logs_path="/var/lib/pg/logs/16/main/pgbackrest_logs",
+            bin_path="/usr/lib/postgresql",
+            service="pgbackrest server",
+            storage_path="/var/lib/pg/data",
+            tls_ca_chain_path="/var/lib/pg/data/pgbackrest-tls-ca-chain.crt",
+            extra_args=(),
+        )
+        workload.get_available_resources.return_value = (4, 1000)
+        workload.user = "postgres"
+        workload.group = "postgres"
+    return workload
+
+
+@pytest.fixture
+def backup_manager(harness, substrate, workload):
+    """A BackupManager wired to the harness state and mocked collaborators."""
+    manager = BackupManager(
+        state=harness.charm.state,
+        workload=workload,
+        s3_client=MagicMock(),
+        patroni_manager=MagicMock(),
+        update_config=MagicMock(return_value=True),
+        resource_provider=workload,
+        is_standby_cluster=None if substrate == "k8s" else MagicMock(return_value=False),
+    )
+    manager = manager_with_harness(harness, manager)
+    yield manager
+
+
+def manager_with_harness(harness, manager):
+    """Bind the manager to the harness charm's live state accessors."""
+    manager.state = harness.charm.state
+    return manager
+
+
+def _mock_run_cmd(manager, return_code=0, stdout="", stderr=""):
+    from single_kernel_postgresql.workload.base import CommandResult
+
+    manager.workload.run_cmd.return_value = CommandResult(return_code, stdout, stderr)
+
+
+# -- stanza_name ----------------------------------------------------------------
+
+
+def test_stanza_name_composes_model_and_cluster_name(harness, substrate, backup_manager):
+    expected = f"{harness.model.name}.{harness.charm.state.cluster_name}"
+    assert backup_manager.stanza_name == expected
+
+
+# -- _execute_pgbackrest ----------------------------------------------------------
+
+
+def test_execute_pgbackrest_uses_config_flag_only_on_vm(backup_manager, substrate):
+    _mock_run_cmd(backup_manager)
+    backup_manager._execute_pgbackrest(["stanza-create"])
+    command = backup_manager.workload.run_cmd.call_args.args[0]
+    if substrate == "vm":
+        assert command.startswith(f"{VM_EXECUTABLE} --config=")
+    else:
+        assert command.startswith(K8S_EXECUTABLE)
+        assert "--config" not in command
+    assert "--log-level-stderr=warn" in command
+    assert "stanza-create" in command
+
+
+def test_execute_pgbackrest_server_ping_runs_without_config(backup_manager, substrate):
+    _mock_run_cmd(backup_manager)
+    backup_manager._execute_pgbackrest(["server-ping", "1.2.3.4"], with_config=False)
+    command = backup_manager.workload.run_cmd.call_args.args[0]
+    assert "--config" not in command
+
+
+# -- stanza lifecycle -------------------------------------------------------------
+
+
+def test_initialise_stanza_refused_when_blocked_without_s3_message(harness, backup_manager):
+    rel_id = harness.model.get_relation("database-peers").id
+    harness.model.unit.status = BlockedStatus("blocked")
+    assert backup_manager._initialise_stanza() is False
+    assert "stanza" not in harness.get_relation_data(rel_id, harness.charm.unit.name)
+
+
+def test_check_stanza_writes_done_marker_on_non_leader(harness, backup_manager):
+    _mock_run_cmd(backup_manager)
+    backup_manager.update_config.return_value = True
+    assert backup_manager.check_stanza() is True
+    rel_id = harness.model.get_relation("database-peers").id
+    unit_db = harness.get_relation_data(rel_id, harness.charm.unit.name)
+    app_db = harness.get_relation_data(rel_id, harness.charm.app.name)
+    if harness.charm.state.peer.is_app_leader:
+        assert app_db.get("s3-initialization-start") == ""
+    else:
+        assert unit_db.get("s3-initialization-done") == "True"
+
+
+# -- backup permission gates -------------------------------------------------------
+
+
+def test_can_unit_perform_backup_rejects_standby_cluster(backup_manager, substrate):
+    if substrate != "vm":
+        pytest.skip("is_standby_cluster bridge is VM-only")
+    backup_manager._is_standby_cluster_bridge = MagicMock(return_value=True)
+    ok, message = backup_manager._can_unit_perform_backup()
+    assert ok is False
+    assert message == STANDBY_CLUSTER_CREATE_BACKUP_ERROR_MESSAGE
+
+
+def test_can_unit_perform_backup_k8s_is_never_standby(backup_manager, substrate):
+    if substrate != "k8s":
+        pytest.skip("K8s has no standby-cluster bridge")
+    assert backup_manager._is_standby_cluster is False
+
+
+def test_can_unit_perform_backup_rejects_missing_stanza(backup_manager):
+    backup_manager.patroni_manager.member_started = True
+    backup_manager.patroni_manager.get_primary.return_value = None
+    ok, message = backup_manager._can_unit_perform_backup()
+    assert ok is False
+    assert message == "Stanza was not initialised"
+
+
+def test_create_backup_rejects_invalid_type(backup_manager):
+    ok, message = backup_manager.create_backup("bogus")
+    assert ok is False
+    assert message.startswith("Invalid backup type: bogus")
+
+
+def test_create_backup_rejects_differential_without_full_backup(backup_manager):
+    backup_manager._list_backups = MagicMock(return_value={})
+    ok, message = backup_manager.create_backup("differential")
+    assert ok is False
+    assert "No previous full backup to reference" in message
+
+
+def test_create_backup_brackets_with_connectivity_off_on_replica(backup_manager):
+    backup_manager._list_backups = MagicMock(return_value={})
+    backup_manager.s3_client.upload_content.return_value = True
+    backup_manager.patroni_manager.get_primary.return_value = None
+    backup_manager._can_unit_perform_backup = MagicMock(return_value=(True, ""))
+    backup_manager._run_backup = MagicMock(return_value=(False, "boom"))
+    ok, message = backup_manager.create_backup("full")
+    assert ok is False
+    assert message == "boom"
+    # On a non-primary the connectivity-off rule is applied before the run and
+    # restored after; the creating-backup flag bracketing is unconditional.
+    connectivity_calls = [
+        c
+        for c in backup_manager.update_config.call_args_list
+        if c.kwargs.get("is_creating_backup") is True
+    ]
+    assert len(connectivity_calls) >= 1
+    assert (
+        backup_manager.update_config.call_args_list[-1].kwargs.get("is_creating_backup") is False
+    )
+
+
+# -- backup listing -----------------------------------------------------------------
+
+
+def _fake_info_payload():
+    return json.dumps([
+        {
+            "name": "test-model.app",
+            "backup": [
+                {
+                    "label": "20240101-101010F",
+                    "reference": [],
+                    "lsn": {"start": "0/1000000", "stop": "0/2000000"},
+                    "timestamp": {"start": 1704110410, "stop": 1704111010},
+                    "archive": {"start": "000000010000000000000001"},
+                    "error": None,
+                }
+            ],
+        }
+    ])
+
+
+def test_list_backups_parses_backup_ids(backup_manager):
+    _mock_run_cmd(backup_manager, stdout=_fake_info_payload())
+    backups = backup_manager._list_backups(show_failed=False)
+    assert list(backups) == ["2024-01-01T10:10:10Z"]
+    assert backups["2024-01-01T10:10:10Z"][1] == "1"
+
+
+def test_list_backups_raises_list_backups_error_on_vm_failure(backup_manager, substrate):
+    if substrate != "vm":
+        pytest.skip("ListBackupsError branch is VM-only")
+    _mock_run_cmd(backup_manager, return_code=1, stderr="ERROR: boom")
+    with pytest.raises(ListBackupsError):
+        backup_manager._list_backups(show_failed=False)
+
+
+def test_generate_backup_list_output_includes_header_and_row(harness, backup_manager):
+    _mock_run_cmd(backup_manager, stdout=_fake_info_payload())
+    backup_manager._list_timelines = MagicMock(return_value={})
+    rel_id = harness.add_relation(S3_RELATION_NAME, "s3-integrator")
+    harness.update_relation_data(
+        rel_id, "s3-integrator", {"bucket": "bucket", "access-key": "k", "secret-key": "s"}
+    )
+    output = backup_manager._generate_backup_list_output()
+    assert "Storage bucket name: bucket" in output
+    assert "2024-01-01T10:10:10Z" in output
+    assert "full backup" in output
+
+
+# -- S3 initialization flow -----------------------------------------------------------
+
+
+def test_credential_changed_checks_k8s_requires_connection_info(
+    harness, backup_manager, substrate
+):
+    if substrate != "k8s":
+        pytest.skip("connection-info-first check is K8s-specific")
+    backup_manager.workload.write_text = MagicMock()
+    backup_manager._render_pgbackrest_conf_file = MagicMock(return_value=True)
+    backup_manager._can_initialise_stanza = MagicMock(return_value=True)
+    # No S3 relation data yet -> no connection info -> reject before any render.
+    assert backup_manager._credential_changed_checks() is False
+
+
+def test_credential_changed_checks_rejects_during_pitr_restore(harness, backup_manager):
+    rel_id = harness.model.get_relation("database-peers").id
+    harness.update_relation_data(rel_id, harness.charm.app.name, {"restore-to-time": "latest"})
+    backup_manager._render_pgbackrest_conf_file = MagicMock(return_value=True)
+    assert backup_manager._credential_changed_checks() is False
+
+    with harness.hooks_disabled():
+        harness.set_leader()
+    backup_manager.s3_client.create_bucket_if_not_exists.side_effect = ValueError("bad region")
+    backup_manager._render_pgbackrest_conf_file = MagicMock(return_value=True)
+    assert backup_manager.initialise_s3_repository() is False
+    app = harness.charm.state.application
+    assert app.s3_initialization_block_message == FAILED_TO_ACCESS_CREATE_BUCKET_ERROR_MESSAGE
+
+
+def test_initialise_s3_repository_rejects_foreign_repository(harness, backup_manager):
+    with harness.hooks_disabled():
+        harness.set_leader()
+    backup_manager.can_use_s3_repository = MagicMock(
+        return_value=(False, ANOTHER_CLUSTER_REPOSITORY_ERROR_MESSAGE)
+    )
+    assert backup_manager.initialise_s3_repository() is False
+    assert (
+        harness.charm.state.application.s3_initialization_block_message
+        == ANOTHER_CLUSTER_REPOSITORY_ERROR_MESSAGE
+    )
+
+
+def test_clear_s3_state_clears_markers(backup_manager, substrate):
+    backup_manager.clear_s3_state()
+    if substrate == "k8s":
+        backup_manager.workload.stop_service.assert_called_once_with("rotate-logs")
+    else:
+        backup_manager.workload.stop_service.assert_not_called()

--- a/tests/unit/test_backup_manager.py
+++ b/tests/unit/test_backup_manager.py
@@ -22,6 +22,7 @@ from single_kernel_postgresql.config.literals import S3_RELATION_NAME
 from single_kernel_postgresql.managers.backup import BackupManager
 from single_kernel_postgresql.utils.backup import (
     ANOTHER_CLUSTER_REPOSITORY_ERROR_MESSAGE,
+    CANNOT_RESTORE_PITR,
     FAILED_TO_ACCESS_CREATE_BUCKET_ERROR_MESSAGE,
     STANDBY_CLUSTER_CREATE_BACKUP_ERROR_MESSAGE,
 )
@@ -271,15 +272,15 @@ def test_credential_changed_checks_k8s_requires_connection_info(
     backup_manager.workload.write_text = MagicMock()
     backup_manager._render_pgbackrest_conf_file = MagicMock(return_value=True)
     backup_manager._can_initialise_stanza = MagicMock(return_value=True)
-    # No S3 relation data yet -> no connection info -> reject before any render.
-    assert backup_manager._credential_changed_checks() is False
+    # No S3 relation data yet -> no connection info -> reject before any render,
+    # without deferring (the K8s charm returns without defer here too).
+    assert backup_manager._credential_changed_checks() == (False, False)
 
 
 def test_credential_changed_checks_rejects_during_pitr_restore(harness, backup_manager):
-    rel_id = harness.model.get_relation("database-peers").id
-    harness.update_relation_data(rel_id, harness.charm.app.name, {"restore-to-time": "latest"})
+    harness.model.unit.status = BlockedStatus(CANNOT_RESTORE_PITR)
     backup_manager._render_pgbackrest_conf_file = MagicMock(return_value=True)
-    assert backup_manager._credential_changed_checks() is False
+    assert backup_manager._credential_changed_checks() == (False, True)
 
     with harness.hooks_disabled():
         harness.set_leader()


### PR DESCRIPTION
## Issue

Part of the backups module migration from the PostgreSQL VM and K8s charms' 16/edge branches into this library. Stacks the restore-side pre-flight logic and the PITR target resolution onto the backup series.

## Solution

Introduces `RestoreManager` with the pre-restore gate chain (standby cluster via the injected predicate, S3 settings, backup-id-or-time requirement, PITR timestamp validation, blocked-state exceptions for the foreign-repository and PITR-recovery messages, single-unit check, no active async-replication relation, leader check, and the K8s container-connect guard), and the target resolution matrix: real backup id, timeline id requiring restore-to-time, and nearest-timeline search including the latest-timeline edge case. The PITR failure-detection helpers move in from the VM charm: recognising a failed point-in-time recovery from the Patroni logs and logging the last transaction time for the debug status. The constructor mirrors the backup manager's bridge pattern and takes the backup manager as its read-only repository of backups and timelines.

Provenance: `src/backups.py` restore paths and VM `src/charm.py` PITR helpers `@ 03494fb7b7` (VM) and `@ dec4b9602d` (K8s).

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
