### PR TITLE
feat(backups): backup events handler and s3 action wiring (15/19)

### DIFF
--- a/single_kernel_postgresql/managers/restore.py
+++ b/single_kernel_postgresql/managers/restore.py
@@ -358,7 +358,13 @@ class RestoreManager(BaseManager):
         # prevent wrong status indicated and logs reading race condition (as logs
         # cleared / moved with service restarts).
         if not self._override_patroni_restart_condition(RESTORE_REPEAT_CAUSE):
-            error_message = "Failed to override Patroni restart condition"
+            # The K8s charm words this after the Pebble on-failure condition it
+            # overrides; the VM charm after the systemd restart condition.
+            error_message = (
+                "Failed to override Patroni on-failure condition"
+                if self.state.substrate == Substrates.K8S
+                else "Failed to override Patroni restart condition"
+            )
             logger.error(f"Restore failed: {error_message}")
             self._restart_database()
             return False, error_message


### PR DESCRIPTION
## Issue

Part of the backups module migration from the PostgreSQL VM and K8s charms' 16/edge branches into this library. The actions and S3 relation events need a thin handler that translates manager outcomes into Juju results, defers, and statuses.

## Solution

Adds `BackupEventsHandler`: it owns the s3 requirer observers (credentials changed and gone, plus leader election re-running the initialization flow), the create-backup, list-backups, and restore actions, and nothing else — no pgBackRest or boto logic. Manager results map to action results and failures, status transitions go through the charm's refresh-aware status bridge, and every defer returns immediately. Two intentional differences from the charms: a Patroni error during the service start now defers on K8s as well (the K8s charm let it error the hook), and the restore request is logged before the pre-checks rather than after. The action flows keep the charm wording for failures and results, including the backup-status and restore-status payloads.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
