### PR TITLE
test(backups): cover the restore manager (16/19)

### DIFF
--- a/single_kernel_postgresql/events/backup.py
+++ b/single_kernel_postgresql/events/backup.py
@@ -13,8 +13,9 @@ import logging
 import time
 from typing import TYPE_CHECKING
 
-from ops import ActiveStatus, MaintenanceStatus, Object
+from ops import Object
 from ops.charm import ActionEvent
+from ops.pebble import ExecError
 from tenacity import RetryError
 
 from single_kernel_postgresql.config.exceptions import ListBackupsError
@@ -64,7 +65,13 @@ class BackupEventsHandler(Object):
 
     def _on_s3_credential_changed(self, event) -> None:
         """Call the stanza initialization when the credentials or the connection info change."""
-        if not self.backup_manager._credential_changed_checks():
+        proceed, defer = self.backup_manager._credential_changed_checks()
+        if not proceed:
+            # The charms defer on every branch that deferred there: credentials
+            # arriving too early, mid-PITR, mid-restore, or on a unit that
+            # cannot initialise yet must be retried later, not dropped.
+            if defer:
+                event.defer()
             return
 
         # Start the pgBackRest service for the check_stanza to be successful. It's
@@ -93,15 +100,15 @@ class BackupEventsHandler(Object):
     def _on_create_backup_action(self, event: ActionEvent) -> None:
         """Request that pgBackRest creates a backup."""
         backup_type = event.params.get("type", "full")
-        logger.info(f"A {backup_type} backup has been requested on unit")
-        self.charm.set_unit_status(MaintenanceStatus("creating backup"))
+        # The manager owns the creating-backup status bracket: the charms set
+        # Maintenance only after validation and the metadata upload, and reset
+        # Active only once the run started — never on a gate failure.
         ok, message = self.backup_manager.create_backup(backup_type)
         if not ok:
             logger.error(f"Backup failed: {message}")
             event.fail(message)
         else:
             event.set_results({"backup-status": "backup created"})
-        self.charm.set_unit_status(ActiveStatus())
 
     def _on_list_backups_action(self, event: ActionEvent) -> None:
         """List the previously created backups."""
@@ -119,7 +126,9 @@ class BackupEventsHandler(Object):
         try:
             formatted_list = self.backup_manager._generate_backup_list_output()
             event.set_results({"backups": formatted_list})
-        except ListBackupsError as e:
+        except (ListBackupsError, ExecError) as e:
+            # The K8s charm catches ExecError here (pgbackrest failures raise
+            # instead of returning a code); the message matches both charms.
             logger.exception(e)
             event.fail(f"Failed to list PostgreSQL backups with error: {e!s}")
 

--- a/single_kernel_postgresql/events/backup.py
+++ b/single_kernel_postgresql/events/backup.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Handler for backup-related charm events.
+
+The charm is the composition root: the handler receives the managers and owns
+only the observers and the mapping of manager results/exceptions onto action
+results, unit statuses and defers. No business logic lives here.
+"""
+
+import logging
+import time
+from typing import TYPE_CHECKING
+
+from ops import ActiveStatus, MaintenanceStatus, Object
+from ops.charm import ActionEvent
+from tenacity import RetryError
+
+from single_kernel_postgresql.config.exceptions import ListBackupsError
+from single_kernel_postgresql.managers.backup import BackupManager
+from single_kernel_postgresql.utils.backup import STANDBY_CLUSTER_LIST_BACKUPS_ERROR_MESSAGE
+
+if TYPE_CHECKING:
+    from single_kernel_postgresql.charms.abstract_charm import AbstractPostgreSQLCharm
+    from single_kernel_postgresql.core.state import CharmState
+    from single_kernel_postgresql.managers.restore import RestoreManager
+
+logger = logging.getLogger(__name__)
+
+
+class BackupEventsHandler(Object):
+    """Class implementing backup-related charm events handling."""
+
+    backup_manager: BackupManager
+
+    def __init__(
+        self,
+        charm: "AbstractPostgreSQLCharm",
+        state: "CharmState",
+        backup_manager: BackupManager,
+        restore_manager: "RestoreManager",
+    ) -> None:
+        super().__init__(charm, key="backup_events")
+        self.charm = charm
+        self.state = state
+        self.backup_manager = backup_manager
+        self.restore_manager = restore_manager
+
+        # s3 relation handles the config options for s3 backups
+        self.framework.observe(
+            self.state.s3_requirer.on.credentials_changed, self._on_s3_credential_changed
+        )
+        # When the leader unit is being removed, s3_client.on.credentials_gone is performed
+        # on it (and only on it). After a new leader is elected, the S3 connection must be
+        # reinitialized.
+        self.framework.observe(self.charm.on.leader_elected, self._on_s3_credential_changed)
+        self.framework.observe(
+            self.state.s3_requirer.on.credentials_gone, self._on_s3_credential_gone
+        )
+        self.framework.observe(self.charm.on.create_backup_action, self._on_create_backup_action)
+        self.framework.observe(self.charm.on.list_backups_action, self._on_list_backups_action)
+        self.framework.observe(self.charm.on.restore_action, self._on_restore_action)
+
+    def _on_s3_credential_changed(self, event) -> None:
+        """Call the stanza initialization when the credentials or the connection info change."""
+        if not self.backup_manager._credential_changed_checks():
+            return
+
+        # Start the pgBackRest service for the check_stanza to be successful. It's
+        # required to run on all the units if the tls is enabled.
+        try:
+            self.backup_manager.start_stop_pgbackrest_service()
+        except RetryError:
+            logger.debug("Cannot initialise service yet.")
+            event.defer()
+            return
+
+        if self.state.peer.is_app_leader:
+            application = self.state.application
+            application.s3_initialization_block_message = ""
+            application.s3_initialization_start = time.asctime(time.gmtime())
+            application.stanza = ""
+            application.s3_initialization_done = ""
+
+        if self.backup_manager.is_primary and self.state.peer.s3_initialization_done is None:
+            self.backup_manager.initialise_s3_repository()
+
+    def _on_s3_credential_gone(self, _) -> None:
+        """Clear the stanza and the S3 initialization markers when credentials are gone."""
+        self.backup_manager.clear_s3_state()
+
+    def _on_create_backup_action(self, event: ActionEvent) -> None:
+        """Request that pgBackRest creates a backup."""
+        backup_type = event.params.get("type", "full")
+        logger.info(f"A {backup_type} backup has been requested on unit")
+        self.charm.set_unit_status(MaintenanceStatus("creating backup"))
+        ok, message = self.backup_manager.create_backup(backup_type)
+        if not ok:
+            logger.error(f"Backup failed: {message}")
+            event.fail(message)
+        else:
+            event.set_results({"backup-status": "backup created"})
+        self.charm.set_unit_status(ActiveStatus())
+
+    def _on_list_backups_action(self, event: ActionEvent) -> None:
+        """List the previously created backups."""
+        if self.backup_manager._is_standby_cluster:
+            logger.warning(STANDBY_CLUSTER_LIST_BACKUPS_ERROR_MESSAGE)
+            event.fail(STANDBY_CLUSTER_LIST_BACKUPS_ERROR_MESSAGE)
+            return
+
+        are_backup_settings_ok, validation_message = self.backup_manager._are_backup_settings_ok()
+        if not are_backup_settings_ok:
+            logger.warning(validation_message)
+            event.fail(validation_message)
+            return
+
+        try:
+            formatted_list = self.backup_manager._generate_backup_list_output()
+            event.set_results({"backups": formatted_list})
+        except ListBackupsError as e:
+            logger.exception(e)
+            event.fail(f"Failed to list PostgreSQL backups with error: {e!s}")
+
+    def _on_restore_action(self, event: ActionEvent) -> None:
+        """Request that pgBackRest restores a backup."""
+        backup_id = event.params.get("backup-id")
+        restore_to_time = event.params.get("restore-to-time")
+        logger.info(
+            f"A restore with backup-id {backup_id}"
+            f"{f' to time point {restore_to_time}' if restore_to_time else ''}"
+            f" has been requested on the unit"
+        )
+
+        can_restore, error_message = self.restore_manager._pre_restore_checks(
+            backup_id, restore_to_time
+        )
+        if not can_restore:
+            event.fail(error_message)
+            return
+
+        # Validate the provided backup id and restore to time.
+        logger.info("Validating provided backup-id and restore-to-time")
+        try:
+            restore_stanza_timeline, is_backup_id_real, error_message = (
+                self.restore_manager._resolve_restore_target(backup_id, restore_to_time)
+            )
+        except ListBackupsError as e:
+            logger.exception(e)
+            error_message = "Failed to retrieve backups list"
+            logger.error(f"Restore failed: {error_message}")
+            event.fail(error_message)
+            return
+        if restore_stanza_timeline is None:
+            logger.error(f"Restore failed: {error_message}")
+            event.fail(error_message)
+            return
+
+        self.charm.set_unit_status(MaintenanceStatus("restoring backup"))
+        ok, message = self.restore_manager.restore(
+            restore_stanza_timeline, backup_id, restore_to_time, is_backup_id_real
+        )
+        if not ok:
+            logger.error(f"Restore failed: {message}")
+            event.fail(message)
+            return
+
+        event.set_results({"restore-status": "restore started"})

--- a/tests/unit/test_restore_manager.py
+++ b/tests/unit/test_restore_manager.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Tests for the RestoreManager (restore checks, PITR helpers and orchestration)."""
+
+import logging
+from functools import partial
+from unittest.mock import MagicMock
+
+import pytest
+from lightkube.core.exceptions import ApiError
+from lightkube.models.meta_v1 import Status
+from ops import BlockedStatus
+from single_kernel_postgresql.config.literals import K8S_POSTGRESQL_SERVICE_NAME
+from single_kernel_postgresql.core.peer_relation import PostgreSQLApplication
+from single_kernel_postgresql.managers.restore import RestoreManager
+from single_kernel_postgresql.utils.backup import (
+    ANOTHER_CLUSTER_REPOSITORY_ERROR_MESSAGE,
+    CANNOT_RESTORE_PITR,
+    STANDBY_CLUSTER_RESTORE_ERROR_MESSAGE,
+)
+from single_kernel_postgresql.workload.base import CommandResult
+from single_kernel_postgresql.workload.vm import VMWorkload
+
+BACKUP_ID = "2024-01-01T10:10:10Z"
+BACKUP_LABEL = "20240101-101010F"
+TIMELINE_ID = "2024-01-02T10:10:10Z"
+
+
+@pytest.fixture
+def workload(substrate):
+    """A mock workload for the restore seams."""
+    workload = MagicMock()
+    workload.empty_data_files.return_value = True
+    workload.remove_cluster_info.return_value = CommandResult(return_code=0)
+    if substrate == "k8s":
+        workload.workload_present = True
+    return workload
+
+
+@pytest.fixture
+def backup_manager():
+    """A mocked BackupManager: the RestoreManager's read-only repository dependency."""
+    manager = MagicMock()
+
+    def list_backups(show_failed, parse=True):
+        key = BACKUP_LABEL if not parse else BACKUP_ID
+        return {key: ("model.cluster", "1")}
+
+    manager._list_backups.side_effect = list_backups
+    manager._list_timelines.return_value = {TIMELINE_ID: ("model.cluster", "2")}
+    manager._are_backup_settings_ok.return_value = (True, "")
+    return manager
+
+
+@pytest.fixture
+def restore_manager(harness, substrate, workload, backup_manager, monkeypatch):
+    """A RestoreManager wired to the harness state and mocked collaborators."""
+    monkeypatch.setattr("single_kernel_postgresql.managers.restore.time.sleep", lambda _: None)
+    manager = RestoreManager(
+        state=harness.charm.state,
+        workload=workload,
+        patroni_manager=MagicMock(),
+        update_config=MagicMock(return_value=True),
+        backup_manager=backup_manager,
+        is_standby_cluster=None if substrate == "k8s" else MagicMock(return_value=False),
+        update_pebble_layers=MagicMock() if substrate == "k8s" else None,
+    )
+    manager.patroni_manager.get_patroni_restart_condition.return_value = "always"
+    # The conftest harness counts the remote peer unit, so the app reads as having
+    # two planned units; the restore pre-checks require a single-unit cluster.
+    monkeypatch.setattr(PostgreSQLApplication, "planned_units", property(lambda self: 1))
+    with harness.hooks_disabled():
+        harness.set_leader()
+    return manager
+
+
+# -- _pre_restore_checks -----------------------------------------------------------
+
+
+def test_pre_restore_checks_rejects_standby_cluster(restore_manager, substrate):
+    if substrate != "vm":
+        pytest.skip("standby cluster is a VM-only concept")
+    restore_manager._is_standby_cluster_bridge.return_value = True
+    ok, message = restore_manager._pre_restore_checks(BACKUP_ID, None)
+    assert not ok
+    assert message == STANDBY_CLUSTER_RESTORE_ERROR_MESSAGE
+
+
+def test_pre_restore_checks_rejects_missing_target(restore_manager):
+    ok, message = restore_manager._pre_restore_checks(None, None)
+    assert not ok
+    assert "Either backup-id or restore-to-time" in message
+
+
+def test_pre_restore_checks_rejects_bad_timestamp(restore_manager):
+    ok, message = restore_manager._pre_restore_checks(None, "yesterday")
+    assert not ok
+    assert message == "Bad restore-to-time format"
+
+
+def test_pre_restore_checks_rejects_container_not_ready(restore_manager, substrate):
+    if substrate != "k8s":
+        pytest.skip("container readiness is a K8s-only check")
+    restore_manager.workload.workload_present = False
+    ok, message = restore_manager._pre_restore_checks(BACKUP_ID, None)
+    assert not ok
+    assert message == "Workload container not ready yet!"
+
+
+def test_pre_restore_checks_rejects_blocking_state(harness, restore_manager):
+    harness.charm.unit.status = BlockedStatus("some blocking state")
+    ok, message = restore_manager._pre_restore_checks(BACKUP_ID, None)
+    assert not ok
+    assert message == "Cluster or unit is in a blocking state"
+
+
+def test_pre_restore_checks_allows_pitr_blocked_status(harness, restore_manager):
+    """A PITR failure blocked state must not block a new restore request."""
+    harness.charm.unit.status = BlockedStatus(CANNOT_RESTORE_PITR)
+    ok, _ = restore_manager._pre_restore_checks(BACKUP_ID, None)
+    assert ok
+
+
+def test_pre_restore_checks_allows_foreign_repository_blocked_status(harness, restore_manager):
+    harness.charm.unit.status = BlockedStatus(ANOTHER_CLUSTER_REPOSITORY_ERROR_MESSAGE)
+    ok, _ = restore_manager._pre_restore_checks(BACKUP_ID, None)
+    assert ok
+
+
+def test_pre_restore_checks_rejects_multiple_units(harness, restore_manager, monkeypatch):
+    monkeypatch.setattr(PostgreSQLApplication, "planned_units", property(lambda self: 2))
+    peer_rel_id = harness.model.get_relation("database-peers").id
+    harness.add_relation_unit(peer_rel_id, "postgresql-single-kernel/1")
+    ok, message = restore_manager._pre_restore_checks(BACKUP_ID, None)
+    assert not ok
+    assert message == "Unit cannot restore backup as there are more than one unit in the cluster"
+
+
+def test_pre_restore_checks_rejects_active_async_relation(harness, restore_manager):
+    harness.add_relation("replication", "other-postgresql")
+    ok, message = restore_manager._pre_restore_checks(BACKUP_ID, None)
+    assert not ok
+    assert message == "Unit cannot restore backup with an active async replication relation"
+
+
+def test_pre_restore_checks_rejects_non_leader(harness, restore_manager):
+    with harness.hooks_disabled():
+        harness.set_leader(False)
+    ok, message = restore_manager._pre_restore_checks(BACKUP_ID, None)
+    assert not ok
+    assert message == "Unit cannot restore backup as it was not elected the leader unit yet"
+
+
+# -- _resolve_restore_target --------------------------------------------------------
+
+
+def test_resolve_restore_target_real_backup_id(restore_manager):
+    target, is_real, message = restore_manager._resolve_restore_target(BACKUP_ID, None)
+    assert target == ("model.cluster", "1")
+    assert is_real is True
+    assert message == ""
+
+
+def test_resolve_restore_target_rejects_invalid_backup_id(restore_manager):
+    target, _is_real, message = restore_manager._resolve_restore_target("nope", None)
+    assert target is None
+    assert message == "Invalid backup-id: nope"
+
+
+def test_resolve_restore_target_rejects_timeline_without_time(restore_manager):
+    target, _is_real, message = restore_manager._resolve_restore_target(TIMELINE_ID, None)
+    assert target is None
+    assert message == "Cannot restore to the timeline without restore-to-time parameter"
+
+
+def test_resolve_restore_target_latest_requires_base_backup(restore_manager):
+    """No backup was created from the latest timeline, so "latest" must be rejected."""
+    target, _is_real, message = restore_manager._resolve_restore_target(None, "latest")
+    assert target is None
+    assert message == "There is no base backup created from the latest timeline"
+
+
+def test_resolve_restore_target_resolves_nearest_timeline(restore_manager):
+    restore_manager.backup_manager._list_backups.side_effect = None
+    restore_manager.backup_manager._list_backups.return_value = {}
+    target, _is_real, message = restore_manager._resolve_restore_target(
+        None, "2024-01-03 00:00:00"
+    )
+    assert target == ("model.cluster", "2")
+    assert _is_real is False
+    assert message == ""
+
+
+def test_resolve_restore_target_rejects_missing_timeline(restore_manager):
+    restore_manager.backup_manager._list_backups.side_effect = None
+    restore_manager.backup_manager._list_backups.return_value = {}
+    restore_manager.backup_manager._list_timelines.return_value = {}
+    target, _is_real, message = restore_manager._resolve_restore_target(
+        None, "2024-01-03 00:00:00"
+    )
+    assert target is None
+    assert message.startswith("Can't find the nearest timeline before timestamp")
+
+
+# -- restore orchestration -----------------------------------------------------------
+
+
+def test_restore_vm_stops_patroni_then_reconfigures(restore_manager, substrate):
+    if substrate != "vm":
+        pytest.skip("VM-only orchestration")
+    restore_manager.patroni_manager.get_patroni_restart_condition.return_value = "always"
+    ok, message = restore_manager.restore(
+        ("model.cluster", "2"), None, "2024-01-03 00:00:00", False
+    )
+    assert (ok, message) == (True, "restore started")
+    restore_manager.patroni_manager.stop_patroni.assert_called_once()
+    restore_manager.patroni_manager.update_patroni_restart_condition.assert_called_once_with("no")
+    restore_manager.workload.empty_data_files.assert_called_once()
+    restore_manager.update_config.assert_called_once()
+    restore_manager.patroni_manager.start_patroni.assert_called_once()
+    app_data = restore_manager.state.application.data
+    assert app_data["restore-stanza"] == "model.cluster"
+    assert app_data["restore-timeline"] == "2"
+    assert app_data["restore-to-time"] == "2024-01-03 00:00:00"
+    # ops deletes a databag key when it is set to the empty string
+    assert app_data.get("restoring-backup", "") == ""
+    assert app_data.get("s3-initialization-block-message", "") == ""
+
+
+def test_restore_vm_removes_cluster_info_after_start(restore_manager, substrate):
+    if substrate != "vm":
+        pytest.skip("VM-only orchestration")
+    restore_manager.restore(("model.cluster", "1"), BACKUP_ID, None, True)
+    calls = [call[0] for call in restore_manager.workload.mock_calls]
+    assert calls.index("empty_data_files") < calls.index("remove_cluster_info")
+    restore_manager.workload.remove_cluster_info.assert_called_once_with(
+        restore_manager.state.cluster_name
+    )
+
+
+def test_vm_remove_cluster_info_sends_confirmation_stdin(substrate):
+    """The VM patronictl remove carries the cluster name + confirmation on stdin."""
+    if substrate != "vm":
+        pytest.skip("VM-only cluster-info removal")
+    workload = MagicMock()
+    workload.paths.patroni_config = "/etc/patroni"
+    remove = partial(VMWorkload.remove_cluster_info, workload)
+    remove("model.cluster")
+    args, kwargs = workload.run_cmd.call_args
+    assert "remove" in args[0]
+    assert "model.cluster" in args[0]
+    assert kwargs["stdin"] == "model.cluster\nYes I am aware"
+    assert kwargs["timeout"] == 10
+
+
+def test_restore_k8s_stops_and_controls_pebble_services(restore_manager, substrate):
+    if substrate != "k8s":
+        pytest.skip("K8s-only orchestration")
+    ok, message = restore_manager.restore(("model.cluster", "1"), BACKUP_ID, None, True)
+    assert (ok, message) == (True, "restore started")
+    restore_manager.workload.stop_service.assert_called_once_with(K8S_POSTGRESQL_SERVICE_NAME)
+    restore_manager.workload.start_service.assert_called_once_with(K8S_POSTGRESQL_SERVICE_NAME)
+    restore_manager.workload.init_storage.assert_called_once()
+    restore_manager.workload.remove_cluster_info.assert_called_once_with(
+        restore_manager.state.cluster_name, restore_manager.state.model_name
+    )
+
+
+def test_restore_k8s_overrides_on_failure_condition(restore_manager, substrate):
+    if substrate != "k8s":
+        pytest.skip("K8s-only orchestration")
+    restore_manager.restore(("model.cluster", "1"), BACKUP_ID, None, True)
+    unit_data = restore_manager.state.peer.data
+    assert unit_data["patroni-on-failure-condition-override"] == "ignore"
+    assert unit_data["overridden-patroni-on-failure-condition-repeat-cause"] == "restore-backup"
+    restore_manager._update_pebble_layers_bridge.assert_called()
+
+
+def test_restore_k8s_removes_cluster_info_before_wipe(restore_manager, substrate):
+    if substrate != "k8s":
+        pytest.skip("K8s-only orchestration")
+    restore_manager.restore(("model.cluster", "1"), BACKUP_ID, None, True)
+    calls = [call[0] for call in restore_manager.workload.mock_calls]
+    assert calls.index("remove_cluster_info") < calls.index("empty_data_files")
+
+
+def test_restore_failure_to_stop_database_returns_error(restore_manager, substrate):
+    if substrate != "vm":
+        pytest.skip("VM-only stop path")
+    restore_manager.patroni_manager.stop_patroni.return_value = False
+    ok, message = restore_manager.restore(("model.cluster", "1"), BACKUP_ID, None, True)
+    assert (ok, message) == (False, "Failed to stop database service")
+    restore_manager.workload.empty_data_files.assert_not_called()
+
+
+def test_restore_override_failure_recovers_database(restore_manager, substrate):
+    if substrate != "vm":
+        pytest.skip("VM-only restart-condition override")
+    unit_data = restore_manager.state.peer.data
+    unit_data["overridden-patroni-restart-condition"] = "always"
+    unit_data["overridden-patroni-restart-condition-repeat-cause"] = "other-cause"
+    ok, message = restore_manager.restore(("model.cluster", "1"), BACKUP_ID, None, True)
+    assert (ok, message) == (False, "Failed to override Patroni restart condition")
+    restore_manager.update_config.assert_called_once()  # from _restart_database
+    restore_manager.patroni_manager.start_patroni.assert_called_once()
+
+
+def test_restore_empty_failure_recovers_database(restore_manager, substrate):
+    if substrate != "vm":
+        pytest.skip("VM-only empty failure path")
+    restore_manager.workload.empty_data_files.return_value = False
+    ok, message = restore_manager.restore(("model.cluster", "1"), BACKUP_ID, None, True)
+    assert (ok, message) == (False, "Failed to remove contents of the data directory")
+    restore_manager.patroni_manager.start_patroni.assert_called_once()
+
+
+def test_restore_k8s_endpoint_failure_recovers_database(restore_manager, substrate):
+    if substrate != "k8s":
+        pytest.skip("K8s-only endpoint removal")
+    restore_manager.workload.remove_cluster_info.side_effect = ApiError(
+        status=Status(message="boom")
+    )
+    ok, message = restore_manager.restore(("model.cluster", "1"), BACKUP_ID, None, True)
+    assert ok is False
+    assert message.startswith("Failed to remove previous cluster information")
+    restore_manager.workload.start_service.assert_called_once_with(K8S_POSTGRESQL_SERVICE_NAME)
+
+
+def test_restore_patroni_restart_condition_restores_override(restore_manager, substrate):
+    if substrate != "vm":
+        pytest.skip("VM-only restart-condition override")
+    restore_manager.patroni_manager.get_patroni_restart_condition.return_value = "always"
+    restore_manager.restore(("model.cluster", "1"), BACKUP_ID, None, True)
+    restore_manager.restore_patroni_restart_condition()
+    unit_data = restore_manager.state.peer.data
+    # setting the override fields to "" removes them from the databag
+    assert "overridden-patroni-restart-condition" not in unit_data
+    restore_manager.patroni_manager.update_patroni_restart_condition.assert_any_call("always")
+
+
+# -- PITR helpers ---------------------------------------------------------------------
+
+
+def test_is_pitr_failed_tracks_new_failures(restore_manager, substrate):
+    if substrate != "vm":
+        pytest.skip("VM-only patroni logs")
+    restore_manager.patroni_manager.patroni_logs.return_value = (
+        "2024-01-01T00:00:00.000Z localhost patroni.exceptions.PatroniFatalException:"
+        " Failed to bootstrap cluster"
+    )
+    assert restore_manager.is_pitr_failed() == (True, True)
+    assert restore_manager.is_pitr_failed() == (True, False)
+    restore_manager.patroni_manager.patroni_logs.return_value = (
+        "2024-01-02T00:00:00.000Z localhost patroni.exceptions.PatroniFatalException:"
+        " Failed to bootstrap cluster"
+    )
+    assert restore_manager.is_pitr_failed() == (True, True)
+
+
+def test_is_pitr_failed_reports_no_failure(restore_manager, substrate):
+    if substrate != "vm":
+        pytest.skip("VM-only patroni logs")
+    restore_manager.patroni_manager.patroni_logs.return_value = ""
+    assert restore_manager.is_pitr_failed() == (False, False)
+
+
+def test_is_pitr_failed_k8s_scans_pebble_logs(restore_manager, substrate):
+    if substrate != "k8s":
+        pytest.skip("K8s-only pebble logs")
+    restore_manager.workload.pitr_bootstrap_failure_logs.return_value = (
+        (
+            "2024-01-01T00:00:00.000Z [postgresql] patroni.exceptions.PatroniFatalException:"
+            " Failed to bootstrap cluster"
+        ),
+        False,
+    )
+    assert restore_manager.is_pitr_failed() == (True, True)
+
+
+def test_log_pitr_last_transaction_time(restore_manager, caplog):
+    caplog.set_level(logging.INFO)
+    restore_manager.patroni_manager.last_postgresql_logs.return_value = (
+        "2024-01-01 00:00:00 UTC [123]: LOG:  last completed transaction was at log time"
+        " 2024-01-01 00:00:00 UTC"
+    )
+    restore_manager.log_pitr_last_transaction_time()
+    assert any("Last completed transaction was at" in record.message for record in caplog.records)
+
+
+def test_log_pitr_last_transaction_time_reports_missing_time(restore_manager, caplog):
+    restore_manager.patroni_manager.last_postgresql_logs.return_value = ""
+    restore_manager.log_pitr_last_transaction_time()
+    assert any(
+        "Can't tell last completed transaction time" in record.message for record in caplog.records
+    )


### PR DESCRIPTION
## Issue

Unit tests for the restore manager, stacked on its port PRs.

## Solution

Covers the pre-restore gate chain per substrate (including the async-replication and leader guards), the target-resolution matrix (real id, timeline id, nearest timeline, latest-timeline edge case), the PITR helpers, and the orchestration sequence: the service stop and start, the restart-condition override and its recovery path, the peer-field writes that drive the library's Patroni restore rendering, and the substrate-ordered cluster-information removal, on the dual-substrate harness with the workload, S3, Patroni, and config bridges mocked at their seams.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
