### PR TITLE
feat(backups): ship the rotate-logs script and push it from the render (18/19)

### DIFF
--- a/single_kernel_postgresql/managers/backup.py
+++ b/single_kernel_postgresql/managers/backup.py
@@ -304,6 +304,22 @@ class BackupManager(BaseManager):
             user=None,
             group=None,
         )
+        if self.state.substrate == Substrates.K8S:
+            # The Pebble layer declares the rotate-logs service around this
+            # script; push it where the layer's command expects it and start
+            # the service when the layer already declared it.
+            rotate_logs_script = (
+                importlib.resources
+                .files("single_kernel_postgresql.scripts")
+                .joinpath("rotate_logs.py")
+                .read_text()
+            )
+            self.workload.write_text(
+                rotate_logs_script,
+                self.workload.root / "home/postgres/rotate_logs.py",
+            )
+            if self.workload.service_exists(K8S_ROTATE_LOGS_SERVICE_NAME):
+                self.workload.start_service(K8S_ROTATE_LOGS_SERVICE_NAME)
         return True
 
     # -- Stanza lifecycle -------------------------------------------------------

--- a/single_kernel_postgresql/scripts/rotate_logs.py
+++ b/single_kernel_postgresql/scripts/rotate_logs.py
@@ -1,0 +1,21 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Service for rotating logs."""
+
+import subprocess
+import time
+
+
+def main():
+    """Main loop that calls logrotate."""
+    while True:
+        # Command is hardcoded
+        subprocess.run(["/usr/sbin/logrotate", "-f", "/etc/logrotate.d/pgbackrest.logrotate"])
+
+        # Wait 60 seconds before executing logrotate again.
+        time.sleep(60)
+
+
+if __name__ == "__main__":
+    main()

--- a/single_kernel_postgresql/workload/base.py
+++ b/single_kernel_postgresql/workload/base.py
@@ -370,6 +370,11 @@ class BaseWorkload(ABC):
         pass
 
     @abstractmethod
+    def service_exists(self, service: str) -> bool:
+        """Whether the workload layer declares the named service at all."""
+        pass
+
+    @abstractmethod
     def service_is_running(self, service: str) -> bool:
         """Check whether a named service is running on the workload.
 

--- a/single_kernel_postgresql/workload/k8s.py
+++ b/single_kernel_postgresql/workload/k8s.py
@@ -187,6 +187,12 @@ class K8sWorkload(BaseWorkload):
         else:
             self.container.restart(service)
 
+    def service_exists(self, service: str) -> bool:
+        """Whether the Pebble plan declares the named service."""
+        if not self.container.can_connect():
+            return False
+        return len(self.container.pebble.get_services(names=[service])) > 0
+
     def service_is_running(self, service: str) -> bool:
         """Check whether a named Pebble service is running.
 

--- a/single_kernel_postgresql/workload/vm.py
+++ b/single_kernel_postgresql/workload/vm.py
@@ -218,6 +218,14 @@ class VMWorkload(BaseWorkload):
         """
         self.restart_service(service)
 
+    def service_exists(self, service: str) -> bool:
+        """Whether the snap declares the named service."""
+        try:
+            services = snap.SnapCache()["charmed-postgresql"].services
+        except snap.SnapError:
+            return False
+        return service in services
+
     def service_is_running(self, service: str) -> bool:
         """Check whether a named snap service is running.
 


### PR DESCRIPTION
## Issue

Part of the backups module migration from the PostgreSQL VM and K8s charms' 16/edge branches into this library. The rotate-logs Pebble service declared in the K8s layer runs a script both charms carry and their render pushed into the container; without it the adopted render would leave the service pointing at a missing file.

## Solution

The library ships the converged script under `single_kernel_postgresql/scripts/` (the two charm copies differed only in style) and the K8s render branch pushes it where the layer's command expects it, starting the service when the layer already declares it, exactly as the charm's render did. The presence check is backed by a new `service_exists` workload seam alongside `service_is_running`. The VM charm's `RotateLogs` wrapper stays charm-side for now: it is status-coupled charm wiring around the same logrotate invocation.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
