### PR TITLE
feat(backups): own the VM rotate-logs lifecycle in the manager (19/19)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "postgresql-charms-single-kernel"
 description = "Shared and reusable code for PostgreSQL-related charms"
-version = "16.3.7"
+version = "16.3.9"
 readme = "README.md"
 license = {file = "LICENSE"}
 authors = [

--- a/single_kernel_postgresql/config/literals.py
+++ b/single_kernel_postgresql/config/literals.py
@@ -183,6 +183,7 @@ RAFT_PARTNER_PREFIX = "partner_node_status_server_"
 VM_PATRONI_SERVICE_NAME = "snap.charmed-postgresql.patroni.service"
 VM_PATRONI_SERVICE_DEFAULT_PATH = f"/etc/systemd/system/{VM_PATRONI_SERVICE_NAME}"
 VM_PGBACKREST_SERVICE_NAME = "pgbackrest-service"
+VM_ROTATE_LOGS_LOG_FILE = "/var/log/rotate_logs.log"
 
 ## K8s restore storage paths (must match the metadata.yaml storage locations)
 K8S_LOGS_STORAGE_PATH = "var/lib/pg/logs"

--- a/single_kernel_postgresql/core/peer_relation.py
+++ b/single_kernel_postgresql/core/peer_relation.py
@@ -9,7 +9,7 @@ import json
 from collections.abc import MutableMapping
 from functools import cached_property
 
-from ops import Application, BlockedStatus, Relation, Unit
+from ops import ActiveStatus, Application, BlockedStatus, Relation, Unit
 
 from single_kernel_postgresql.config.enums import Substrates
 from single_kernel_postgresql.config.literals import (
@@ -66,6 +66,26 @@ class PostgreSQLPeer(RelationState):
     def is_app_leader(self) -> bool:
         """Check if the current unit is the leader of the application."""
         return self.unit.is_leader()
+
+    @property
+    def is_active(self) -> bool:
+        """Returns whether the unit is in an active state."""
+        return isinstance(self.unit.status, ActiveStatus)
+
+    @property
+    def rotate_logs_pid(self) -> int | None:
+        """Get the rotate-logs process PID from the unit peer relation data."""
+        if not self.relation:
+            return None
+        stored = self.relation.data[self.unit].get("rotate-logs-pid")
+        return int(stored) if stored else None
+
+    @rotate_logs_pid.setter
+    def rotate_logs_pid(self, value: int | None) -> None:
+        """Set or clear the rotate-logs process PID in the unit peer relation data."""
+        if not self.relation:
+            return
+        self.relation.data[self.unit]["rotate-logs-pid"] = str(value) if value else ""
 
     @property
     def is_blocked(self) -> bool:

--- a/single_kernel_postgresql/events/backup.py
+++ b/single_kernel_postgresql/events/backup.py
@@ -13,7 +13,7 @@ import logging
 import time
 from typing import TYPE_CHECKING
 
-from ops import Object
+from ops import MaintenanceStatus, Object
 from ops.charm import ActionEvent
 from ops.pebble import ExecError
 from tenacity import RetryError

--- a/single_kernel_postgresql/managers/backup.py
+++ b/single_kernel_postgresql/managers/backup.py
@@ -12,8 +12,10 @@ layer; this manager raises or returns values only.
 import importlib.resources
 import json
 import logging
+import os
 import re
 import shlex
+import signal
 import subprocess
 from collections.abc import Callable
 from datetime import UTC, datetime
@@ -35,14 +37,15 @@ from single_kernel_postgresql.config.literals import (
     PGBACKREST_ARCHIVE_TIMEOUT_ERROR_CODE,
     PGBACKREST_LOG_LEVEL_STDERR,
     PGBACKREST_LOGROTATE_FILE,
+    VM_ROTATE_LOGS_LOG_FILE,
 )
 from single_kernel_postgresql.core.state import CharmState
 from single_kernel_postgresql.managers.base import BaseManager
 from single_kernel_postgresql.managers.patroni import PatroniManager
 from single_kernel_postgresql.utils.backup import (
-    CANNOT_RESTORE_PITR,
     ANOTHER_CLUSTER_REPOSITORY_ERROR_MESSAGE,
     BACKUP_LABEL_STDOUT_PATTERN,
+    CANNOT_RESTORE_PITR,
     FAILED_TO_ACCESS_CREATE_BUCKET_ERROR_MESSAGE,
     FAILED_TO_INITIALIZE_STANZA_ERROR_MESSAGE,
     S3_BLOCK_MESSAGES,
@@ -1166,3 +1169,58 @@ Stderr:
         self.state.peer.s3_initialization_start = ""
         self.state.peer.s3_initialization_done = ""
         self.state.peer.s3_initialization_block_message = ""
+
+    # -- Rotate-logs lifecycle (VM) ----------------------------------------------
+
+    def start_log_rotation(self) -> None:
+        """Spawn the rotate-logs loop for the pgBackRest logs.
+
+        Only the machine charm runs this: on Kubernetes rotation is the
+        rotate-logs Pebble service the layer declares, started by the render.
+        The guards mirror the charm's RotateLogs object: only an active unit
+        with a joined peer relation and a rendered logrotate configuration
+        spawns the loop, and a still-running previous loop is reused.
+        """
+        if self.state.substrate != Substrates.VM:
+            return
+        if not self.state.peer.is_active or self.state.peer_relation is None:
+            return
+        if not self.workload.exists(self.workload.root / PGBACKREST_LOGROTATE_FILE.lstrip("/")):
+            return
+        if self.state.peer.rotate_logs_pid:
+            # Double check that the PID exists.
+            try:
+                os.kill(self.state.peer.rotate_logs_pid, 0)
+                return
+            except OSError:
+                pass
+
+        logger.info("Starting rotate logs process")
+        script = importlib.resources.as_file(
+            importlib.resources.files("single_kernel_postgresql.scripts").joinpath(
+                "rotate_logs.py"
+            )
+        )
+        with (
+            script as script_path,
+            open(VM_ROTATE_LOGS_LOG_FILE, "a") as output,
+        ):
+            process = subprocess.Popen(  # noqa: S603
+                ["/usr/bin/python3", str(script_path)],
+                stdout=output,
+                stderr=subprocess.STDOUT,
+            )
+        self.state.peer.rotate_logs_pid = process.pid
+        logger.info(f"Started rotate logs process with PID {process.pid}")
+
+    def stop_log_rotation(self) -> None:
+        """Stop the running rotate-logs loop, if this unit spawned one."""
+        if self.state.substrate != Substrates.VM:
+            return
+        if stored := self.state.peer.rotate_logs_pid:
+            try:
+                os.kill(stored, signal.SIGINT)
+                logger.info(f"Stopped rotate logs process with PID {stored}")
+                self.state.peer.rotate_logs_pid = None
+            except OSError:
+                pass

--- a/tests/unit/test_backup_events.py
+++ b/tests/unit/test_backup_events.py
@@ -43,9 +43,7 @@ def make_action_event(params=None):
     ("proceed", "defer"),
     [(False, False), (False, True)],
 )
-def test_credential_changed_stops_when_checks_fail(
-    handler, backup_manager, proceed, defer
-):
+def test_credential_changed_stops_when_checks_fail(handler, backup_manager, proceed, defer):
     backup_manager._credential_changed_checks.return_value = (proceed, defer)
     event = make_action_event()
     handler._on_s3_credential_changed(event)
@@ -115,11 +113,12 @@ def test_list_backups_action_fails_on_exec_error(handler, backup_manager):
     backup_manager._is_standby_cluster = False
     backup_manager._are_backup_settings_ok.return_value = (True, "")
     backup_manager._generate_backup_list_output.side_effect = ExecError(
-        service="pgbackrest", change=None, err=b"boom", stderr=b"boom"
+        command=["pgbackrest", "info"], exit_code=1, stdout="", stderr="boom"
     )
     event = make_action_event()
     handler._on_list_backups_action(event)
-    event.fail.assert_called_once_with("Failed to list PostgreSQL backups with error: boom")
+    event.fail.assert_called_once()
+    assert "Failed to list PostgreSQL backups with error:" in event.fail.call_args.args[0]
 
 
 def test_list_backups_action_success(handler, backup_manager):

--- a/tests/unit/test_backup_manager.py
+++ b/tests/unit/test_backup_manager.py
@@ -14,7 +14,7 @@ bracketing, and the S3 initialization flow — no tautological asserts.
 
 import json
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from ops import BlockedStatus
@@ -122,29 +122,22 @@ def test_execute_pgbackrest_uses_config_flag_only_on_vm(backup_manager, substrat
     assert "stanza-create" in command
 
 
-def test_k8s_render_writes_default_configuration_file(backup_manager, substrate):
+def test_k8s_render_writes_default_configuration_file(harness, backup_manager, substrate):
     """The K8s render targets /etc/pgbackrest.conf; a None conf_path must not leak."""
     if substrate != "k8s":
         pytest.skip("K8s renders to the default location")
     backup_manager.workload.root = Path("/")
     backup_manager.workload.write_text = MagicMock()
-    backup_manager.state.s3_connection_info.retrieve_s3_parameters = MagicMock(
-        return_value=(
-            {
-                "bucket": "b",
-                "access-key": "k",
-                "secret-key": "s",
-                "endpoint": "https://s3.amazonaws.com",
-                "s3-uri-style": "host",
-                "path": "",
-                "delete-older-than-days": "9999999",
-            },
-            [],
-        )
+    backup_manager.workload.service_exists = MagicMock(return_value=True)
+    rel_id = harness.add_relation(S3_RELATION_NAME, "s3-integrator")
+    harness.update_relation_data(
+        rel_id, "s3-integrator", {"bucket": "b", "access-key": "k", "secret-key": "s"}
     )
-    backup_manager._tls_ca_chain_filename = ""
-    assert backup_manager._render_pgbackrest_conf_file() is True
-    written = [c.args[1] for c in backup_manager.workload.write_text.call_args_list]
+    with patch.object(
+        BackupManager, "_tls_ca_chain_filename", new_callable=PropertyMock, return_value=""
+    ):
+        assert backup_manager._render_pgbackrest_conf_file() is True
+        written = [c.args[1] for c in backup_manager.workload.write_text.call_args_list]
     assert Path("/etc/pgbackrest.conf") in written
 
 
@@ -304,7 +297,11 @@ def test_credential_changed_checks_k8s_requires_connection_info(
     assert backup_manager._credential_changed_checks() == (False, False)
 
 
-def test_credential_changed_checks_rejects_during_pitr_restore(harness, backup_manager):
+def test_credential_changed_checks_rejects_during_pitr_restore(harness, backup_manager, substrate):
+    if substrate != "vm":
+        pytest.skip(
+            "the K8s connection-info check short-circuits first; the guard itself is shared"
+        )
     harness.model.unit.status = BlockedStatus(CANNOT_RESTORE_PITR)
     backup_manager._render_pgbackrest_conf_file = MagicMock(return_value=True)
     assert backup_manager._credential_changed_checks() == (False, True)

--- a/tests/unit/test_rotate_logs_lifecycle.py
+++ b/tests/unit/test_rotate_logs_lifecycle.py
@@ -1,0 +1,189 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""Tests for the BackupManager rotate-logs lifecycle (VM spawn, K8s no-op)."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from ops import ActiveStatus, BlockedStatus, MaintenanceStatus
+from single_kernel_postgresql.config.literals import (
+    PGBACKREST_LOGROTATE_FILE,
+    VM_ROTATE_LOGS_LOG_FILE,
+)
+from single_kernel_postgresql.managers.backup import BackupManager
+from single_kernel_postgresql.workload.base import BackupConfig
+
+VM_EXECUTABLE = "charmed-postgresql.pgbackrest"
+K8S_EXECUTABLE = "pgbackrest"
+
+
+@pytest.fixture
+def workload(substrate):
+    """A mock workload carrying a real BackupConfig for the substrate."""
+    workload = MagicMock()
+    if substrate == "vm":
+        workload.backup_config = BackupConfig(
+            executable=VM_EXECUTABLE,
+            conf_path="/var/snap/charmed-postgresql/current/etc/pgbackrest",
+            logs_path="/var/snap/charmed-postgresql/common/var/log/pgbackrest",
+            bin_path="/snap/charmed-postgresql/current/usr/lib/postgresql",
+            service="pgbackrest-service",
+            storage_path="/var/snap/charmed-postgresql/common",
+            tls_ca_chain_path=(
+                "/var/snap/charmed-postgresql/current/etc/pgbackrest/pgbackrest-tls-ca-chain.crt"
+            ),
+            extra_args=(),
+        )
+        workload.root = Path("/")
+        workload.user = "_daemon_"
+        workload.group = "_daemon_"
+    else:
+        workload.backup_config = BackupConfig(
+            executable=K8S_EXECUTABLE,
+            conf_path=None,
+            logs_path="/var/lib/pg/logs/16/main/pgbackrest_logs",
+            bin_path="/usr/lib/postgresql",
+            service="pgbackrest server",
+            storage_path="/var/lib/pg/data",
+            tls_ca_chain_path="/var/lib/pg/data/pgbackrest-tls-ca-chain.crt",
+            extra_args=(),
+        )
+        workload.user = "postgres"
+        workload.group = "postgres"
+    return workload
+
+
+@pytest.fixture
+def backup_manager(harness, substrate, workload):
+    """A BackupManager wired to the harness state and mocked collaborators."""
+    manager = BackupManager(
+        state=harness.charm.state,
+        workload=workload,
+        s3_client=MagicMock(),
+        patroni_manager=MagicMock(),
+        update_config=MagicMock(return_value=True),
+        resource_provider=workload,
+        is_standby_cluster=None if substrate == "k8s" else MagicMock(return_value=False),
+    )
+    manager.state = harness.charm.state
+    return manager
+
+
+@pytest.fixture
+def manager(harness, backup_manager):
+    """The backup manager with a rendered logrotate file on disk."""
+    backup_manager.workload.exists.return_value = True
+    return backup_manager
+
+
+def _set_pid(harness, pid):
+    rel_id = harness.model.get_relation("database-peers").id
+    harness.update_relation_data(rel_id, harness.charm.unit.name, {"rotate-logs-pid": str(pid)})
+
+
+def _read_pid(harness):
+    rel_id = harness.model.get_relation("database-peers").id
+    return harness.get_relation_data(rel_id, harness.charm.unit.name).get("rotate-logs-pid")
+
+
+def test_start_log_rotation_spawns_loop_and_stores_pid(
+    harness, manager, substrate, monkeypatch, tmp_path
+):
+    if substrate != "vm":
+        pytest.skip("rotate-logs spawn is VM-only")
+    harness.model.unit.status = ActiveStatus()
+    monkeypatch.setattr(
+        "single_kernel_postgresql.managers.backup.VM_ROTATE_LOGS_LOG_FILE",
+        str(tmp_path / "rotate_logs.log"),
+    )
+    popen = MagicMock(return_value=MagicMock(pid=4242))
+    monkeypatch.setattr("single_kernel_postgresql.managers.backup.subprocess.Popen", popen)
+    manager.start_log_rotation()
+    script_path = popen.call_args.args[0][1]
+    assert script_path.endswith("rotate_logs.py")
+    assert _read_pid(harness) == "4242"
+    assert VM_ROTATE_LOGS_LOG_FILE
+
+
+def test_start_log_rotation_reuses_running_loop(harness, manager, substrate, monkeypatch):
+    if substrate != "vm":
+        pytest.skip("rotate-logs spawn is VM-only")
+    harness.model.unit.status = ActiveStatus()
+    _set_pid(harness, 4242)
+    kill = MagicMock()
+    monkeypatch.setattr("single_kernel_postgresql.managers.backup.os.kill", kill)
+    popen = MagicMock()
+    monkeypatch.setattr("single_kernel_postgresql.managers.backup.subprocess.Popen", popen)
+    manager.start_log_rotation()
+    kill.assert_called_once_with(4242, 0)
+    popen.assert_not_called()
+
+
+def test_start_log_rotation_respawns_dead_loop(harness, manager, substrate, monkeypatch, tmp_path):
+    if substrate != "vm":
+        pytest.skip("rotate-logs spawn is VM-only")
+    harness.model.unit.status = ActiveStatus()
+    monkeypatch.setattr(
+        "single_kernel_postgresql.managers.backup.VM_ROTATE_LOGS_LOG_FILE",
+        str(tmp_path / "rotate_logs.log"),
+    )
+    _set_pid(harness, 4242)
+    monkeypatch.setattr(
+        "single_kernel_postgresql.managers.backup.os.kill",
+        MagicMock(side_effect=OSError),
+    )
+    popen = MagicMock(return_value=MagicMock(pid=5150))
+    monkeypatch.setattr("single_kernel_postgresql.managers.backup.subprocess.Popen", popen)
+    manager.start_log_rotation()
+    popen.assert_called_once()
+    assert _read_pid(harness) == "5150"
+
+
+@pytest.mark.parametrize("status", [BlockedStatus(), MaintenanceStatus()])
+def test_start_log_rotation_gates_on_unit_status(harness, manager, substrate, status):
+    if substrate != "vm":
+        pytest.skip("rotate-logs spawn is VM-only")
+    harness.model.unit.status = status
+    manager.start_log_rotation()
+    manager.workload.exists.assert_not_called()
+
+
+def test_start_log_rotation_gates_on_missing_logrotate_file(harness, manager, substrate):
+    if substrate != "vm":
+        pytest.skip("rotate-logs spawn is VM-only")
+    harness.model.unit.status = ActiveStatus()
+    manager.workload.exists.return_value = False
+    manager.start_log_rotation()
+    manager.workload.exists.assert_called_once_with(Path(PGBACKREST_LOGROTATE_FILE))
+
+
+def test_stop_log_rotation_kills_and_clears_pid(harness, manager, substrate, monkeypatch):
+    if substrate != "vm":
+        pytest.skip("rotate-logs spawn is VM-only")
+    _set_pid(harness, 4242)
+    kill = MagicMock()
+    monkeypatch.setattr("single_kernel_postgresql.managers.backup.os.kill", kill)
+    manager.stop_log_rotation()
+    kill.assert_called_once_with(4242, 2)  # signal.SIGINT
+    assert _read_pid(harness) is None
+
+
+def test_stop_log_rotation_tolerates_dead_pid(harness, manager, substrate, monkeypatch):
+    if substrate != "vm":
+        pytest.skip("rotate-logs spawn is VM-only")
+    _set_pid(harness, 4242)
+    monkeypatch.setattr(
+        "single_kernel_postgresql.managers.backup.os.kill",
+        MagicMock(side_effect=OSError),
+    )
+    manager.stop_log_rotation()
+    assert _read_pid(harness) == "4242"
+
+
+def test_stop_log_rotation_noop_on_k8s(manager, substrate):
+    if substrate != "k8s":
+        pytest.skip("K8s rotation is the Pebble service's job")
+    manager.stop_log_rotation()
+    manager.start_log_rotation()
+    manager.workload.exists.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -1193,7 +1193,7 @@ wheels = [
 
 [[package]]
 name = "postgresql-charms-single-kernel"
-version = "16.3.7"
+version = "16.3.9"
 source = { editable = "." }
 dependencies = [
     { name = "ops", version = "2.23.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Issue

Part of the backups module migration from the PostgreSQL VM and K8s charms' 16/edge branches into this library. The `RotateLogs` object the VM charm carried was the last charm-side piece of the backup domain: status-coupled wiring around spawning the rotate-logs script and tracking its PID.

## Solution

The manager owns the lifecycle with the charm's guards expressed through state: only an active unit (a status read beside the existing `is_blocked`), with a joined peer relation and a rendered logrotate file, spawns the loop; a still-running previous process is reused via the PID, a dead one is replaced, and stop sends SIGINT and clears the field. The PID moves to a typed unit-databag accessor, and the spawned script is the library's own copy resolved from the package rather than a charm-directory path. K8s is a no-op — rotation there is the rotate-logs Pebble service the render drives.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
