### PR TITLE
feat(refresh): port the K8s charm-specific refresh class (1/6)

### DIFF
--- a/single_kernel_postgresql/charms/abstract_charm.py
+++ b/single_kernel_postgresql/charms/abstract_charm.py
@@ -150,3 +150,12 @@ class AbstractPostgreSQLCharm(CharmBase, ABC):
     def primary_endpoint(self) -> str | None:
         """Address of the cluster primary, or None when there is not one."""
         pass
+
+    @abstractmethod
+    def get_async_primary_cluster_endpoint(self) -> str | None:
+        """Endpoint of the primary cluster of the async replication partner, if any.
+
+        Owned by the async-replication module until that phase migrates; the refresh
+        pre-refresh checks need it to decide whether a switchover crosses clusters.
+        """
+        pass

--- a/single_kernel_postgresql/charms/k8s_charm.py
+++ b/single_kernel_postgresql/charms/k8s_charm.py
@@ -92,3 +92,7 @@ class PostgreSQLK8sCharm(AbstractPostgreSQLCharm):
     def primary_endpoint(self) -> str | None:
         """Address of the cluster primary's Service."""
         return self.state.primary_endpoint
+
+    def get_async_primary_cluster_endpoint(self) -> str | None:
+        """Endpoint of the primary cluster of the async replication partner, if any."""
+        return None

--- a/single_kernel_postgresql/charms/vm_charm.py
+++ b/single_kernel_postgresql/charms/vm_charm.py
@@ -84,3 +84,7 @@ class PostgreSQLVMCharm(AbstractPostgreSQLCharm):
         """Address of the cluster primary, or None when there is not one."""
         primary = self.patroni_manager.get_primary()
         return self.patroni_manager.get_member_ip(primary) if primary else None
+
+    def get_async_primary_cluster_endpoint(self) -> str | None:
+        """Endpoint of the primary cluster of the async replication partner, if any."""
+        return None

--- a/single_kernel_postgresql/managers/refresh.py
+++ b/single_kernel_postgresql/managers/refresh.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Refresh Manager.
+
+This module ports the refresh (rolling upgrade) logic from the PostgreSQL VM and K8s
+charms' 16/edge branches. It hosts the charm-specific callbacks handed to
+``charm_refresh`` and the manager that owns the refresh-aware unit status handling.
+"""
+
+import dataclasses
+import logging
+from typing import TYPE_CHECKING
+
+import charm_refresh
+from charm_refresh import CharmVersion, PrecheckFailed
+
+from single_kernel_postgresql.config.exceptions import SwitchoverFailedError
+
+if TYPE_CHECKING:
+    from single_kernel_postgresql.charms.abstract_charm import AbstractPostgreSQLCharm
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(eq=False)
+class PostgreSQLRefreshBase(charm_refresh.CharmSpecificCommon):
+    """Base class for PostgreSQL refresh operations, shared by both substrates."""
+
+    _charm: "AbstractPostgreSQLCharm"
+
+    @classmethod
+    def is_compatible(
+        cls,
+        *,
+        old_charm_version: CharmVersion,
+        new_charm_version: CharmVersion,
+        old_workload_version: str,
+        new_workload_version: str,
+    ) -> bool:
+        """Checks charm and workload version compatibility."""
+        if not super().is_compatible(
+            old_charm_version=old_charm_version,
+            new_charm_version=new_charm_version,
+            old_workload_version=old_workload_version,
+            new_workload_version=new_workload_version,
+        ):
+            return False
+
+        # Check workload version compatibility
+        old_major, old_minor = (int(component) for component in old_workload_version.split("."))
+        new_major, new_minor = (int(component) for component in new_workload_version.split("."))
+        if old_major != new_major:
+            return False
+        return new_minor >= old_minor
+
+
+@dataclasses.dataclass(eq=False)
+class PostgreSQLRefreshK8s(PostgreSQLRefreshBase, charm_refresh.CharmSpecificKubernetes):
+    """Charm-specific refresh callbacks for the Kubernetes substrate."""
+
+    def run_pre_refresh_checks_after_1_unit_refreshed(self) -> None:
+        """Implement pre-refresh checks after 1 unit refreshed."""
+        logger.debug("Running pre-refresh checks")
+        if self._charm.patroni_manager.is_creating_backup:
+            raise PrecheckFailed("Backup in progress")
+
+        # Check if all units except the highest unit (first to be refreshed) are online.
+        running_members = self._charm.patroni_manager.get_running_cluster_members()
+
+        # The highest unit number is planned_units - 1 (e.g., if 3 units, highest is unit 2).
+        # Members are named like "postgresql-k8s-0", "postgresql-k8s-1", etc.
+        highest_unit_number = self._charm.app.planned_units() - 1
+
+        # Check if all units except the highest unit are online.
+        for unit_number in range(self._charm.app.planned_units()):
+            member_name = f"{self._charm.app.name}-{unit_number}"
+            if unit_number != highest_unit_number and member_name not in running_members:
+                raise PrecheckFailed(f"PostgreSQL is not running on unit {unit_number}")
+
+        # Switch primary to last unit to refresh (lowest unit number).
+        last_unit_to_refresh = f"{self._charm.app.name}/0"
+        if self._charm.patroni_manager.get_primary(unit_name_pattern=True) == last_unit_to_refresh:
+            logger.info(
+                f"Unit {last_unit_to_refresh} was already primary during pre-refresh check"
+            )
+        else:
+            try:
+                self._charm.patroni_manager.switchover(
+                    candidate=last_unit_to_refresh,
+                    async_cluster=bool(self._charm.get_async_primary_cluster_endpoint()),
+                )
+            except SwitchoverFailedError as e:
+                logger.warning(f"switchover failed with reason: {e}")
+                raise PrecheckFailed("Unable to switch primary") from None
+            else:
+                logger.info(
+                    f"Switched primary to unit {last_unit_to_refresh} during pre-refresh check"
+                )
+
+    def run_pre_refresh_checks_before_any_units_refreshed(self) -> None:
+        """Implement pre-refresh checks before any unit refreshed."""
+        if not self._charm.patroni_manager.are_all_members_ready():
+            raise PrecheckFailed("PostgreSQL is not running on 1+ units")
+
+        self.run_pre_refresh_checks_after_1_unit_refreshed()
+
+
+__all__ = [
+    "PostgreSQLRefreshBase",
+    "PostgreSQLRefreshK8s",
+]

--- a/tests/unit/test_refresh.py
+++ b/tests/unit/test_refresh.py
@@ -1,0 +1,186 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for the refresh module's charm-specific classes."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from charm_refresh import CharmVersion, PrecheckFailed
+from single_kernel_postgresql.config.exceptions import SwitchoverFailedError
+from single_kernel_postgresql.managers.refresh import PostgreSQLRefreshK8s
+
+CHARM_VERSION = "16/1.0.0"
+
+
+@pytest.fixture
+def refresh_versions_toml(tmp_path, monkeypatch):
+    """Provide a minimal refresh_versions.toml in the working directory.
+
+    charm_refresh reads the pinned charm and workload versions from the working
+    directory when a charm-specific class is instantiated; the repository keeps the
+    file only inside the test charms.
+    """
+    monkeypatch.chdir(tmp_path)
+    Path("refresh_versions.toml").write_text(f'charm = "{CHARM_VERSION}"\nworkload = "16.14"\n')
+    return tmp_path
+
+
+@pytest.fixture
+def charm():
+    """A mock charm with the surfaces the K8s pre-refresh checks touch."""
+    return MagicMock(name="charm")
+
+
+@pytest.fixture
+def refresh_k8s(charm, refresh_versions_toml) -> PostgreSQLRefreshK8s:
+    """The K8s charm-specific refresh class wired to the mock charm."""
+    return PostgreSQLRefreshK8s(
+        workload_name="PostgreSQL",
+        charm_name="postgresql-k8s",
+        oci_resource_name="postgresql-image",
+        _charm=charm,
+    )
+
+
+@pytest.mark.parametrize(
+    "old_charm,new_charm,expected",
+    [
+        # Released, same track, upgrade: compatible.
+        ("16/1.0.0", "16/1.1.0", True),
+        # Charm code downgrade: incompatible.
+        ("16/1.1.0", "16/1.0.0", False),
+        # Track change: incompatible.
+        ("16/1.0.0", "14/1.1.0", False),
+        # Unreleased charm versions: incompatible.
+        ("16/1.0.0.dev0+abc", "16/1.1.0", False),
+        ("16/1.0.0", "16/1.1.0.post1.dev0+abc", False),
+    ],
+)
+def test_is_compatible_charm_version(old_charm, new_charm, expected, refresh_k8s):
+    assert (
+        PostgreSQLRefreshK8s.is_compatible(
+            old_charm_version=CharmVersion(old_charm),
+            new_charm_version=CharmVersion(new_charm),
+            old_workload_version="16.9",
+            new_workload_version="16.14",
+        )
+        is expected
+    )
+
+
+@pytest.mark.parametrize(
+    "old_workload,new_workload,expected",
+    [
+        # Same major, minor upgrade: compatible.
+        ("16.9", "16.14", True),
+        # Same major, same version: compatible.
+        ("16.14", "16.14", True),
+        # Same major, minor downgrade: incompatible.
+        ("16.14", "16.9", False),
+        # Major upgrade: incompatible (dump/restore required instead).
+        ("16.14", "17.0", False),
+    ],
+)
+def test_is_compatible_workload_version(old_workload, new_workload, expected, refresh_k8s):
+    assert (
+        PostgreSQLRefreshK8s.is_compatible(
+            old_charm_version=CharmVersion("16/1.0.0"),
+            new_charm_version=CharmVersion("16/1.1.0"),
+            old_workload_version=old_workload,
+            new_workload_version=new_workload,
+        )
+        is expected
+    )
+
+
+def test_pre_refresh_check_after_1_unit_refreshed_backup_in_progress(refresh_k8s, charm):
+    charm.patroni_manager.is_creating_backup = True
+    with pytest.raises(PrecheckFailed, match=r"Backup in progress"):
+        refresh_k8s.run_pre_refresh_checks_after_1_unit_refreshed()
+
+
+def test_pre_refresh_check_after_1_unit_refreshed_member_not_running(refresh_k8s, charm):
+    charm.app.planned_units.return_value = 3
+    charm.app.name = "postgresql-k8s"
+    charm.patroni_manager.is_creating_backup = False
+    charm.patroni_manager.get_running_cluster_members.return_value = [
+        "postgresql-k8s-0",
+        "postgresql-k8s-2",
+    ]
+    with pytest.raises(PrecheckFailed, match="PostgreSQL is not running on unit 1"):
+        refresh_k8s.run_pre_refresh_checks_after_1_unit_refreshed()
+
+
+def test_pre_refresh_check_after_1_unit_refreshed_switches_primary(refresh_k8s, charm):
+    charm.app.planned_units.return_value = 3
+    charm.app.name = "postgresql-k8s"
+    charm.patroni_manager.is_creating_backup = False
+    charm.patroni_manager.get_running_cluster_members.return_value = [
+        "postgresql-k8s-0",
+        "postgresql-k8s-1",
+        "postgresql-k8s-2",
+    ]
+    charm.patroni_manager.get_primary.return_value = "postgresql-k8s/2"
+    charm.get_async_primary_cluster_endpoint.return_value = None
+
+    refresh_k8s.run_pre_refresh_checks_after_1_unit_refreshed()
+
+    charm.patroni_manager.switchover.assert_called_once_with(
+        candidate="postgresql-k8s/0", async_cluster=False
+    )
+
+
+def test_pre_refresh_check_after_1_unit_refreshed_already_primary(refresh_k8s, charm):
+    charm.app.planned_units.return_value = 3
+    charm.app.name = "postgresql-k8s"
+    charm.patroni_manager.is_creating_backup = False
+    charm.patroni_manager.get_running_cluster_members.return_value = [
+        "postgresql-k8s-0",
+        "postgresql-k8s-1",
+        "postgresql-k8s-2",
+    ]
+    charm.patroni_manager.get_primary.return_value = "postgresql-k8s/0"
+
+    refresh_k8s.run_pre_refresh_checks_after_1_unit_refreshed()
+
+    charm.patroni_manager.switchover.assert_not_called()
+
+
+def test_pre_refresh_check_after_1_unit_refreshed_switchover_failed(refresh_k8s, charm):
+    charm.app.planned_units.return_value = 3
+    charm.app.name = "postgresql-k8s"
+    charm.patroni_manager.is_creating_backup = False
+    charm.patroni_manager.get_running_cluster_members.return_value = [
+        "postgresql-k8s-0",
+        "postgresql-k8s-1",
+        "postgresql-k8s-2",
+    ]
+    charm.patroni_manager.get_primary.return_value = "postgresql-k8s/2"
+    charm.patroni_manager.switchover.side_effect = SwitchoverFailedError
+
+    with pytest.raises(PrecheckFailed, match="Unable to switch primary"):
+        refresh_k8s.run_pre_refresh_checks_after_1_unit_refreshed()
+
+
+def test_pre_refresh_check_before_any_units_refreshed_members_not_ready(refresh_k8s, charm):
+    charm.patroni_manager.are_all_members_ready.return_value = False
+    with pytest.raises(PrecheckFailed, match=r"PostgreSQL is not running on 1\+ units"):
+        refresh_k8s.run_pre_refresh_checks_before_any_units_refreshed()
+
+
+def test_pre_refresh_check_before_any_units_refreshed_delegates(refresh_k8s, charm):
+    charm.patroni_manager.are_all_members_ready.return_value = True
+    charm.app.planned_units.return_value = 1
+    charm.app.name = "postgresql-k8s"
+    charm.patroni_manager.is_creating_backup = False
+    charm.patroni_manager.get_running_cluster_members.return_value = ["postgresql-k8s-0"]
+    charm.patroni_manager.get_primary.return_value = "postgresql-k8s/0"
+
+    with patch.object(
+        PostgreSQLRefreshK8s, "run_pre_refresh_checks_after_1_unit_refreshed"
+    ) as delegate:
+        refresh_k8s.run_pre_refresh_checks_before_any_units_refreshed()
+
+    delegate.assert_called_once()


### PR DESCRIPTION
## Issue

Part of the refresh module migration from the PostgreSQL VM and K8s charms' 16/edge branches into this library (series of 6, this is 1/5).

## Solution

Ports the K8s charm's `src/refresh.py` (`PostgreSQLRefresh`, `charm_refresh.CharmSpecificKubernetes`) as `PostgreSQLRefreshK8s` in the new `managers/refresh.py`, and deduplicates the `is_compatible` check that both charms carried verbatim into a shared `PostgreSQLRefreshBase` (charm-version compatibility via `charm_refresh` plus the workload major/minor compatibility rule).

The pre-refresh checks consult the async-replication primary cluster endpoint through a new `get_async_primary_cluster_endpoint` charm bridge (stubbed in the lib charms) because the async-replication module has not migrated yet; the production charm implements it from its existing `async_replication` helper in the charm-side PR.

The `RefreshManager` that wires `charm_refresh.Machines`/`Kubernetes` and owns the refresh-aware status gate lands in 2/6 (with the VM charm-specific class), the VM post-refresh flows in 4/6, and the K8s reconcile flow in 5/6.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.

