### PR TITLE
test(observers): cover the observer scripts (4/6)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,9 +70,9 @@ lint = [
 ]
 unit = [
     "coverage[toml]==7.15.4",
-    "pytest==9.1.1"
+    "pytest==9.1.1",
+    "pytest-asyncio==1.4.0",
 ]
-
 
 [tool.uv.dependency-groups]
 unit = {requires-python = ">=3.12"}
@@ -89,6 +89,7 @@ show_missing = true
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"
+asyncio_mode = "auto"
 
 # Linting tools configuration
 [tool.ruff]

--- a/tests/unit/test_observer_scripts.py
+++ b/tests/unit/test_observer_scripts.py
@@ -1,0 +1,339 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+import sys
+from unittest.mock import Mock, mock_open, patch, sentinel
+
+import pytest
+from pysyncobj.utility import UtilityException
+from single_kernel_postgresql.scripts.authorisation_rules_observer import (
+    UnreachableUnitsError as AuthorisationRulesUnreachableUnitsError,
+)
+from single_kernel_postgresql.scripts.authorisation_rules_observer import (
+    check_for_database_changes as authorisation_rules_check_for_database_changes,
+)
+from single_kernel_postgresql.scripts.authorisation_rules_observer import (
+    main as authorisation_rules_main,
+)
+from single_kernel_postgresql.scripts.cluster_topology_observer import (
+    UnreachableUnitsError,
+    check_for_database_changes,
+    dispatch,
+    main,
+)
+from single_kernel_postgresql.scripts.raft_observer import check_raft_connection
+
+
+def test_dispatch():
+    with patch("subprocess.run") as _run:
+        command = "test-command"
+        charm_dir = "/path"
+        dispatch(command, "postgresql-single-kernel/0", charm_dir, "cluster_topology_change")
+        _run.assert_called_once_with([
+            command,
+            "-u",
+            "postgresql-single-kernel/0",
+            f"JUJU_DISPATCH_PATH=hooks/cluster_topology_change {charm_dir}/dispatch",
+        ])
+
+
+async def test_main():
+    with (
+        patch(
+            "single_kernel_postgresql.scripts.cluster_topology_observer.check_for_database_changes"
+        ),
+        patch.object(
+            sys,
+            "argv",
+            ["cmd", "http://server1:8008,http://server2:8008", "run_cmd", "unit/0", "charm_dir"],
+        ),
+        patch(
+            "single_kernel_postgresql.scripts.cluster_topology_observer.sleep", return_value=None
+        ),
+        patch(
+            "single_kernel_postgresql.scripts.cluster_topology_observer.AsyncClient"
+        ) as _async_client,
+        patch(
+            "single_kernel_postgresql.scripts.cluster_topology_observer.subprocess"
+        ) as _subprocess,
+        patch(
+            "single_kernel_postgresql.scripts.cluster_topology_observer.create_default_context"
+        ) as _context,
+    ):
+        mock1 = Mock()
+        mock1.json.return_value = {
+            "members": [
+                {"name": "unit-2", "api_url": "http://server3:8008/patroni", "role": "standby"},
+                {"name": "unit-0", "api_url": "http://server1:8008/patroni", "role": "leader"},
+            ]
+        }
+        mock2 = Mock()
+        mock2.json.return_value = {
+            "members": [
+                {"name": "unit-2", "api_url": "https://server3:8008/patroni", "role": "leader"},
+            ]
+        }
+        async with _async_client() as cli:
+            _get = cli.get
+            _get.side_effect = [
+                mock1,
+                Exception,
+                mock2,
+            ]
+        with pytest.raises(UnreachableUnitsError):
+            await main()
+        _async_client.assert_any_call(timeout=5, verify=_context.return_value)
+        _get.assert_any_call("http://server1:8008/cluster")
+        _get.assert_any_call("http://server3:8008/cluster")
+
+        _subprocess.run.assert_called_once_with([
+            "run_cmd",
+            "-u",
+            "unit/0",
+            "JUJU_DISPATCH_PATH=hooks/cluster_topology_change charm_dir/dispatch",
+        ])
+
+
+def test_check_for_database_changes():
+    with (
+        patch(
+            "single_kernel_postgresql.scripts.cluster_topology_observer.subprocess"
+        ) as _subprocess,
+        patch("single_kernel_postgresql.scripts.cluster_topology_observer.psycopg2") as _psycopg2,
+    ):
+        run_cmd = "run_cmd"
+        unit = "unit/0"
+        charm_dir = "charm_dir"
+        mock = mock_open(
+            read_data="""postgresql:
+  listen: test:5432
+  authentication:
+    superuser:
+      username: test_user
+      password: test_password"""
+        )
+        with patch("builtins.open", mock, create=True):
+            _cursor = _psycopg2.connect.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value
+            _cursor.fetchall.side_effect = [[sentinel.databases], sentinel.relation_users]
+
+            # Test the first time this function is called.
+            result = check_for_database_changes(run_cmd, unit, charm_dir, None)
+            assert result == [sentinel.databases, sentinel.relation_users]
+            _subprocess.run.assert_not_called()
+            _psycopg2.connect.assert_called_once_with(
+                "dbname='postgres' user='operator' host='/tmp/snap-private-tmp/snap.charmed-postgresql/tmp/' "
+                "password='test_password' connect_timeout=1"
+            )
+            assert _cursor.execute.call_count == 2
+            _cursor.execute.assert_any_call("SELECT datname, datacl FROM pg_database;")
+            _cursor.execute.assert_any_call(
+                "SELECT oid, rolname FROM pg_roles WHERE pg_has_role(oid, 'relation_access', 'member');"
+            )
+
+            # Test when the databases changed.
+            _cursor.fetchall.side_effect = [[sentinel.databases_changed], sentinel.relation_users]
+            result = check_for_database_changes(run_cmd, unit, charm_dir, result)
+            assert result == [sentinel.databases_changed, sentinel.relation_users]
+
+            _subprocess.run.assert_called_once_with([
+                run_cmd,
+                "-u",
+                unit,
+                f"JUJU_DISPATCH_PATH=hooks/databases_change {charm_dir}/dispatch",
+            ])
+
+            # Test when the databases haven't changed.
+            _subprocess.reset_mock()
+            _cursor.fetchall.side_effect = [[sentinel.databases_changed], sentinel.relation_users]
+            check_for_database_changes(run_cmd, unit, charm_dir, result)
+            assert result == [sentinel.databases_changed, sentinel.relation_users]
+            _subprocess.run.assert_not_called()
+
+
+def test_check_raft_connection():
+    with (
+        patch("single_kernel_postgresql.scripts.raft_observer.TcpUtility") as _tcp_utility,
+        patch("single_kernel_postgresql.scripts.raft_observer.dispatch") as _dispatch,
+    ):
+        # No status
+        _tcp_utility.return_value.executeCommand.return_value = None
+        check_raft_connection("testpass")
+
+        _tcp_utility.assert_called_once_with(password="testpass", timeout=3)
+        _tcp_utility.return_value.executeCommand.assert_called_once_with(
+            "127.0.0.1:2222", ["status"]
+        )
+        assert not _dispatch.called
+        _tcp_utility.reset_mock()
+
+        # No leader
+        _tcp_utility.return_value.executeCommand.return_value = {
+            "has_quorum": False,
+            "leader": None,
+        }
+
+        check_raft_connection("testpass")
+
+        _tcp_utility.assert_called_once_with(password="testpass", timeout=3)
+        _tcp_utility.return_value.executeCommand.assert_called_once_with(
+            "127.0.0.1:2222", ["status"]
+        )
+        assert not _dispatch.called
+        _tcp_utility.reset_mock()
+
+        # Status exception
+        _tcp_utility.return_value.executeCommand.side_effect = UtilityException
+        check_raft_connection("testpass")
+
+        _tcp_utility.assert_called_once_with(password="testpass", timeout=3)
+        _tcp_utility.return_value.executeCommand.assert_called_once_with(
+            "127.0.0.1:2222", ["status"]
+        )
+        assert not _dispatch.called
+        _tcp_utility.reset_mock()
+
+        # Disconnected partner
+        _tcp_utility.return_value.executeCommand.side_effect = [
+            {
+                "partner_node_status_server_1.1.1.1:2222": 2,
+                "partner_node_status_server_2.2.2.2:2222": 0,
+                "has_quorum": True,
+                "leader": sentinel.raft_leader,
+            },
+            UtilityException,
+        ]
+        check_raft_connection("testpass")
+
+        _tcp_utility.assert_called_once_with(password="testpass", timeout=3)
+        assert _tcp_utility.return_value.executeCommand.call_count == 2
+        _tcp_utility.return_value.executeCommand.assert_any_call("127.0.0.1:2222", ["status"])
+        _tcp_utility.return_value.executeCommand.assert_any_call("2.2.2.2:2222", ["status"])
+        assert not _dispatch.called
+        _tcp_utility.reset_mock()
+
+        # Stuck partner
+        _tcp_utility.return_value.executeCommand.side_effect = [
+            {
+                "partner_node_status_server_1.1.1.1:2222": 2,
+                "partner_node_status_server_2.2.2.2:2222": 0,
+                "has_quorum": True,
+                "leader": sentinel.raft_leader,
+            },
+            {
+                "has_quorum": True,
+                "leader": sentinel.raft_leader,
+            },
+        ]
+        check_raft_connection("testpass")
+
+        _tcp_utility.assert_called_once_with(password="testpass", timeout=3)
+        assert _tcp_utility.return_value.executeCommand.call_count == 2
+        _tcp_utility.return_value.executeCommand.assert_any_call("127.0.0.1:2222", ["status"])
+        _tcp_utility.return_value.executeCommand.assert_any_call("2.2.2.2:2222", ["status"])
+        _dispatch.assert_called_once_with("raft_reconnect")
+        _tcp_utility.reset_mock()
+
+
+async def test_authorisation_rules_main():
+    with (
+        patch(
+            "single_kernel_postgresql.scripts.authorisation_rules_observer.check_for_database_changes"
+        ),
+        patch.object(
+            sys,
+            "argv",
+            ["cmd", "http://server1:8008,http://server2:8008", "run_cmd", "unit/0", "charm_dir"],
+        ),
+        patch(
+            "single_kernel_postgresql.scripts.authorisation_rules_observer.sleep",
+            return_value=None,
+        ),
+        patch(
+            "single_kernel_postgresql.scripts.authorisation_rules_observer.AsyncClient"
+        ) as _async_client,
+        patch(
+            "single_kernel_postgresql.scripts.authorisation_rules_observer.create_default_context"
+        ) as _context,
+    ):
+        mock1 = Mock()
+        mock1.json.return_value = {
+            "members": [
+                {"name": "unit-2", "api_url": "http://server3:8008/patroni", "role": "standby"},
+                {"name": "unit-0", "api_url": "http://server1:8008/patroni", "role": "leader"},
+            ]
+        }
+        mock2 = Mock()
+        mock2.json.return_value = {
+            "members": [
+                {"name": "unit-2", "api_url": "https://server3:8008/patroni", "role": "leader"},
+            ]
+        }
+        async with _async_client() as cli:
+            _get = cli.get
+            _get.side_effect = [
+                mock1,
+                Exception,
+                mock2,
+            ]
+        with pytest.raises(AuthorisationRulesUnreachableUnitsError):
+            await authorisation_rules_main()
+        _async_client.assert_any_call(timeout=5, verify=_context.return_value)
+        _get.assert_any_call("http://server1:8008/cluster")
+        _get.assert_any_call("http://server3:8008/cluster")
+
+
+def test_authorisation_rules_check_for_database_changes():
+    with (
+        patch(
+            "single_kernel_postgresql.scripts.authorisation_rules_observer.subprocess"
+        ) as _subprocess,
+        patch(
+            "single_kernel_postgresql.scripts.authorisation_rules_observer.psycopg2"
+        ) as _psycopg2,
+    ):
+        run_cmd = "run_cmd"
+        unit = "unit/0"
+        charm_dir = "charm_dir"
+        mock = mock_open(
+            read_data="""postgresql:
+  authentication:
+    superuser:
+      username: test_user
+      password: test_password"""
+        )
+        with patch("builtins.open", mock, create=True):
+            _cursor = _psycopg2.connect.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value
+            _cursor.fetchall.side_effect = [[sentinel.databases], sentinel.relation_users]
+
+            # Test the first time this function is called.
+            result = authorisation_rules_check_for_database_changes(run_cmd, unit, charm_dir, None)
+            assert result == [sentinel.databases, sentinel.relation_users]
+            _subprocess.run.assert_not_called()
+            _psycopg2.connect.assert_called_once_with(
+                "dbname='postgres' user='operator' host='localhost' password='test_password' connect_timeout=1"
+            )
+            assert _cursor.execute.call_count == 2
+            _cursor.execute.assert_any_call("SELECT datname, datacl FROM pg_database;")
+            _cursor.execute.assert_any_call(
+                "SELECT oid, rolname FROM pg_roles WHERE pg_has_role(oid, 'relation_access', 'member');"
+            )
+
+            # Test when the databases changed.
+            _cursor.fetchall.side_effect = [[sentinel.databases_changed], sentinel.relation_users]
+            result = authorisation_rules_check_for_database_changes(
+                run_cmd, unit, charm_dir, result
+            )
+            assert result == [sentinel.databases_changed, sentinel.relation_users]
+
+            _subprocess.run.assert_called_once_with([
+                run_cmd,
+                "-u",
+                unit,
+                f"JUJU_DISPATCH_PATH=hooks/databases_change {charm_dir}/dispatch",
+            ])
+
+            # Test when the databases haven't changed.
+            _subprocess.reset_mock()
+            _cursor.fetchall.side_effect = [[sentinel.databases_changed], sentinel.relation_users]
+            authorisation_rules_check_for_database_changes(run_cmd, unit, charm_dir, result)
+            assert result == [sentinel.databases_changed, sentinel.relation_users]
+            _subprocess.run.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -1206,6 +1206,7 @@ lint = [
 unit = [
     { name = "coverage", marker = "python_full_version >= '3.12'" },
     { name = "pytest", marker = "python_full_version >= '3.12'" },
+    { name = "pytest-asyncio", marker = "python_full_version >= '3.12'" },
 ]
 
 [package.metadata]
@@ -1242,6 +1243,7 @@ lint = [
 unit = [
     { name = "coverage", extras = ["toml"], marker = "python_full_version >= '3.12'", specifier = "==7.15.4" },
     { name = "pytest", marker = "python_full_version >= '3.12'", specifier = "==9.1.1" },
+    { name = "pytest-asyncio", marker = "python_full_version >= '3.12'", specifier = "==1.4.0" },
 ]
 
 [[package]]
@@ -1494,6 +1496,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Issue

Part of the observers module migration from the PostgreSQL VM and K8s charms' 16/edge branches into this library. Stacks on #260.

## Solution

Ports the scripts' unit suites from both charms: the cluster topology observer script (dispatch, main watch loop, databases snapshot diffing) and the raft observer script (raft connectivity decision table), plus the authorisation rules observer script's suite from the K8s charm (databases snapshot diffing and main watch loop). Patch targets move to the `single_kernel_postgresql.scripts.*` module paths.

The authorisation rules script defines its own `UnreachableUnitsError`, so its main-loop test asserts against that class rather than the cluster topology observer's.

`pytest-asyncio` joins the unit dependency group and `asyncio_mode = "auto"` mirrors the charms' pytest config, as the ported main-loop tests are async without explicit markers.

Provenance: tests ported from `tests/unit/test_cluster_topology_observer.py` @ `03494fb7b77f96b3108d5968b5eb4d4b61fb6f7f` (postgresql-operator) and `tests/unit/test_authorisation_rules_observer.py` @ `dec4b9602d8642310d0516e5cb3551e183e1418e` (postgresql-k8s-operator), both on 16/edge.

## Checklist

- [x] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.

Wiring up at canonical/postgresql-operator#1940 and canonical/postgresql-k8s-operator#1725.