### PR TITLE
test(observers): cover the observer handlers (5/6)

### DIFF
--- a/tests/unit/test_authorisation_rules_observer.py
+++ b/tests/unit/test_authorisation_rules_observer.py
@@ -1,0 +1,142 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""Tests for the K8s authorisation rules observer handler.
+
+The spawned-script suite lives in test_observer_scripts.py; these cover the
+start/stop process lifecycle the K8s charm drives on its event handlers.
+"""
+
+import signal
+from unittest.mock import Mock, PropertyMock, patch
+
+import pytest
+from ops.model import ActiveStatus, WaitingStatus
+from single_kernel_postgresql.config.enums import Substrates
+
+
+def test_observer_is_substrate_gated(harness, substrate):
+    charm = harness.charm
+    if substrate == Substrates.K8S:
+        assert hasattr(charm, "authorisation_rules_observer")
+        assert not hasattr(charm, "cluster_topology_observer")
+    else:
+        assert hasattr(charm, "cluster_topology_observer")
+        assert not hasattr(charm, "authorisation_rules_observer")
+
+
+def test_start_authorisation_rules_observer(harness, substrate):
+    if substrate != Substrates.K8S:
+        pytest.skip("the authorisation rules observer is K8s-only")
+    charm = harness.charm
+    charm.unit.status = ActiveStatus()
+    container = Mock()
+    container.can_connect.return_value = True
+    with (
+        patch("builtins.open"),
+        patch("subprocess.Popen") as _popen,
+        patch("os.kill") as _kill,
+        patch.object(charm.unit, "get_container", return_value=container),
+        patch(
+            "single_kernel_postgresql.core.peer_relation.PostgreSQLPeer.data",
+            new_callable=PropertyMock,
+        ) as _peer_data,
+        patch(
+            "single_kernel_postgresql.core.state.CharmState.endpoints",
+            new_callable=PropertyMock,
+            return_value=set(),
+        ),
+        patch(
+            "single_kernel_postgresql.core.state.CharmState.application",
+            new_callable=PropertyMock,
+        ) as _application,
+    ):
+        _application.return_value = Mock(is_cluster_initialised=True)
+        observer = charm.authorisation_rules_observer
+
+        # Test that the process is started on a connected, initialised cluster.
+        _peer_data.return_value = {}
+        _popen.return_value = Mock(pid=42)
+        observer.start_authorisation_rules_observer()
+        _popen.assert_called_once()
+        container.can_connect.assert_called_once()
+        _kill.assert_not_called()
+        assert _peer_data.return_value["authorisation-rules-observer-pid"] == "42"
+
+        # Test that nothing is done if the charm is not in an active status.
+        _popen.reset_mock()
+        charm.unit.status = WaitingStatus()
+        observer.start_authorisation_rules_observer()
+        _popen.assert_not_called()
+        charm.unit.status = ActiveStatus()
+
+        # Test that nothing is done if there is already a running process.
+        _kill.side_effect = None
+        observer.start_authorisation_rules_observer()
+        _popen.assert_not_called()
+        _kill.assert_called_once_with(42, 0)
+        _kill.reset_mock()
+
+        # If the stored process is already dead, it should restart.
+        _kill.side_effect = OSError
+        observer.start_authorisation_rules_observer()
+        _kill.assert_called_once_with(42, 0)
+        _popen.assert_called_once()
+
+
+def test_start_authorisation_rules_observer_on_uninitialised_cluster(harness, substrate):
+    if substrate != Substrates.K8S:
+        pytest.skip("the authorisation rules observer is K8s-only")
+    charm = harness.charm
+    charm.unit.status = ActiveStatus()
+    container = Mock()
+    container.can_connect.return_value = True
+    with (
+        patch("subprocess.Popen") as _popen,
+        patch.object(charm.unit, "get_container", return_value=container),
+        patch(
+            "single_kernel_postgresql.core.peer_relation.PostgreSQLPeer.data",
+            new_callable=PropertyMock,
+        ) as _peer_data,
+        patch(
+            "single_kernel_postgresql.core.state.CharmState.application",
+            new_callable=PropertyMock,
+        ) as _application,
+    ):
+        _application.return_value = Mock(is_cluster_initialised=False)
+        charm.authorisation_rules_observer.start_authorisation_rules_observer()
+        _popen.assert_not_called()
+
+
+def test_stop_authorisation_rules_observer(harness, substrate):
+    if substrate != Substrates.K8S:
+        pytest.skip("the authorisation rules observer is K8s-only")
+    with (
+        patch("os.kill") as _kill,
+        patch(
+            "single_kernel_postgresql.core.peer_relation.PostgreSQLPeer.data",
+            new_callable=PropertyMock,
+        ) as _peer_data,
+    ):
+        observer = harness.charm.authorisation_rules_observer
+
+        # Test that nothing is done if there is no process running.
+        observer.stop_authorisation_rules_observer()
+        _kill.assert_not_called()
+
+        _peer_data.return_value = {}
+        observer.stop_authorisation_rules_observer()
+        _kill.assert_not_called()
+
+        # Test that the process is killed and its pid dropped.
+        _peer_data.return_value = {"authorisation-rules-observer-pid": "1"}
+        observer.stop_authorisation_rules_observer()
+        _kill.assert_called_once_with(1, signal.SIGTERM)
+        assert "authorisation-rules-observer-pid" not in _peer_data.return_value
+        _kill.reset_mock()
+
+        # Dead process doesn't break the stop.
+        _peer_data.return_value = {"authorisation-rules-observer-pid": "1"}
+        _kill.side_effect = OSError
+        observer.stop_authorisation_rules_observer()
+        _kill.assert_called_once_with(1, signal.SIGTERM)
+        _kill.reset_mock()

--- a/tests/unit/test_cluster_topology_observer.py
+++ b/tests/unit/test_cluster_topology_observer.py
@@ -1,0 +1,191 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""Tests for the VM cluster topology observer handler.
+
+Ported from the PostgreSQL VM charm's tests/unit/test_cluster_topology_observer.py
+(16/edge); the spawned-script suites moved to test_observer_scripts.py.
+"""
+
+import signal
+from importlib.resources import files
+from unittest.mock import Mock, PropertyMock, patch
+
+import pytest
+from jinja2 import Template
+from ops.model import ActiveStatus, WaitingStatus
+from single_kernel_postgresql.config.enums import Substrates
+from single_kernel_postgresql.observers.cluster_topology import start_raft_observer
+
+
+def test_observer_is_substrate_gated(harness, substrate):
+    charm = harness.charm
+    if substrate == Substrates.VM:
+        assert hasattr(charm, "cluster_topology_observer")
+        assert not hasattr(charm, "authorisation_rules_observer")
+    else:
+        assert hasattr(charm, "authorisation_rules_observer")
+        assert not hasattr(charm, "cluster_topology_observer")
+
+
+def test_start_observer(harness, substrate):
+    if substrate != Substrates.VM:
+        pytest.skip("the cluster topology observer is VM-only")
+    with (
+        patch("builtins.open"),
+        patch("subprocess.Popen") as _popen,
+        patch(
+            "single_kernel_postgresql.core.peer_relation.PostgreSQLPeer.data",
+            new_callable=PropertyMock,
+        ) as _peer_data,
+        patch("single_kernel_postgresql.core.state.CharmState.unit_ip", new_callable=PropertyMock),
+        patch(
+            "single_kernel_postgresql.core.state.CharmState.peer_members_ips",
+            new_callable=PropertyMock,
+        ) as _peer_members_ips,
+        patch(
+            "single_kernel_postgresql.core.state.CharmState.peer_relation",
+            new_callable=PropertyMock,
+            return_value=Mock(),
+        ) as _peers,
+    ):
+        observer = harness.charm.cluster_topology_observer
+
+        # Test that nothing is done if there is already a running process.
+        _peer_data.return_value = {"observer-pid": "1"}
+        observer.start_observer()
+        _popen.assert_not_called()
+
+        # Test that nothing is done if the charm is not in an active status.
+        harness.charm.unit.status = WaitingStatus()
+        _peer_data.return_value = {}
+        observer.start_observer()
+        _popen.assert_not_called()
+
+        # Test that nothing is done if peer relation is not available yet.
+        harness.charm.unit.status = ActiveStatus()
+        _peers.return_value = None
+        observer.start_observer()
+        _popen.assert_not_called()
+
+        # Test that the process is started otherwise.
+        _peers.return_value = Mock()
+        _popen.return_value = Mock(pid=1)
+        observer.start_observer()
+        _popen.assert_called_once()
+
+
+def test_start_observer_already_running(harness, substrate):
+    if substrate != Substrates.VM:
+        pytest.skip("the cluster topology observer is VM-only")
+    with (
+        patch("builtins.open"),
+        patch("subprocess.Popen") as _popen,
+        patch("os.kill") as _kill,
+        patch(
+            "single_kernel_postgresql.core.peer_relation.PostgreSQLPeer.data",
+            new_callable=PropertyMock,
+        ) as _peer_data,
+        patch("single_kernel_postgresql.core.state.CharmState.unit_ip", new_callable=PropertyMock),
+    ):
+        harness.charm.unit.status = ActiveStatus()
+        observer = harness.charm.cluster_topology_observer
+        _peer_data.return_value = {"observer-pid": "1234"}
+        observer.start_observer()
+        _kill.assert_called_once_with(1234, 0)
+        assert not _popen.called
+        _kill.reset_mock()
+
+        # If process is already dead, it should restart
+        _kill.side_effect = OSError
+        observer.start_observer()
+        _kill.assert_called_once_with(1234, 0)
+        _popen.assert_called_once()
+        _kill.reset_mock()
+
+
+def test_stop_observer(harness, substrate):
+    if substrate != Substrates.VM:
+        pytest.skip("the cluster topology observer is VM-only")
+    with (
+        patch("os.kill") as _kill,
+        patch(
+            "single_kernel_postgresql.core.peer_relation.PostgreSQLPeer.data",
+            new_callable=PropertyMock,
+        ) as _peer_data,
+    ):
+        observer = harness.charm.cluster_topology_observer
+
+        # Test that nothing is done if there is no process running.
+        observer.stop_observer()
+        _kill.assert_not_called()
+
+        _peer_data.return_value = {}
+        observer.stop_observer()
+        _kill.assert_not_called()
+
+        # Test that the process is killed.
+        _peer_data.return_value = {"observer-pid": "1"}
+        observer.stop_observer()
+        _kill.assert_called_once_with(1, signal.SIGINT)
+        _kill.reset_mock()
+
+        # Dead process doesn't break the script
+        _peer_data.return_value = {"observer-pid": "1"}
+        _kill.side_effect = OSError
+        observer.stop_observer()
+        _kill.assert_called_once_with(1, signal.SIGINT)
+        _kill.reset_mock()
+
+
+def test_start_raft_observer(harness, substrate):
+    if substrate != Substrates.VM:
+        pytest.skip("the raft observer is VM-only")
+    with (
+        patch(
+            "single_kernel_postgresql.observers.cluster_topology.daemon_reload"
+        ) as _daemon_reload,
+        patch(
+            "single_kernel_postgresql.observers.cluster_topology.service_enable"
+        ) as _service_enable,
+        patch("single_kernel_postgresql.observers.cluster_topology.render_file") as _render_file,
+        patch(
+            "single_kernel_postgresql.observers.cluster_topology.copy_environment",
+            return_value={"ENV": "var"},
+        ) as _copy_environment,
+    ):
+        # Get the expected content from the package templates.
+        service_source = (
+            files("single_kernel_postgresql.templates")
+            .joinpath("vm/raft-observer.service.j2")
+            .read_text()
+        )
+        expected_service = Template(service_source).render(
+            envvars={"ENV": "var"},
+            script=str(files("single_kernel_postgresql.scripts").joinpath("raft_observer.py")),
+        )
+        timer_source = (
+            files("single_kernel_postgresql.templates")
+            .joinpath("vm/raft-observer.timer.j2")
+            .read_text()
+        )
+        expected_timer = Template(timer_source).render()
+
+        start_raft_observer()
+
+        _daemon_reload.assert_called_once_with()
+        _service_enable.assert_called_once_with("/etc/systemd/system/raft-observer.timer", "--now")
+        assert _render_file.call_count == 2
+        _render_file.assert_any_call(
+            Substrates.VM,
+            "/etc/systemd/system/raft-observer.service",
+            expected_service,
+            0o644,
+            change_owner=False,
+        )
+        _render_file.assert_any_call(
+            Substrates.VM,
+            "/etc/systemd/system/raft-observer.timer",
+            expected_timer,
+            0o644,
+            change_owner=False,
+        )


### PR DESCRIPTION
## Issue

Part of the observers module migration from the PostgreSQL VM and K8s charms' 16/edge branches into this library. Stacks on #261.

## Solution

Ports the cluster topology observer's start/stop and raft-observer unit-rendering suites from the VM charm onto the library harness: patch targets move from the charms' `_peers`/`_peer_members_ips` properties to the library state (`peer_relation`/`peer_members_ips`), the harness peer relation backs the positive cases, and the raft-observer test reads its expected systemd unit content from the package templates instead of the charm's `templates/` directory.

Adds the authorisation rules observer's start/stop coverage (the K8s charm had none): guards on status, peers, container connectivity and cluster initialisation, the already-running and dead-pid restart paths, SIGTERM stop with databag cleanup, and the substrate gating of both handlers' construction on the abstract charm.

Every test runs under both substrates via the session fixture and skips itself on the substrate that does not ship the handler.

Provenance: tests ported from `tests/unit/test_cluster_topology_observer.py` @ `03494fb7b77f96b3108d5968b5eb4d4b61fb6f7f` (postgresql-operator 16/edge); the authorisation rules handler tests are new, matching the ported behavior.

## Checklist

- [x] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.

Wiring up at canonical/postgresql-operator#1940 and canonical/postgresql-k8s-operator#1725.