### PR TITLE
chore(observers): bump library patch version to 16.3.10 (6/6)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "postgresql-charms-single-kernel"
 description = "Shared and reusable code for PostgreSQL-related charms"
-version = "16.3.7"
+version = "16.3.10"
 readme = "README.md"
 license = {file = "LICENSE"}
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1156,7 +1156,7 @@ wheels = [
 
 [[package]]
 name = "postgresql-charms-single-kernel"
-version = "16.3.7"
+version = "16.3.10"
 source = { editable = "." }
 dependencies = [
     { name = "ops", version = "2.23.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Issue

Part of the observers module migration from the PostgreSQL VM and K8s charms' 16/edge branches into this library. Stacks on #262.

## Solution

Carries the version bump the release flow needs: it refuses to publish an already-tagged version, so the final merge of the stack must bring a fresh one. 16.3.9 is taken by the open backups stack, so this stack bumps the patch version to 16.3.10.

## Checklist

- [x] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.

Wiring up at canonical/postgresql-operator#1940 and canonical/postgresql-k8s-operator#1725.