### PR TITLE
feat(refresh): own the refresh-aware unit status gate (2/6)

### DIFF
--- a/single_kernel_postgresql/charms/abstract_charm.py
+++ b/single_kernel_postgresql/charms/abstract_charm.py
@@ -3,10 +3,15 @@
 """Skeleton for the abstract charm."""
 
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 from data_platform_helpers.advanced_statuses import StatusHandler
 from ops import StatusBase
 from ops.charm import CharmBase
+
+if TYPE_CHECKING:
+    import charm_refresh
+
 
 from single_kernel_postgresql.core.state import CharmState
 from single_kernel_postgresql.events.database import DatabaseEventsHandler
@@ -19,6 +24,7 @@ from single_kernel_postgresql.managers.cluster import ClusterManager
 from single_kernel_postgresql.managers.config import ConfigManager
 from single_kernel_postgresql.managers.database import DatabaseManager
 from single_kernel_postgresql.managers.patroni import PatroniManager
+from single_kernel_postgresql.managers.refresh import RefreshManager
 from single_kernel_postgresql.managers.tls import TLSManager
 from single_kernel_postgresql.workload.base import BaseWorkload, ResourceProvider
 
@@ -71,6 +77,16 @@ class AbstractPostgreSQLCharm(CharmBase, ABC):
             resource_provider=self.get_resource_provider,
             request_restart=self.request_restart,
             restart_services=self.restart_services,
+        )
+
+        # The refresh manager owns the charm_refresh integration and the priority gate
+        # every unit status write routes through. Constructed before the events handler
+        # so the K8s pebble-ready handler can consult the refresh state.
+        self.refresh_manager = RefreshManager(
+            state=self.state,
+            workload=self.workload,
+            charm=self,
+            set_default_status=self.set_default_unit_status,
         )
 
         # Events Handler
@@ -136,8 +152,28 @@ class AbstractPostgreSQLCharm(CharmBase, ABC):
         pass
 
     @abstractmethod
-    def set_unit_status(self, status: StatusBase) -> None:
+    def set_unit_status(
+        self,
+        status: StatusBase,
+        /,
+        *,
+        refresh: "charm_refresh.Machines | charm_refresh.Kubernetes | None" = None,
+    ) -> None:
         """Set the unit status without overriding a higher-priority refresh status."""
+        pass
+
+    @abstractmethod
+    def set_default_unit_status(self) -> None:
+        """Set the unit status that applies when no refresh status is active."""
+        pass
+
+    @abstractmethod
+    def set_app_status(self) -> None:
+        """Set the application status from the async-replication state.
+
+        Owned by the async-replication module until that phase migrates; the refresh
+        status reconciliation consults it for the leader's app status interplay.
+        """
         pass
 
     @abstractmethod

--- a/single_kernel_postgresql/charms/k8s_charm.py
+++ b/single_kernel_postgresql/charms/k8s_charm.py
@@ -5,8 +5,9 @@
 """PostgreSQL Kubernetes Charm."""
 
 import logging
+from typing import TYPE_CHECKING
 
-from ops import StatusBase
+from ops import ActiveStatus, StatusBase
 
 from single_kernel_postgresql.charms.abstract_charm import AbstractPostgreSQLCharm, PostgreSQL
 from single_kernel_postgresql.config.enums import Substrates
@@ -14,6 +15,9 @@ from single_kernel_postgresql.config.literals import CONTAINER_NAME, SYSTEM_USER
 from single_kernel_postgresql.managers.k8s import K8sManager
 from single_kernel_postgresql.workload.base import BaseWorkload
 from single_kernel_postgresql.workload.k8s import K8sWorkload
+
+if TYPE_CHECKING:
+    import charm_refresh
 
 logger = logging.getLogger(__name__)
 
@@ -68,8 +72,8 @@ class PostgreSQLK8sCharm(AbstractPostgreSQLCharm):
         return Substrates.K8S
 
     # The concrete production charm owns these bridges (update_scrape_job_spec +
-    # acquire_lock, pebble metrics/ldap restarts, the refresh-aware status write and the
-    # config re-render), so they are minimal here.
+    # acquire_lock, pebble metrics/ldap restarts, the async app status and the config
+    # re-render), so they are minimal here.
     def get_resource_provider(self) -> K8sManager:
         """Return the substrate's (cpu_cores, memory_bytes) introspector."""
         return self.k8s_manager
@@ -80,11 +84,24 @@ class PostgreSQLK8sCharm(AbstractPostgreSQLCharm):
     def restart_services(self) -> None:
         """Restart the monitoring and LDAP-sync sidecar services."""
 
-    def set_unit_status(self, status: StatusBase) -> None:
+    def set_unit_status(
+        self,
+        status: StatusBase,
+        /,
+        *,
+        refresh: "charm_refresh.Kubernetes | None" = None,
+    ) -> None:
         """Set the unit status without overriding a higher-priority refresh status."""
-        self.unit.status = status
+        self.refresh_manager.set_unit_status(status, refresh=refresh)
 
-    def update_config(self) -> bool:
+    def set_default_unit_status(self) -> None:
+        """Set the unit status that applies when no refresh status is active."""
+        self.unit.status = ActiveStatus()
+
+    def set_app_status(self) -> None:
+        """Set the application status from the async-replication state."""
+
+    def update_config(self, *, refresh: "charm_refresh.Kubernetes | None" = None) -> bool:
         """Re-render the Patroni configuration and apply it."""
         return self.config_manager.update_config(self.postgresql)
 

--- a/single_kernel_postgresql/charms/vm_charm.py
+++ b/single_kernel_postgresql/charms/vm_charm.py
@@ -5,13 +5,17 @@
 """PostgreSQL VM Charm."""
 
 import logging
+from typing import TYPE_CHECKING
 
-from ops import StatusBase
+from ops import ActiveStatus, StatusBase
 
 from single_kernel_postgresql.charms.abstract_charm import AbstractPostgreSQLCharm, PostgreSQL
 from single_kernel_postgresql.config.enums import Substrates
 from single_kernel_postgresql.config.literals import SYSTEM_USERS, USER
 from single_kernel_postgresql.workload.vm import VMWorkload
+
+if TYPE_CHECKING:
+    import charm_refresh
 
 logger = logging.getLogger(__name__)
 
@@ -59,8 +63,8 @@ class PostgreSQLVMCharm(AbstractPostgreSQLCharm):
         return Substrates.VM
 
     # The concrete production charm owns these bridges (pops postgresql_restarted +
-    # acquire_lock, snap metrics/ldap restarts, the refresh-aware status write, the
-    # Patroni-derived primary lookup and the config re-render), so they are minimal here.
+    # acquire_lock, snap metrics/ldap restarts, the async app status, the Patroni-derived
+    # primary lookup and the config re-render), so they are minimal here.
     def get_resource_provider(self) -> VMWorkload:
         """Return the substrate's (cpu_cores, memory_bytes) introspector."""
         return self.workload
@@ -71,13 +75,28 @@ class PostgreSQLVMCharm(AbstractPostgreSQLCharm):
     def restart_services(self) -> None:
         """Restart the monitoring and LDAP-sync sidecar services."""
 
-    def set_unit_status(self, status: StatusBase) -> None:
+    def set_unit_status(
+        self,
+        status: StatusBase,
+        /,
+        *,
+        refresh: "charm_refresh.Machines | None" = None,
+    ) -> None:
         """Set the unit status without overriding a higher-priority refresh status."""
-        self.unit.status = status
+        self.refresh_manager.set_unit_status(status, refresh=refresh)
 
-    def update_config(self) -> bool:
+    def set_default_unit_status(self) -> None:
+        """Set the unit status that applies when no refresh status is active."""
+        self.unit.status = ActiveStatus()
+
+    def set_app_status(self) -> None:
+        """Set the application status from the async-replication state."""
+
+    def update_config(self, *, refresh: "charm_refresh.Machines | None" = None) -> bool:
         """Re-render the Patroni configuration and apply it."""
-        return self.config_manager.update_config(self.postgresql)
+        if refresh is None:
+            refresh = self.refresh_manager.refresh
+        return self.config_manager.update_config(self.postgresql, refresh=refresh)
 
     @property
     def primary_endpoint(self) -> str | None:

--- a/single_kernel_postgresql/config/literals.py
+++ b/single_kernel_postgresql/config/literals.py
@@ -178,3 +178,10 @@ RAFT_PARTNER_PREFIX = "partner_node_status_server_"
 # VM services
 VM_PATRONI_SERVICE_NAME = "snap.charmed-postgresql.patroni.service"
 VM_PATRONI_SERVICE_DEFAULT_PATH = f"/etc/systemd/system/{VM_PATRONI_SERVICE_NAME}"
+
+# Refresh (charm_refresh integration)
+WORKLOAD_NAME = "PostgreSQL"
+VM_CHARM_NAME = "postgresql"
+K8S_CHARM_NAME = "postgresql-k8s"
+K8S_OCI_RESOURCE_NAME = "postgresql-image"
+LAST_REFRESH_UNIT_STATUS_FILE = ".last_refresh_unit_status.json"

--- a/single_kernel_postgresql/managers/refresh.py
+++ b/single_kernel_postgresql/managers/refresh.py
@@ -10,16 +10,34 @@ charms' 16/edge branches. It hosts the charm-specific callbacks handed to
 """
 
 import dataclasses
+import json
 import logging
-from typing import TYPE_CHECKING
+import pathlib
+import sys
+from collections.abc import Callable
+from typing import TYPE_CHECKING, cast
 
 import charm_refresh
 from charm_refresh import CharmVersion, PrecheckFailed
+from ops import ActiveStatus, MaintenanceStatus, StatusBase
+from tenacity import Retrying, stop_after_attempt, wait_fixed
 
+from single_kernel_postgresql.config.enums import Substrates
 from single_kernel_postgresql.config.exceptions import SwitchoverFailedError
+from single_kernel_postgresql.config.literals import (
+    K8S_CHARM_NAME,
+    K8S_OCI_RESOURCE_NAME,
+    LAST_REFRESH_UNIT_STATUS_FILE,
+    VM_CHARM_NAME,
+    WORKLOAD_NAME,
+)
+from single_kernel_postgresql.core.state import CharmState
+from single_kernel_postgresql.managers.base import BaseManager
+from single_kernel_postgresql.workload.base import BaseWorkload
 
 if TYPE_CHECKING:
     from single_kernel_postgresql.charms.abstract_charm import AbstractPostgreSQLCharm
+    from single_kernel_postgresql.workload.vm import VMWorkload
 
 logger = logging.getLogger(__name__)
 
@@ -107,7 +125,223 @@ class PostgreSQLRefreshK8s(PostgreSQLRefreshBase, charm_refresh.CharmSpecificKub
         self.run_pre_refresh_checks_after_1_unit_refreshed()
 
 
+@dataclasses.dataclass(eq=False)
+class PostgreSQLRefreshVM(PostgreSQLRefreshBase, charm_refresh.CharmSpecificMachines):
+    """Charm-specific refresh callbacks for the machines substrate."""
+
+    def _check_temp_tablespace_objects(self) -> None:
+        try:
+            connection = self._charm.postgresql._connect_to_database()
+            connection.autocommit = True
+            cursor = connection.cursor()
+            cursor.execute(
+                "SELECT count(*) FROM pg_class WHERE reltablespace = "
+                "(SELECT oid FROM pg_tablespace WHERE spcname = 'temp');"
+            )
+            count = cursor.fetchone()[0]
+            cursor.close()
+            connection.close()
+            if count > 0:
+                raise PrecheckFailed(
+                    f"Temp tablespace has {count} active object(s). "
+                    "Please ensure no sessions are using temp tables before refreshing."
+                )
+        except PrecheckFailed:
+            raise
+        except Exception:
+            logger.debug("Unable to check temp tablespace objects", exc_info=True)
+
+    def run_pre_refresh_checks_after_1_unit_refreshed(self) -> None:
+        """Run the temp tablespace pre-refresh check."""
+        self._check_temp_tablespace_objects()
+
+    def run_pre_refresh_checks_before_any_units_refreshed(self) -> None:
+        """Implement pre-refresh checks before any unit refreshed."""
+        for attempt in Retrying(stop=stop_after_attempt(2), wait=wait_fixed(1), reraise=True):
+            with attempt:
+                if not self._charm.patroni_manager.are_all_members_ready():
+                    raise PrecheckFailed("PostgreSQL is not running on 1+ units")
+        if self._charm.patroni_manager.is_creating_backup:
+            raise PrecheckFailed("Backup in progress")
+        self._check_temp_tablespace_objects()
+
+        # Switch primary to last unit to refresh
+
+        if self._charm.state.peer_relation is None:
+            # This should not happen since `charm_refresh.PeerRelationNotReady` should've been
+            # raised, so this code would not run
+            raise ValueError
+        all_units = (
+            unit.name for unit in (*self._charm.state.peer_relation.units, self._charm.unit)
+        )
+
+        def unit_number(unit_name: str):
+            _, number = unit_name.split("/")
+            return int(number)
+
+        # Lowest unit number is last to refresh
+        last_unit_to_refresh = sorted(all_units, key=unit_number)[0].replace("/", "-")
+        if self._charm.patroni_manager.get_primary() == last_unit_to_refresh:
+            logger.info(
+                f"Unit {last_unit_to_refresh} was already primary during pre-refresh check"
+            )
+        else:
+            try:
+                self._charm.patroni_manager.switchover(
+                    candidate=last_unit_to_refresh,
+                    async_cluster=bool(self._charm.get_async_primary_cluster_endpoint()),
+                )
+                self._charm.update_relation_endpoints()
+            except SwitchoverFailedError as e:
+                logger.warning(f"switchover failed with reason: {e}")
+                raise PrecheckFailed("Unable to switch primary") from None
+            else:
+                logger.info(
+                    f"Switched primary to unit {last_unit_to_refresh} during pre-refresh check"
+                )
+
+    def refresh_snap(
+        self, *, snap_name: str, snap_revision: str, refresh: charm_refresh.Machines
+    ) -> None:
+        """Refresh the PostgreSQL snap."""
+        # Update the configuration.
+        self._charm.set_unit_status(MaintenanceStatus("updating configuration"), refresh=refresh)
+        self._charm.update_config(refresh=refresh)
+
+        # TODO add graceful shutdown before refreshing snap?
+        # TODO future improvement: if snap refresh fails (i.e. same snap revision installed) after
+        # graceful shutdown, restart workload
+
+        self._charm.set_unit_status(MaintenanceStatus("refreshing the snap"), refresh=refresh)
+        cast("VMWorkload", self._charm.workload).install_snap_package(
+            revision=snap_revision, refresh=refresh
+        )
+
+
+class RefreshManager(BaseManager):
+    """PostgreSQL Refresh Manager.
+
+    Owns the ``charm_refresh`` integration and the refresh-aware unit status handling.
+    Status writes route through the priority gate so refresh statuses are never
+    overridden, and the collect-unit-status reconciliation keeps the cached refresh
+    status in sync with the workload state.
+    """
+
+    def __init__(
+        self,
+        state: CharmState,
+        workload: BaseWorkload,
+        charm: "AbstractPostgreSQLCharm",
+        set_default_status: Callable[[], None],
+    ) -> None:
+        super().__init__(state, workload, "refresh_manager")
+        self._charm = charm
+        self.set_default_status = set_default_status
+        self.can_set_app_status = True
+        self.refresh: charm_refresh.Machines | charm_refresh.Kubernetes | None
+        if state.substrate == Substrates.VM:
+            try:
+                self.refresh = charm_refresh.Machines(
+                    PostgreSQLRefreshVM(
+                        workload_name=WORKLOAD_NAME, charm_name=VM_CHARM_NAME, _charm=charm
+                    )
+                )
+            except (charm_refresh.UnitTearingDown, charm_refresh.PeerRelationNotReady):
+                self.refresh = None
+        else:
+            try:
+                self.refresh = charm_refresh.Kubernetes(
+                    PostgreSQLRefreshK8s(
+                        workload_name=WORKLOAD_NAME,
+                        charm_name=K8S_CHARM_NAME,
+                        oci_resource_name=K8S_OCI_RESOURCE_NAME,
+                        _charm=charm,
+                    )
+                )
+            except charm_refresh.KubernetesJujuAppNotTrusted:
+                self.refresh = None
+                self.can_set_app_status = False
+            except charm_refresh.PeerRelationNotReady:
+                self.refresh = None
+            except charm_refresh.UnitTearingDown:
+                self._charm.unit.status = MaintenanceStatus("Tearing down")
+                sys.exit()
+        self.reconcile_refresh_status()
+
+    def set_unit_status(
+        self,
+        status: StatusBase,
+        /,
+        *,
+        refresh: charm_refresh.Machines | charm_refresh.Kubernetes | None = None,
+    ) -> None:
+        """Set unit status without overriding higher priority refresh status."""
+        if refresh is None:
+            refresh = self.refresh
+        if refresh is not None and refresh.unit_status_higher_priority:
+            return
+        if (
+            isinstance(status, ActiveStatus)
+            and refresh is not None
+            and (refresh_status := refresh.unit_status_lower_priority())
+        ):
+            self._charm.unit.status = refresh_status
+            pathlib.Path(LAST_REFRESH_UNIT_STATUS_FILE).write_text(
+                json.dumps(refresh_status.message)
+            )
+            return
+        self._charm.unit.status = status
+
+    def reconcile_refresh_status(self, _=None) -> None:
+        """Reconcile the unit status with the refresh status.
+
+        Workaround for other unit statuses being set in a stateful way (i.e. unable to
+        recompute status on every event). The charms observe this on collect-unit-status;
+        do not use collect status events elsewhere - otherwise ops will prioritize
+        statuses incorrectly.
+        """
+        if self._charm.unit.is_leader():
+            self._charm.set_app_status()
+
+        path = pathlib.Path(LAST_REFRESH_UNIT_STATUS_FILE)
+        try:
+            last_refresh_unit_status = json.loads(path.read_text())
+        except FileNotFoundError:
+            last_refresh_unit_status = None
+        new_refresh_unit_status = None
+        if self.refresh is not None and self.refresh.unit_status_higher_priority:
+            self._charm.unit.status = self.refresh.unit_status_higher_priority
+            new_refresh_unit_status = self.refresh.unit_status_higher_priority.message
+        elif self._charm.unit.status.message == last_refresh_unit_status:
+            if self.refresh is not None and (
+                refresh_status := self.refresh.unit_status_lower_priority(
+                    workload_is_running=self.state.substrate == Substrates.VM
+                    or self.workload.is_patroni_running()
+                )
+            ):
+                self._charm.unit.status = refresh_status
+                new_refresh_unit_status = refresh_status.message
+            else:
+                # Clear refresh status from unit status
+                self.set_default_status()
+        elif (
+            isinstance(self._charm.unit.status, ActiveStatus)
+            and self.refresh is not None
+            and (
+                refresh_status := self.refresh.unit_status_lower_priority(
+                    workload_is_running=self.state.substrate == Substrates.VM
+                    or self.workload.is_patroni_running()
+                )
+            )
+        ):
+            self._charm.unit.status = refresh_status
+            new_refresh_unit_status = refresh_status.message
+        path.write_text(json.dumps(new_refresh_unit_status))
+
+
 __all__ = [
     "PostgreSQLRefreshBase",
     "PostgreSQLRefreshK8s",
+    "PostgreSQLRefreshVM",
+    "RefreshManager",
 ]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,12 +1,64 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import pathlib
+import shutil
 from unittest.mock import patch, sentinel
 
 import pytest
 from ops.testing import Harness
 from single_kernel_postgresql.charms import k8s_charm, vm_charm
 from single_kernel_postgresql.config.literals import PEER_RELATION
+
+
+class _MockRefresh:
+    """Stands in for charm_refresh.Machines/Kubernetes in every unit test."""
+
+    in_progress = False
+    next_unit_allowed_to_refresh = True
+    workload_allowed_to_start = True
+    app_status_higher_priority = None
+    unit_status_higher_priority = None
+
+    def __init__(self, _, /):
+        pass
+
+    def unit_status_lower_priority(self, *, workload_is_running=True):
+        return None
+
+
+@pytest.fixture(autouse=True)
+def mock_refresh(request, monkeypatch):
+    """Shunt the charm_refresh integration.
+
+    The refresh manager constructs its charm_refresh object whenever a charm is
+    instantiated, and charm_refresh reads refresh_versions.toml (pinned charm and
+    workload versions) from the working directory, which the unit environment does
+    not have. Patch the entry points and provide a minimal versions file; the file
+    is backed up and restored when one already exists.
+    """
+    monkeypatch.setattr("charm_refresh.Machines", _MockRefresh)
+    monkeypatch.setattr("charm_refresh.Kubernetes", _MockRefresh)
+
+    # Anchor on the setup-time working directory: other fixtures may chdir for the
+    # duration of a test, and the shared monkeypatch undo runs after this teardown.
+    base = pathlib.Path.cwd()
+    path = base / "refresh_versions.toml"
+    backup = base / "refresh_versions.toml.backup"
+    status_path = base / ".last_refresh_unit_status.json"
+    existed = path.exists()
+    if existed:
+        shutil.copy(path, backup)
+    # Overwrite with minimal pinned versions; tests never read the real pins (the
+    # charm_refresh entry points and the workload version getter are patched).
+    path.write_text('charm = "16/0.0.0"\nworkload = "16.0"\n')
+
+    yield
+
+    status_path.unlink(missing_ok=True)
+    path.unlink(missing_ok=True)
+    if existed:
+        shutil.move(backup, path)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Issue

Part of the refresh module migration from the PostgreSQL VM and K8s charms' 16/edge branches into this library. Stacks on #257.

## Solution

Adds the `RefreshManager`: it constructs the substrate's `charm_refresh` object (`Machines`/`Kubernetes` wrapping the charm-specific classes, including the K8s `KubernetesJujuAppNotTrusted` → `can_set_app_status = False` and `UnitTearingDown` → teardown-exit handling) and owns the refresh-aware unit status handling the two charms duplicated:

- the `set_unit_status` priority gate with the `.last_refresh_unit_status.json` caching, deduplicated onto the `workload.is_patroni_running()` check (the K8s charm passed it explicitly, the VM relied on the default), and
- the collect-unit-status reconciliation, with the clear-status branch delegated to a new `set_default_unit_status` bridge (the charms' `_set_primary_status_message`/`_set_active_status`) and the leader's app status to a `set_app_status` bridge (both owned by charm-side modules until those phases migrate).

The refresh-aware gate becomes the library's `set_unit_status` bridge, so the status writes the managers already route through the charm now respect the refresh priority interplay. `update_config` gains the `refresh` keyword the VM refresh flow threads through to the existing `ConfigManager` snap-revision gate.

Unit tests follow in #265. The conftest shunts the `charm_refresh` entry points and pins a minimal `refresh_versions.toml`, mirroring the charms' unit conftests.

