### PR TITLE
[DPE-7882] fix(logical-replication): block cyclic subscription requests (4/5)

### DIFF
--- a/single_kernel_postgresql/events/logical_replication.py
+++ b/single_kernel_postgresql/events/logical_replication.py
@@ -13,6 +13,7 @@ import json
 import logging
 
 from ops import (
+    ActiveStatus,
     BlockedStatus,
     EventBase,
     LeaderElectedEvent,
@@ -213,11 +214,8 @@ class PostgreSQLLogicalReplication(Object):
         if not self._relation_changed_checks(event):
             return
 
-        for error in json.loads(event.relation.data[event.app].get("errors", "[]")):
-            logger.error(
-                f"Got logical replication error from the publisher in {LOGICAL_REPLICATION_RELATION} #{event.relation.id}: {error}"
-            )
-            self.charm.set_unit_status(BlockedStatus(LOGICAL_REPLICATION_VALIDATION_ERROR_STATUS))
+        if not self._handle_publisher_errors(event):
+            return
 
         secret_content = self.model.get_secret(
             id=event.relation.data[event.app]["secret-id"]
@@ -294,6 +292,47 @@ class PostgreSQLLogicalReplication(Object):
 
     # region Events
 
+    def _handle_publisher_errors(self, event: RelationChangedEvent) -> bool:
+        """Surface publisher errors on the unit status; drop the stale ones.
+
+        Returns:
+            False when relation processing must stop, True to continue.
+        """
+        errors = json.loads(event.relation.data[event.app].get("errors", "[]"))
+        if not errors:
+            return True
+
+        our_request = json.loads(
+            event.relation.data[self.model.app].get("subscription-request", "{}")
+        )
+
+        # If we have a subscription-request, re-validate to check if these errors are
+        # current; _check_publisher_errors() handles the stale-error detection.
+        if our_request and self.charm.unit.is_leader():
+            logger.debug(
+                f"Publisher reported errors: {errors}. Re-validating to check if errors are current."
+            )
+            if not self._validate_subscription_request():
+                # Validation failed with current errors
+                return False
+            # Validation passed, errors were stale - continue processing
+            logger.info("Publisher errors were stale, continuing with relation processing")
+            return True
+
+        # No subscription-request yet, or not leader - process errors as-is
+        for error in errors:
+            logger.error(
+                f"Got logical replication error from the publisher in {LOGICAL_REPLICATION_RELATION} #{event.relation.id}: {error}"
+            )
+            # Set specific message for circular replication errors
+            if "circular replication" in error.lower():
+                self.charm.set_unit_status(BlockedStatus("Circular replication detected"))
+            else:
+                self.charm.set_unit_status(
+                    BlockedStatus(LOGICAL_REPLICATION_VALIDATION_ERROR_STATUS)
+                )
+        return False
+
     def _on_secret_changed(self, event: SecretChangedEvent) -> None:
         if not self.charm.unit.is_leader():
             logger.debug(
@@ -356,8 +395,22 @@ class PostgreSQLLogicalReplication(Object):
             self.state.application.data["logical-replication-validation"] = "ongoing"
             event.defer()
             return False
+        # Clear any previous error state when config changes
+        # This prevents retry_validations() from validating stale config
+        self.state.application.data["logical-replication-validation"] = "ongoing"
+
+        # Send subscription request to publisher first, before full validation
+        # This allows the publisher to detect circular replication and report errors
+        # which we can then check before doing our local validation
+        if relation := self.model.get_relation(LOGICAL_REPLICATION_RELATION):
+            relation.data[self.model.app]["subscription-request"] = (
+                self.state.config.logical_replication_subscription_request or "{}"
+            )
+
         if self._validate_subscription_request():
             self._apply_updated_subscription_request()
+            # Clear any previous blocked status from validation errors
+            self.charm.set_unit_status(ActiveStatus())
         return True
 
     def retry_validations(self) -> None:
@@ -373,6 +426,8 @@ class PostgreSQLLogicalReplication(Object):
             and self._validate_subscription_request()
         ):
             self._apply_updated_subscription_request()
+            # Clear any previous blocked status from validation errors
+            self.charm.set_unit_status(ActiveStatus())
         for relation in self.model.relations.get(LOGICAL_REPLICATION_OFFER_RELATION, ()):
             if json.loads(relation.data[self.model.app].get("errors", "[]")):
                 self._process_offer(relation)
@@ -406,6 +461,143 @@ class PostgreSQLLogicalReplication(Object):
             str(relation.id): subscriptions
         })
 
+    def _is_error_relevant_to_request(
+        self, error: str, subscription_request: dict[str, list[str]]
+    ) -> bool:
+        """Check if a publisher error is relevant to the current subscription request.
+
+        Args:
+            error: The error message from the publisher
+            subscription_request: The subscription request being validated (database -> tables)
+
+        Returns:
+            True if the error is relevant to this request, False otherwise
+        """
+        # Non-circular errors apply to the whole request
+        if "circular replication" not in error.lower():
+            return True
+
+        # For circular replication errors, check if they mention any of our tables
+        for database, tables in subscription_request.items():
+            for table in tables:
+                # Check if this specific table is mentioned in the error
+                if table in error and database in error:
+                    return True
+
+        return False
+
+    def _check_publisher_errors(
+        self, relation: Relation | None, subscription_request: dict[str, list[str]]
+    ) -> bool:
+        """Check if the publisher has reported errors for the current subscription request.
+
+        Args:
+            relation: The subscription relation
+            subscription_request: The subscription request being validated (database -> tables)
+
+        Returns:
+            True if validation should fail, False to continue validation
+        """
+        if not relation:
+            return False
+
+        publisher_errors = json.loads(relation.data[relation.app].get("errors", "[]"))
+        if not publisher_errors:
+            return False
+
+        # Check if we have the same subscription request in relation data
+        # If the request has changed, old errors may not be relevant
+        current_relation_request = json.loads(
+            relation.data[self.model.app].get("subscription-request", "{}")
+        )
+
+        # If requests don't match, publisher errors are stale - ignore them
+        # The publisher will re-validate when we update the subscription-request
+        if current_relation_request != subscription_request:
+            return False
+
+        # Filter to only errors relevant to the tables we're trying to subscribe to
+        relevant_errors = [
+            error
+            for error in publisher_errors
+            if self._is_error_relevant_to_request(error, subscription_request)
+        ]
+
+        # Only fail if we have relevant errors
+        if not relevant_errors:
+            return False
+
+        # Check if any relevant error mentions circular replication
+        for error in relevant_errors:
+            if "circular replication" in error.lower():
+                self._fail_validation(
+                    f"Publisher rejected subscription: {error}",
+                    status_msg="Circular replication detected",
+                )
+                return True
+
+        # Generic publisher error
+        self._fail_validation(f"Publisher errors: {', '.join(relevant_errors)}")
+        return True
+
+    def _validate_table_for_subscription(
+        self,
+        relation: Relation | None,
+        database: str,
+        schematable: str,
+        subscription_request_relation: dict[str, list[str]],
+    ) -> bool:
+        """Validate a single table for subscription.
+
+        Args:
+            relation: The subscription relation
+            database: The database name
+            schematable: The table name in schema.table format
+            subscription_request_relation: Current subscription request from relation data
+
+        Returns:
+            True if validation passes, False otherwise
+        """
+        try:
+            schema, table = schematable.split(".")
+        except ValueError:
+            return self._fail_validation(f"table format isn't right at {schematable}")
+
+        if not self.charm.postgresql.table_exists(database, schema, table):
+            return self._fail_validation(
+                f"table {schematable} in database {database} doesn't exist"
+            )
+
+        # Check for circular replication FIRST before checking if table is empty
+        # This is important because:
+        # 1. If we're already publishing to the remote app, we can't subscribe from them
+        # 2. The table might not be empty because of existing data (not from replication)
+        if relation and self._check_subscriber_circular_replication(
+            relation, database, schematable
+        ):
+            return self._fail_validation(
+                f"circular replication detected for table {schematable} in database {database}",
+                status_msg=f"Circular replication detected for table {schematable}",
+            )
+
+        # Also check replication chains (for multi-hop scenarios)
+        if relation and self._would_create_circular_replication(relation, database, schematable):
+            return self._fail_validation(
+                f"circular replication detected for table {schematable} in database {database}",
+                status_msg=f"Circular replication detected for table {schematable}",
+            )
+
+        already_subscribed = (
+            database in subscription_request_relation
+            and schematable in subscription_request_relation[database]
+        )
+        if not already_subscribed and not self.charm.postgresql.is_table_empty(
+            database, schema, table
+        ):
+            return self._fail_validation(f"table {schematable} in database {database} isn't empty")
+
+        return True
+
     def _validate_subscription_request(self) -> bool:
         try:
             subscription_request_config = json.loads(
@@ -415,6 +607,11 @@ class PostgreSQLLogicalReplication(Object):
             return self._fail_validation(f"JSON decode error {err}")
 
         relation = self.model.get_relation(LOGICAL_REPLICATION_RELATION)
+
+        # Check for errors from the publisher first
+        if self._check_publisher_errors(relation, subscription_request_config):
+            return False
+
         subscription_request_relation = (
             json.loads(relation.data[self.model.app].get("subscription-request", "{}"))
             if relation
@@ -425,33 +622,20 @@ class PostgreSQLLogicalReplication(Object):
             if not self.charm.postgresql.database_exists(database):
                 return self._fail_validation(f"database {database} doesn't exist")
             for schematable in schematables:
-                try:
-                    schema, table = schematable.split(".")
-                except ValueError:
-                    return self._fail_validation(f"table format isn't right at {schematable}")
-                if not self.charm.postgresql.table_exists(database, schema, table):
-                    return self._fail_validation(
-                        f"table {schematable} in database {database} doesn't exist"
-                    )
-                already_subscribed = (
-                    database in subscription_request_relation
-                    and schematable in subscription_request_relation[database]
-                )
-                if not already_subscribed and not self.charm.postgresql.is_table_empty(
-                    database, schema, table
+                if not self._validate_table_for_subscription(
+                    relation, database, schematable, subscription_request_relation
                 ):
-                    return self._fail_validation(
-                        f"table {schematable} in database {database} isn't empty"
-                    )
+                    return False
 
         self.state.application.data["logical-replication-validation"] = ""
         return True
 
-    def _fail_validation(self, message: str | None = None) -> bool:
+    def _fail_validation(self, message: str | None = None, status_msg: str | None = None) -> bool:
         if message:
             logger.error(f"Logical replication validation: {message}")
         self.state.application.data["logical-replication-validation"] = "error"
-        self.charm.set_unit_status(BlockedStatus(LOGICAL_REPLICATION_VALIDATION_ERROR_STATUS))
+        blocked_message = status_msg or LOGICAL_REPLICATION_VALIDATION_ERROR_STATUS
+        self.charm.set_unit_status(BlockedStatus(blocked_message))
         return False
 
     def _relation_changed_checks(self, event: RelationChangedEvent) -> bool:


### PR DESCRIPTION
## Issue

Fourth PR of the logical replication migration series (after #268). Completes the fix for canonical/postgresql-operator#1085: configuring the same table on both sides of the relation previously set up cyclic replication and an infinite loop of inserts; it must instead fail validation with a blocked status.

## Solution

Subscriber-side rejection of its own circular setups, before the request reaches the publisher:

- subscribing to a table this app already publishes to the same remote app fails validation (`_check_subscriber_circular_replication`),
- subscribing to a table whose remote replication chain already contains this app fails validation (`_would_create_circular_replication`, multi-hop safe),
- both surface `Circular replication detected ...` blocked statuses via `_fail_validation(status_msg=...)`.

Publisher errors reported on the relation are re-validated against the current subscription request, so stale errors no longer block relation processing, and genuine circular rejections keep the specific status message.

## Checklist
- [x] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
