### PR TITLE
feat(refresh): port the K8s refresh reconcile flow (5/6)

### DIFF
--- a/single_kernel_postgresql/charms/abstract_charm.py
+++ b/single_kernel_postgresql/charms/abstract_charm.py
@@ -98,6 +98,7 @@ class AbstractPostgreSQLCharm(CharmBase, ABC):
             self.tls_manager,
             self.config_manager,
             self.patroni_manager,
+            self.refresh_manager,
         )
 
         # Status Handler
@@ -107,6 +108,7 @@ class AbstractPostgreSQLCharm(CharmBase, ABC):
             self.tls_manager,
             self.config_manager,
             self.patroni_manager,
+            self.refresh_manager,
         )
 
     # Postgresql Client
@@ -177,7 +179,9 @@ class AbstractPostgreSQLCharm(CharmBase, ABC):
         pass
 
     @abstractmethod
-    def update_config(self) -> bool:
+    def update_config(
+        self, *, refresh: "charm_refresh.Machines | charm_refresh.Kubernetes | None" = None
+    ) -> bool:
         """Re-render the Patroni configuration and apply it."""
         pass
 
@@ -194,4 +198,23 @@ class AbstractPostgreSQLCharm(CharmBase, ABC):
         Owned by the async-replication module until that phase migrates; the refresh
         pre-refresh checks need it to decide whether a switchover crosses clusters.
         """
+        pass
+
+    @abstractmethod
+    def update_relation_endpoints(self) -> None:
+        """Refresh the client and async relation endpoints after a switchover.
+
+        Owned by the client-relation and async-replication modules until those
+        phases migrate; the VM pre-refresh checks call it after switching primary.
+        """
+        pass
+
+    @abstractmethod
+    def update_pebble_layers(self) -> None:
+        """Reconcile the workload's Pebble layers (K8s)."""
+        pass
+
+    @abstractmethod
+    def ensure_pgdata_dirs_and_symlinks(self) -> None:
+        """Create the storage directories and symlinks for the PostgreSQL data paths (K8s)."""
         pass

--- a/single_kernel_postgresql/charms/k8s_charm.py
+++ b/single_kernel_postgresql/charms/k8s_charm.py
@@ -89,7 +89,7 @@ class PostgreSQLK8sCharm(AbstractPostgreSQLCharm):
         status: StatusBase,
         /,
         *,
-        refresh: "charm_refresh.Kubernetes | None" = None,
+        refresh: "charm_refresh.Machines | charm_refresh.Kubernetes | None" = None,
     ) -> None:
         """Set the unit status without overriding a higher-priority refresh status."""
         self.refresh_manager.set_unit_status(status, refresh=refresh)
@@ -101,7 +101,9 @@ class PostgreSQLK8sCharm(AbstractPostgreSQLCharm):
     def set_app_status(self) -> None:
         """Set the application status from the async-replication state."""
 
-    def update_config(self, *, refresh: "charm_refresh.Kubernetes | None" = None) -> bool:
+    def update_config(
+        self, *, refresh: "charm_refresh.Machines | charm_refresh.Kubernetes | None" = None
+    ) -> bool:
         """Re-render the Patroni configuration and apply it."""
         return self.config_manager.update_config(self.postgresql)
 
@@ -113,3 +115,13 @@ class PostgreSQLK8sCharm(AbstractPostgreSQLCharm):
     def get_async_primary_cluster_endpoint(self) -> str | None:
         """Endpoint of the primary cluster of the async replication partner, if any."""
         return None
+
+    def update_relation_endpoints(self) -> None:
+        """Refresh the client and async relation endpoints after a switchover."""
+
+    def update_pebble_layers(self) -> None:
+        """Reconcile the workload's Pebble layers."""
+        self.k8s_manager.update_pebble_layers(replan=True)
+
+    def ensure_pgdata_dirs_and_symlinks(self) -> None:
+        """Create the storage directories and symlinks for the PostgreSQL data paths."""

--- a/single_kernel_postgresql/charms/vm_charm.py
+++ b/single_kernel_postgresql/charms/vm_charm.py
@@ -80,7 +80,7 @@ class PostgreSQLVMCharm(AbstractPostgreSQLCharm):
         status: StatusBase,
         /,
         *,
-        refresh: "charm_refresh.Machines | None" = None,
+        refresh: "charm_refresh.Machines | charm_refresh.Kubernetes | None" = None,
     ) -> None:
         """Set the unit status without overriding a higher-priority refresh status."""
         self.refresh_manager.set_unit_status(status, refresh=refresh)
@@ -92,7 +92,9 @@ class PostgreSQLVMCharm(AbstractPostgreSQLCharm):
     def set_app_status(self) -> None:
         """Set the application status from the async-replication state."""
 
-    def update_config(self, *, refresh: "charm_refresh.Machines | None" = None) -> bool:
+    def update_config(
+        self, *, refresh: "charm_refresh.Machines | charm_refresh.Kubernetes | None" = None
+    ) -> bool:
         """Re-render the Patroni configuration and apply it."""
         if refresh is None:
             refresh = self.refresh_manager.refresh
@@ -107,3 +109,12 @@ class PostgreSQLVMCharm(AbstractPostgreSQLCharm):
     def get_async_primary_cluster_endpoint(self) -> str | None:
         """Endpoint of the primary cluster of the async replication partner, if any."""
         return None
+
+    def update_relation_endpoints(self) -> None:
+        """Refresh the client and async relation endpoints after a switchover."""
+
+    def update_pebble_layers(self) -> None:
+        """Reconcile the workload's Pebble layers (K8s only)."""
+
+    def ensure_pgdata_dirs_and_symlinks(self) -> None:
+        """Create the storage directories and symlinks for the PostgreSQL data paths."""

--- a/single_kernel_postgresql/events/postgresql.py
+++ b/single_kernel_postgresql/events/postgresql.py
@@ -29,6 +29,7 @@ from single_kernel_postgresql.core.state import CharmState
 from single_kernel_postgresql.managers.cluster import ClusterManager
 from single_kernel_postgresql.managers.config import ConfigManager
 from single_kernel_postgresql.managers.patroni import PatroniManager
+from single_kernel_postgresql.managers.refresh import RefreshManager
 from single_kernel_postgresql.managers.tls import TLSManager
 from single_kernel_postgresql.workload.base import BaseWorkload
 from single_kernel_postgresql.workload.vm import VMWorkload
@@ -52,6 +53,7 @@ class PostgreSQLEventsHandler(Object):
         tls_manager: TLSManager,
         config_manager: ConfigManager,
         patroni_manager: PatroniManager,
+        refresh_manager: RefreshManager,
     ) -> None:
         super().__init__(charm, key="postgresql_events")
         self.charm = charm
@@ -61,6 +63,7 @@ class PostgreSQLEventsHandler(Object):
         self.config_manager = config_manager
         self.tls_manager = tls_manager
         self.patroni_manager = patroni_manager
+        self.refresh_manager = refresh_manager
 
         # Charm events
         self.framework.observe(self.charm.on.install, self._on_install)
@@ -125,7 +128,17 @@ class PostgreSQLEventsHandler(Object):
     def _on_postgresql_pebble_ready(self, event: WorkloadEvent) -> None:
         """Event handler for PostgreSQL container on PebbleReadyEvent."""
         charm = cast("PostgreSQLK8sCharm", self.charm)
-        # TODO: Safeguard against refresh
+        # Safeguard against starting while refreshing.
+        if self.refresh_manager.refresh is None:
+            logger.warning("Warning on_postgresql_pebble_ready: Refresh could be in progress")
+        elif (
+            self.refresh_manager.refresh.in_progress
+            and not self.refresh_manager.refresh.workload_allowed_to_start
+        ):
+            logger.debug("Defer on_postgresql_pebble_ready: Refresh in progress")
+            event.defer()
+            return
+
         if self.state.endpoint in self.state.endpoints:
             # TODO: Fix pod by adding services
             pass

--- a/single_kernel_postgresql/managers/config.py
+++ b/single_kernel_postgresql/managers/config.py
@@ -479,7 +479,7 @@ class ConfigManager(BaseManager):
         watcher_raft_address: str | None = None,
         no_peers: bool = False,
         *,
-        refresh: charm_refresh.Machines | None = None,
+        refresh: charm_refresh.Machines | charm_refresh.Kubernetes | None = None,
     ) -> bool:
         """Updates Patroni config file based on the existence of the TLS files.
 
@@ -578,7 +578,7 @@ class ConfigManager(BaseManager):
             self.state.substrate == Substrates.VM
             and refresh is not None
             and cast("VMWorkload", self.workload).get_snap_revision()
-            != refresh.pinned_snap_revision
+            != cast("charm_refresh.Machines", refresh).pinned_snap_revision
         ):
             logger.debug("Early exit: snap was not refreshed to the right version yet")
             return True

--- a/single_kernel_postgresql/managers/refresh.py
+++ b/single_kernel_postgresql/managers/refresh.py
@@ -19,8 +19,8 @@ from typing import TYPE_CHECKING, cast
 
 import charm_refresh
 from charm_refresh import CharmVersion, PrecheckFailed
-from ops import ActiveStatus, MaintenanceStatus, StatusBase
-from tenacity import Retrying, stop_after_attempt, wait_fixed
+from ops import ActiveStatus, BlockedStatus, MaintenanceStatus, StatusBase, WaitingStatus
+from tenacity import RetryError, Retrying, stop_after_attempt, wait_fixed
 
 from single_kernel_postgresql.config.enums import Substrates
 from single_kernel_postgresql.config.exceptions import SwitchoverFailedError
@@ -337,6 +337,59 @@ class RefreshManager(BaseManager):
             self._charm.unit.status = refresh_status
             new_refresh_unit_status = refresh_status.message
         path.write_text(json.dumps(new_refresh_unit_status))
+
+    # -- Kubernetes substrate: reconcile the unit state after a container refresh
+
+    def on_init(self) -> None:
+        """Resume or prepare the refresh after the charm has been initialized."""
+        refresh = self.refresh
+        if refresh is None:
+            return
+        if refresh.workload_allowed_to_start and not refresh.next_unit_allowed_to_refresh:
+            if refresh.in_progress:
+                self.reconcile()
+            else:
+                refresh.next_unit_allowed_to_refresh = True
+
+    def reconcile(self) -> None:
+        """Reconcile the unit state on refresh."""
+        self.set_unit_status(MaintenanceStatus("starting services"))
+        self._charm.ensure_pgdata_dirs_and_symlinks()
+        self._charm.update_pebble_layers()
+
+        if not self._charm.patroni_manager.member_started:
+            logger.debug("Early exit reconcile: Patroni has not started yet")
+            return
+
+        if self._charm.unit.is_leader() and not self._charm.patroni_manager.primary_endpoint_ready:
+            logger.debug(
+                "Early exit reconcile: current unit is leader but primary endpoint is not ready yet"
+            )
+            return
+
+        self.set_unit_status(WaitingStatus("waiting for database initialisation"))
+        try:
+            for attempt in Retrying(stop=stop_after_attempt(6), wait=wait_fixed(10)):
+                with attempt:
+                    if not (
+                        self._charm.unit.name.replace("/", "-")
+                        in self._charm.patroni_manager.cluster_members
+                        and self._charm.patroni_manager.is_replication_healthy()
+                    ):
+                        logger.error(
+                            "Instance not yet back in the cluster or not healthy."
+                            f" Retry {attempt.retry_state.attempt_number}/6"
+                        )
+                        raise Exception
+        except RetryError:
+            logger.debug("Upgraded unit is not part of the cluster or not healthy")
+            self.set_unit_status(
+                BlockedStatus("upgrade failed. Check logs for rollback instruction")
+            )
+        else:
+            if self.refresh is not None:
+                self.refresh.next_unit_allowed_to_refresh = True
+                self.set_unit_status(ActiveStatus())
 
 
 __all__ = [

--- a/tests/unit/test_refresh.py
+++ b/tests/unit/test_refresh.py
@@ -17,6 +17,7 @@ from single_kernel_postgresql.managers.refresh import (
     PostgreSQLRefreshK8s,
     RefreshManager,
 )
+from tenacity import RetryError
 
 CHARM_VERSION = "16/1.0.0"
 
@@ -336,3 +337,100 @@ def test_reconcile_refresh_status_ignores_unrelated_status(refresh_manager, char
 
     assert charm.unit.status == BlockedStatus("unrelated")
     refresh_manager.refresh.unit_status_lower_priority.assert_not_called()
+
+
+def test_reconcile_updates_layers_and_allows_next_unit(refresh_manager, charm):
+    charm.patroni_manager.member_started = True
+    charm.unit.is_leader.return_value = False
+    charm.unit.name = "postgresql/0"
+    charm.patroni_manager.cluster_members = {"postgresql-0"}
+    charm.patroni_manager.is_replication_healthy.return_value = True
+
+    refresh_manager.reconcile()
+
+    charm.ensure_pgdata_dirs_and_symlinks.assert_called_once()
+    charm.update_pebble_layers.assert_called_once()
+    assert refresh_manager.refresh.next_unit_allowed_to_refresh is True
+    assert charm.unit.status == ActiveStatus()
+
+
+def test_reconcile_exits_early_when_patroni_has_not_started(refresh_manager, charm):
+    charm.patroni_manager.member_started = False
+
+    refresh_manager.reconcile()
+
+    charm.ensure_pgdata_dirs_and_symlinks.assert_called_once()
+    charm.update_pebble_layers.assert_called_once()
+    charm.patroni_manager.is_replication_healthy.assert_not_called()
+
+
+def test_reconcile_exits_early_when_primary_endpoint_not_ready(refresh_manager, charm):
+    charm.patroni_manager.member_started = True
+    charm.unit.is_leader.return_value = True
+    charm.patroni_manager.primary_endpoint_ready = False
+
+    refresh_manager.reconcile()
+
+    assert charm.unit.status == MaintenanceStatus("starting services")
+
+
+def test_reconcile_blocks_when_retries_exhausted(refresh_manager, charm):
+    charm.patroni_manager.member_started = True
+    charm.unit.is_leader.return_value = False
+    charm.unit.name = "postgresql/0"
+    charm.patroni_manager.cluster_members = set()
+    refresh_manager.refresh.next_unit_allowed_to_refresh = False
+
+    with patch(
+        "single_kernel_postgresql.managers.refresh.Retrying",
+        side_effect=RetryError("last attempt"),
+    ):
+        refresh_manager.reconcile()
+
+    assert charm.unit.status == BlockedStatus(
+        "upgrade failed. Check logs for rollback instruction"
+    )
+    assert refresh_manager.refresh.next_unit_allowed_to_refresh is False
+
+
+def test_on_init_reconciles_when_in_progress(refresh_manager):
+    refresh_manager.refresh.in_progress = True
+    refresh_manager.refresh.workload_allowed_to_start = True
+    refresh_manager.refresh.next_unit_allowed_to_refresh = False
+
+    with patch.object(refresh_manager, "reconcile") as reconcile:
+        refresh_manager.on_init()
+
+    reconcile.assert_called_once()
+
+
+def test_on_init_marks_next_unit_allowed_when_not_in_progress(refresh_manager):
+    refresh_manager.refresh.in_progress = False
+    refresh_manager.refresh.workload_allowed_to_start = True
+    refresh_manager.refresh.next_unit_allowed_to_refresh = False
+
+    with patch.object(refresh_manager, "reconcile") as reconcile:
+        refresh_manager.on_init()
+
+    reconcile.assert_not_called()
+    assert refresh_manager.refresh.next_unit_allowed_to_refresh is True
+
+
+def test_on_init_noop_without_refresh_object(refresh_manager):
+    refresh_manager.refresh = None
+
+    with patch.object(refresh_manager, "reconcile") as reconcile:
+        refresh_manager.on_init()
+
+    reconcile.assert_not_called()
+
+
+def test_pebble_ready_defers_while_refresh_in_progress(harness):
+    charm = harness.charm
+    charm.refresh_manager.refresh.in_progress = True
+    charm.refresh_manager.refresh.workload_allowed_to_start = False
+    event = MagicMock()
+
+    charm.postgresql_events_handler._on_postgresql_pebble_ready(event)
+
+    event.defer.assert_called_once()


### PR DESCRIPTION
## Issue

Part of the refresh module migration from the PostgreSQL VM and K8s charms' 16/edge branches into this library. Stacks on #265 and runs in parallel with the VM post-refresh flows PR.

## Solution

Ports the K8s charm's `reconcile()`: ensure the pgdata dirs and symlinks and reconcile the Pebble layers through new charm bridges (the storage helper and layer generation stay behind those bridges until their own migration phases), wait for the member to rejoin with healthy replication, then allow the next unit to refresh - along with the charm-init resume block (`on_init`) for the Kubernetes substrate.

The pebble-ready handler gains the refresh safeguard ported from the charm: defer while a refresh is in progress and the workload is not allowed to start, with the refresh manager injected into the events handler. Note: the K8s charm referenced `is_replication_healthy` without calling it in the reconcile wait (an always-truthy bound method, so the wait only actually checked cluster membership); the library port calls the method, making the replication-health check effective. This makes the refresh resume gate stricter than 16/edge K8s: units with unhealthy replication now wait instead of proceeding.
