### PR TITLE
chore: bump library patch version to 16.3.12 (6/6)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "postgresql-charms-single-kernel"
 description = "Shared and reusable code for PostgreSQL-related charms"
-version = "16.3.7"
+version = "16.3.12"
 readme = "README.md"
 license = {file = "LICENSE"}
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1156,7 +1156,7 @@ wheels = [
 
 [[package]]
 name = "postgresql-charms-single-kernel"
-version = "16.3.7"
+version = "16.3.12"
 source = { editable = "." }
 dependencies = [
     { name = "ops", version = "2.23.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Issue

Part of the refresh module migration from the PostgreSQL VM and K8s charms' 16/edge branches into this library. This is the last PR of the series to be merged into the library, so it carries the version bump.

## Solution

Bumps the library version to 16.3.12 (from 16.3.7 on 16/edge), on top of the integration branch that merges the two parallel flow PRs (#271 VM post-refresh flows, #272 K8s reconcile flow) into #257 → #264 → #265. The charm-side migration PRs pin this commit's archive SHA.