### PR TITLE
[DPE-11198] feat(watcher): own the relation events and wire the handler (2/3)

### DIFF
--- a/single_kernel_postgresql/charms/abstract_charm.py
+++ b/single_kernel_postgresql/charms/abstract_charm.py
@@ -12,6 +12,7 @@ from single_kernel_postgresql.core.state import CharmState
 from single_kernel_postgresql.events.database import DatabaseEventsHandler
 from single_kernel_postgresql.events.postgresql import PostgreSQLEventsHandler
 from single_kernel_postgresql.events.tls import TLS
+from single_kernel_postgresql.events.watcher import WatcherEventsHandler
 from single_kernel_postgresql.lib.charms.data_platform_libs.v0.data_interfaces import (
     DatabaseProvides,
 )
@@ -62,12 +63,23 @@ class AbstractPostgreSQLCharm(CharmBase, ABC):
             self, self.state, self.database_manager, self.patroni_manager, self.tls_manager
         )
 
+        # Watcher relation handler owns the stereo-mode watcher-offer relation. Built
+        # before the config manager so it can constructor-inject it, mirroring the
+        # LDAP handler. VM-only: on K8s there is no watcher relation and the handler
+        # is inert without the metadata entry.
+        self.watcher = (
+            WatcherEventsHandler(self, self.state, self.workload, self.tls_manager)
+            if self.substrate == Substrates.VM
+            else None
+        )
+
         self.config_manager = ConfigManager(
             state=self.state,
             workload=self.workload,
             tls_manager=self.tls_manager,
             patroni_manager=self.patroni_manager,
             database_manager=self.database_manager,
+            watcher_handler=self.watcher,
             resource_provider=self.get_resource_provider,
             request_restart=self.request_restart,
             restart_services=self.restart_services,
@@ -116,7 +128,7 @@ class AbstractPostgreSQLCharm(CharmBase, ABC):
 
     # Charm-side bridges the lib calls back into. request_restart/restart_services are
     # substrate-tangled and stay until their own migration phases; update_config still
-    # supplies the ldap/async/watcher values those phases own; primary_endpoint is the
+    # supplies the ldap/async values those phases own; primary_endpoint is the
     # VM's Patroni-derived primary lookup. set_unit_status routes status writes through
     # the charm_refresh priority gate and stays until the refresh logic itself migrates
     # into the library, at which point the managers own their status writes.

--- a/single_kernel_postgresql/events/watcher.py
+++ b/single_kernel_postgresql/events/watcher.py
@@ -24,6 +24,9 @@ from functools import cached_property
 from ops import (
     Object,
     Relation,
+    RelationBrokenEvent,
+    RelationChangedEvent,
+    RelationJoinedEvent,
     Secret,
     SecretNotFoundError,
 )
@@ -69,6 +72,19 @@ class WatcherEventsHandler(Object):
         self.state = state
         self.workload = workload
         self.tls_manager = tls_manager
+
+        self.framework.observe(
+            self.charm.on[WATCHER_OFFER_RELATION].relation_joined,
+            self._on_watcher_relation_joined,
+        )
+        self.framework.observe(
+            self.charm.on[WATCHER_OFFER_RELATION].relation_changed,
+            self._on_watcher_relation_changed,
+        )
+        self.framework.observe(
+            self.charm.on[WATCHER_OFFER_RELATION].relation_broken,
+            self._on_watcher_relation_broken,
+        )
 
     @cached_property
     def _relation(self) -> Relation | None:
@@ -147,6 +163,97 @@ class WatcherEventsHandler(Object):
         if unit_address and port is not None:
             return f"{unit_address}:{port}"
         return None
+
+    def _on_watcher_relation_joined(self, event: RelationJoinedEvent) -> None:
+        """Handle a new watcher joining the relation.
+
+        Shares cluster information including Raft password and PostgreSQL endpoints
+        with the watcher charm.
+
+        Args:
+            event: The relation joined event.
+        """
+        # Every unit should publish its own per-unit data.
+        self.update_unit_address(event.relation)
+
+        if not self.charm.unit.is_leader():
+            return
+
+        logger.info("Watcher relation joined, sharing cluster information")
+
+        # Ensure watcher user exists before creating the secret,
+        # so both raft-password and watcher-password are included from the start
+        watcher_pw = self._ensure_watcher_user()
+
+        # Create or get the watcher secret containing Raft password and watcher password
+        secret = self._get_or_create_watcher_secret(watcher_password=watcher_pw)
+        if secret is None:
+            logger.warning("Failed to create watcher secret, deferring event")
+            event.defer()
+            return
+
+        # Grant the secret to the watcher application
+        try:
+            secret.grant(event.relation)
+        except Exception as e:
+            logger.warning(f"Failed to grant secret to watcher: {e}")
+
+        # Update relation data with cluster information
+        self._update_relation_data(event.relation)
+
+    def _on_watcher_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Handle watcher relation data changes.
+
+        Updates Patroni configuration to include the watcher in the Raft cluster.
+
+        Args:
+            event: The relation changed event.
+        """
+        # Keep this unit's relation data current on every relation-changed hook.
+        self.update_unit_address(event.relation)
+
+        if not self.state.application.is_cluster_initialised:
+            logger.debug("Cluster not initialized, deferring watcher relation changed")
+            event.defer()
+            return
+
+        watcher_address = None
+        for unit in event.relation.units:
+            if unit_address := event.relation.data[unit].get("unit-address"):
+                watcher_address = unit_address
+                break
+
+        if watcher_address:
+            logger.info(f"Watcher address updated: {watcher_address}")
+            # Only the leader handles Raft membership changes and user management
+            # to avoid race conditions between multiple PostgreSQL units
+            if self.charm.unit.is_leader():
+                self.charm.cleanup_raft_cluster()
+                self._ensure_watcher_user()
+            # Update Patroni configuration to include watcher in Raft
+            self.charm.update_config()
+
+        # Update relation data for the watcher
+        if self.charm.unit.is_leader():
+            self._update_relation_data(event.relation)
+
+    def _on_watcher_relation_broken(self, event: RelationBrokenEvent) -> None:
+        """Handle watcher relation being broken.
+
+         Updates Patroni configuration to remove the watcher from the Raft cluster.
+
+        Args:
+            event: The relation broken event.
+        """
+        if not self.state.application.is_cluster_initialised:
+            return
+
+        logger.info("Watcher relation broken, updating Patroni configuration")
+        self.watcher_raft_address = None
+        if self.charm.unit.is_leader():
+            self.charm.cleanup_raft_cluster()
+        # Update Patroni configuration without the watcher
+        self.charm.update_config()
 
     def _ensure_watcher_user(self) -> str | None:
         """Ensure the watcher PostgreSQL user exists for health checks.

--- a/single_kernel_postgresql/managers/config.py
+++ b/single_kernel_postgresql/managers/config.py
@@ -40,9 +40,9 @@ from single_kernel_postgresql.workload.base import BaseWorkload, ResourceProvide
 
 if TYPE_CHECKING:
     # Import-time only: the VM workload pulls the snap charm lib, which K8s does not ship.
+    from single_kernel_postgresql.events.watcher import WatcherEventsHandler
     from single_kernel_postgresql.managers.database import DatabaseManager
     from single_kernel_postgresql.workload.vm import VMWorkload
-
 logger = logging.getLogger(__name__)
 
 
@@ -62,11 +62,13 @@ class ConfigManager(BaseManager):
         resource_provider: Callable[[], ResourceProvider],
         request_restart: Callable[[], None],
         restart_services: Callable[[], None],
+        watcher_handler: "WatcherEventsHandler | None" = None,
     ):
         super().__init__(state, workload, "config_manager")
         self.tls_manager = tls_manager
         self.patroni_manager = patroni_manager
         self.database_manager = database_manager
+        self.watcher_handler = watcher_handler
         # Resolved on use, not at construction: the K8s manager that provides it is built
         # after this manager in the charm's __init__.
         self.resource_provider = resource_provider
@@ -475,8 +477,6 @@ class ConfigManager(BaseManager):
         async_primary_cluster_endpoint: str | None = None,
         async_partner_addresses: list[str] | None = None,
         async_standby_endpoints: list[str] | None = None,
-        # TODO add rel handler
-        watcher_raft_address: str | None = None,
         no_peers: bool = False,
         *,
         refresh: charm_refresh.Machines | None = None,
@@ -524,7 +524,6 @@ class ConfigManager(BaseManager):
             async_primary_cluster_endpoint=async_primary_cluster_endpoint,
             async_partner_addresses=async_partner_addresses,
             async_standby_endpoints=async_standby_endpoints,
-            watcher_raft_address=watcher_raft_address,
             no_peers=no_peers,
         )
         if no_peers:
@@ -616,8 +615,6 @@ class ConfigManager(BaseManager):
         async_primary_cluster_endpoint: str | None = None,
         async_partner_addresses: list[str] | None = None,
         async_standby_endpoints: list[str] | None = None,
-        # VM watcher rel
-        watcher_raft_address: str | None = None,
     ) -> None:
         """Render the Patroni configuration file.
 
@@ -643,7 +640,6 @@ class ConfigManager(BaseManager):
             async_primary_cluster_endpoint: Primary async cluster endpoint.
             async_standby_endpoints: Primary async cluster endpoint.
             async_partner_addresses: Primary async cluster endpoint.
-            watcher_raft_address: IP address of a related Raft watcher.
         """
         slots = slots or {}
         ldap_parameters = ldap_parameters or {}
@@ -709,7 +705,9 @@ class ConfigManager(BaseManager):
                 "self_ip": self.state.unit_ip,
                 "listen_ips": self.state.listen_ips,
                 "raft_password": self.state.application.raft_password,
-                "watcher": watcher_raft_address,
+                "watcher": self.watcher_handler.watcher_raft_address
+                if self.watcher_handler.is_active
+                else None,
             })
             perms = 0o600
         else:

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -1,5 +1,6 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
+import inspect
 from unittest.mock import ANY, MagicMock, Mock, PropertyMock, patch, sentinel
 
 import pytest
@@ -28,6 +29,7 @@ def config(substrate):
             resource_provider=Mock(),
             request_restart=Mock(),
             database_manager=Mock(),
+            watcher_handler=Mock(),
             restart_services=Mock(),
         )
     yield config
@@ -141,6 +143,9 @@ def test_render_patroni_yml_file(substrate, config):
         )
         _config.return_value.instance_password_encryption = sentinel.instance_password_encryption
         _template.return_value.render.return_value = sentinel.template_output
+        if substrate == Substrates.K8S:
+            # The VM-only watcher branch never runs on K8s: even a None handler is safe.
+            config.watcher_handler = None
 
         config.render_patroni_yml_file()
 
@@ -234,7 +239,7 @@ def test_render_patroni_yml_file(substrate, config):
                 self_ip=sentinel.unit_ip,
                 listen_ips=sentinel.listen_ips,
                 raft_password=sentinel.raft_pass,
-                watcher=None,
+                watcher=config.watcher_handler.watcher_raft_address,
             )
             _render_file.assert_called_once_with(
                 substrate,
@@ -797,6 +802,18 @@ def test_update_config_threads_tls_flag_into_render(orchestrate, postgresql_clie
     orchestrate._is_tls.return_value = False
     orchestrate.update_config(postgresql_client, no_peers=True)
     assert orchestrate.render_patroni_yml_file.call_args.kwargs["enable_tls"] is False
+
+
+def test_update_config_render_call_matches_render_signature(orchestrate, postgresql_client):
+    """Regression: update_config once forwarded the dropped watcher_raft_address kwarg.
+
+    The orchestrator fixture's plain Mock swallows unknown kwargs, so validate the
+    forwarded kwargs against render_patroni_yml_file's real signature instead.
+    """
+    orchestrate.update_config(postgresql_client, no_peers=True)
+    render_params = inspect.signature(ConfigManager.render_patroni_yml_file).parameters
+    unknown = set(orchestrate.render_patroni_yml_file.call_args.kwargs) - set(render_params)
+    assert not unknown
 
 
 def test_update_config_workload_not_running_persists_tls_and_refreshes(


### PR DESCRIPTION
## Issue

Stacks on #274.

## Solution

- Completes the ported handler with the three relation events — joined (per-unit address share, leader-only watcher user + Raft secret creation with the defer-on-failure guard, cluster-information handout), changed (cleanup + config update on watcher address change) and broken (cleanup + config update) — and the matching framework observers, exactly as in the VM charm.
- The abstract charm constructs the `WatcherEventsHandler` before the config manager on VM (inert on K8s: no construction, no watcher-offer relation in the K8s charm's metadata) and constructor-injects it, mirroring the LDAP handler wiring.
- `ConfigManager.update_config` no longer threads `watcher_raft_address` from the charm: `render_patroni_yml_file` sources the Raft address from the injected handler itself inside the VM-only render branch (`watcher_raft_address if is_active else None`, matching the charm's `watcher_offer.is_active` gate). The `watcher_raft_address` parameter is dropped from both `update_config` and `render_patroni_yml_file`; the remaining ldap/async parameters stay for their own migration phases.
- `watcher_handler` is an optional keyword (default `None`): the production charms construct `ConfigManager` directly and do not import the abstract charm, so the K8s charm keeps working unchanged at the pin bump.