### PR TITLE
feat(workload): add async-replication substrate seams (1/8)

### DIFF
--- a/single_kernel_postgresql/config/literals.py
+++ b/single_kernel_postgresql/config/literals.py
@@ -37,6 +37,8 @@ VM_TEMP_PATH = "data/temp"
 
 ## K8s Paths
 K8S_DATA_PATH = "var/lib/pg/data"
+K8S_ARCHIVE_PATH = "var/lib/pg/archive"
+K8S_TEMP_STORAGE_PATH = "var/lib/pg/temp"
 
 ## Shared Paths
 # NOTE: The paths don't have leading slahes since pathops
@@ -125,6 +127,10 @@ ALL_CLIENT_RELATIONS = [DATABASE]
 REPLICATION_CONSUMER_RELATION = "replication"
 REPLICATION_OFFER_RELATION = "replication-offer"
 
+# Async replication peer-data key holding the id of the labelless shared cluster-credentials
+# secret the owner persists: referenced by id everywhere, never by label (DPE-10203).
+ASYNC_SHARED_SECRET_ID_KEY = "async-replication-secret-id"  # noqa: S105 — a databag key name, not a credential
+
 # TLS files
 TLS_KEY_FILE = "key.pem"
 TLS_CA_FILE = "ca.pem"
@@ -134,7 +140,6 @@ TLS_CERT_FILE = "cert.pem"
 METRICS_PORT = "9187"
 PGBACKREST_METRICS_PORT = "9854"
 
-# Secret/database mapping labels
 USERNAME_MAPPING_LABEL = "custom-usernames"
 DATABASE_MAPPING_LABEL = "prefix-databases"
 

--- a/single_kernel_postgresql/core/peer_relation.py
+++ b/single_kernel_postgresql/core/peer_relation.py
@@ -9,7 +9,7 @@ import json
 from collections.abc import MutableMapping
 from functools import cached_property
 
-from ops import Application, BlockedStatus, Relation, Unit
+from ops import Application, BlockedStatus, ModelError, Relation, Unit
 
 from single_kernel_postgresql.config.enums import Substrates
 from single_kernel_postgresql.config.literals import (
@@ -410,8 +410,17 @@ class PostgreSQLApplication(RelationState):
 
     @cached_property
     def planned_units(self) -> int:
-        """Get the number of planned units for the application."""
-        return self.app.planned_units()
+        """Get the number of planned units for the application.
+
+        ops implements ``Application.planned_units()`` via ``goal-state``, which fails
+        ("saas application ... not found") while a cross-model SAAS force-removed during a
+        dead-DC teardown still lingers in goal-state. Fall back to the count of currently
+        known units so the hook reconciles instead of crashing every caller (DPE-10203).
+        """
+        try:
+            return self.app.planned_units()
+        except ModelError:
+            return len(self.relation.units) + 1 if self.relation else 1
 
     @property
     def members_ips(self) -> set[str]:

--- a/single_kernel_postgresql/managers/k8s.py
+++ b/single_kernel_postgresql/managers/k8s.py
@@ -8,13 +8,14 @@ This managers is responsible for handling operations related to Kubernetes,
 such as interacting with the Kubernetes API and also configuring Pebble to work with Kubernetes.
 """
 
+import itertools
 import logging
 
 from data_platform_helpers.advanced_statuses import StatusObject
 from data_platform_helpers.advanced_statuses.types import Scope as AdvancedStatusesScope
 from lightkube import Client
 from lightkube.core.exceptions import ApiError
-from lightkube.resources.core_v1 import Node, Pod
+from lightkube.resources.core_v1 import Endpoints, Node, Pod, Service
 from ops.pebble import CheckDict, Layer, LayerDict, ServiceDict
 
 from single_kernel_postgresql.config.exceptions import DeployedWithoutTrustError
@@ -66,6 +67,27 @@ class K8sManager(BaseManager):
         if pod.spec and pod.spec.nodeName:
             return pod.spec.nodeName
         raise RuntimeError("Pod doesn't exist")
+
+    def delete_patroni_cluster_resources(self) -> None:
+        """Delete the Patroni Endpoints and Services left by a previous cluster."""
+        client = Client()
+        name = f"patroni-{self.state.model.app.name}"
+        for values in itertools.product(
+            [Endpoints, Service],
+            [name, f"{name}-config", f"{name}-sync"],
+        ):
+            try:
+                client.delete(
+                    values[0],
+                    name=values[1],
+                    namespace=self.state.model_name,
+                )
+                logger.debug(f"Deleted {values[0]} {values[1]}")
+            except ApiError as e:
+                # Ignore the error only when the resource doesn't exist.
+                if e.status.code != 404:
+                    raise e
+                logger.debug(f"{values[0]} {values[1]} not found")
 
     def get_resources_limits(self, container_name: str) -> dict:
         """Return resources limits for a given container.

--- a/single_kernel_postgresql/workload/base.py
+++ b/single_kernel_postgresql/workload/base.py
@@ -269,6 +269,21 @@ class BaseWorkload(ABC):
         pass
 
     @abstractmethod
+    def get_system_identifier(self) -> tuple[str | None, str | None]:
+        """Return the PostgreSQL system identifier of this instance, or an error."""
+        pass
+
+    @abstractmethod
+    def create_data_backup_tarball(self) -> str:
+        """Store the current data folder in a tar.gz file and return its name."""
+        pass
+
+    @abstractmethod
+    def clear_data_directories(self) -> None:
+        """Empty the data, archive, logs and temp directories."""
+        pass
+
+    @abstractmethod
     def get_workload_version(self) -> str:
         """Get the workload version."""
         raise NotImplementedError

--- a/single_kernel_postgresql/workload/k8s.py
+++ b/single_kernel_postgresql/workload/k8s.py
@@ -7,18 +7,21 @@ import logging
 import uuid
 from collections.abc import Generator
 from contextlib import contextmanager
+from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 
 from charmlibs import pathops
 from charmlibs.pathops import PathProtocol
 from ops import Container, ModelError
-from ops.pebble import Plan, ServiceStatus
+from ops.pebble import ChangeError, Plan, ServiceStatus
 
 from single_kernel_postgresql.config.exceptions import PostgreSQLFileOperationError
 from single_kernel_postgresql.config.literals import (
     DIR_PERMISSIONS_READONLY,
     K8S_POSTGRESQL_SERVICE_NAME,
+    K8S_WORKLOAD_OS_GROUP,
+    K8S_WORKLOAD_OS_USER,
 )
 from single_kernel_postgresql.workload.base import BaseWorkload
 from single_kernel_postgresql.workload.paths.base import Paths as BasePaths
@@ -102,12 +105,59 @@ class K8sWorkload(BaseWorkload):
         raise NotImplementedError
 
     def stop(self) -> None:
-        """Stop the PostgreSQL service."""
-        ...
+        """Stop the PostgreSQL pebble service."""
+        self.container.stop(K8S_POSTGRESQL_SERVICE_NAME)
 
     def start_service(self):
-        """Start the PostgreSQL service."""
-        ...
+        """Start the PostgreSQL pebble service."""
+        self.container.start(K8S_POSTGRESQL_SERVICE_NAME)
+
+    def postgresql_service_registered(self) -> bool:
+        """Whether the container is connected and the postgresql service exists."""
+        if not self.container.can_connect():
+            return False
+        services = self.container.pebble.get_services(names=[K8S_POSTGRESQL_SERVICE_NAME])
+        return len(services) > 0
+
+    def get_system_identifier(self) -> tuple[str | None, str | None]:
+        """Returns the PostgreSQL system identifier from this instance."""
+        major_version = self.get_postgresql_version().split(".")[0]
+        try:
+            system_identifier, error = self.container.exec(
+                [
+                    f"/usr/lib/postgresql/{major_version}/bin/pg_controldata",
+                    str(self.paths.data),
+                ],
+                user=K8S_WORKLOAD_OS_USER,
+                group=K8S_WORKLOAD_OS_GROUP,
+            ).wait_output()
+        except ChangeError as e:
+            return None, str(e)
+        if error != "":
+            return None, error
+        system_identifier = next(
+            line for line in system_identifier.splitlines() if "Database system identifier" in line
+        ).split(" ")[-1]
+        return system_identifier, None
+
+    def create_data_backup_tarball(self) -> str:
+        """Store the current pgdata folder in a tar.gz file and return its name."""
+        filename = (
+            f"{self.paths.data}-{str(datetime.now()).replace(' ', '-').replace(':', '-')}.tar.gz"
+        )
+        self.container.exec(f"tar -zcf {filename} {self.paths.data}".split()).wait_output()
+        return filename
+
+    def clear_data_directories(self) -> None:
+        """Remove the contents of the data directories to enable replication."""
+        for path in [
+            self.paths.archive,
+            self.paths.data,
+            self.paths.logs,
+            self.paths.temp_storage,
+        ]:
+            logger.info(f"Removing contents from {path}")
+            self.container.exec(["find", str(path), "-mindepth", "1", "-delete"]).wait_output()
 
     def get_workload_version(self) -> str:
         """Get the workload version."""

--- a/single_kernel_postgresql/workload/paths/base.py
+++ b/single_kernel_postgresql/workload/paths/base.py
@@ -61,6 +61,18 @@ class Paths(ABC):
 
     @property
     @abstractmethod
+    def archive(self) -> PathProtocol:
+        """Path to the archive folder of PostgreSQL."""
+        pass
+
+    @property
+    @abstractmethod
+    def temp_storage(self) -> PathProtocol:
+        """Path to the temp storage root."""
+        pass
+
+    @property
+    @abstractmethod
     def postgresql_conf(self) -> PathProtocol:
         """Path to the postgresql.conf file."""
         pass

--- a/single_kernel_postgresql/workload/paths/k8s.py
+++ b/single_kernel_postgresql/workload/paths/k8s.py
@@ -5,7 +5,9 @@
 from charmlibs.pathops import PathProtocol
 
 from single_kernel_postgresql.config.literals import (
+    K8S_ARCHIVE_PATH,
     K8S_DATA_PATH,
+    K8S_TEMP_STORAGE_PATH,
     PATRONI_LOGS_PATH,
     PGBACKREST_CONF_PATH,
     POSTGRESQL_CONF_FILE,
@@ -52,6 +54,16 @@ class K8sPaths(Paths):
     def temp(self) -> PathProtocol:
         """Path to the temporary directory."""
         return self.root / "tmp"
+
+    @property
+    def archive(self) -> PathProtocol:
+        """Path to the archive storage root."""
+        return self.root / K8S_ARCHIVE_PATH
+
+    @property
+    def temp_storage(self) -> PathProtocol:
+        """Path to the temp storage root."""
+        return self.root / K8S_TEMP_STORAGE_PATH
 
     @property
     def postgresql_conf(self) -> PathProtocol:

--- a/single_kernel_postgresql/workload/paths/vm.py
+++ b/single_kernel_postgresql/workload/paths/vm.py
@@ -14,6 +14,7 @@ from single_kernel_postgresql.config.literals import (
     SNAP,
     SNAP_COMMON,
     SNAP_DATA,
+    VM_ARCHIVE_PATH,
     VM_DATA_LOGS_PATH,
     VM_DATA_PATH,
     VM_LOGS_PATH,
@@ -103,6 +104,16 @@ class VMPaths(Paths):
     def temp(self) -> PathProtocol:
         """Path to the temporary directory."""
         return self.snap_common / VM_TEMP_PATH / self.versioned_path
+
+    @property
+    def archive(self) -> PathProtocol:
+        """Path to the archive folder of PostgreSQL."""
+        return self.snap_common / VM_ARCHIVE_PATH / self.versioned_path
+
+    @property
+    def temp_storage(self) -> PathProtocol:
+        """Path to the temp storage root."""
+        return self.snap_common / VM_TEMP_PATH
 
     @property
     def pgbackrest_conf(self) -> PathProtocol:

--- a/single_kernel_postgresql/workload/vm.py
+++ b/single_kernel_postgresql/workload/vm.py
@@ -7,11 +7,15 @@ import logging
 import os
 import pathlib
 import platform
+import pwd
+import shutil
 import subprocess
 import tempfile
 from collections.abc import Generator
 from contextlib import contextmanager
+from datetime import datetime
 from pathlib import Path
+from subprocess import run
 from types import SimpleNamespace
 
 import charm_refresh
@@ -19,6 +23,7 @@ import tomli
 from charmlibs import pathops, snap
 from charmlibs.pathops import PathProtocol
 
+from single_kernel_postgresql.config.literals import SNAP, SNAP_USER
 from single_kernel_postgresql.workload.base import BaseWorkload
 from single_kernel_postgresql.workload.paths.base import Paths as BasePaths
 from single_kernel_postgresql.workload.paths.vm import VMPaths
@@ -152,6 +157,80 @@ class VMWorkload(BaseWorkload):
     def start_service(self):
         """Start the PostgreSQL service."""
         ...
+
+    def get_system_identifier(self) -> tuple[str | None, str | None]:
+        """Returns the PostgreSQL system identifier from this instance."""
+
+        def demote():
+            pw_record = pwd.getpwnam(SNAP_USER)
+
+            def result():
+                os.setgid(pw_record.pw_gid)
+                os.setuid(pw_record.pw_uid)
+
+            return result
+
+        major_version = self.get_postgresql_version().split(".")[0]
+        # Input is hardcoded
+        process = run(  # noqa: S603
+            [
+                f"{SNAP}/usr/lib/postgresql/{major_version}/bin/pg_controldata",
+                str(self.paths.data),
+            ],
+            capture_output=True,
+            preexec_fn=demote(),
+        )
+        if process.returncode != 0:
+            return None, process.stderr.decode()
+        system_identifier = next(
+            line
+            for line in process.stdout.decode().splitlines()
+            if "Database system identifier" in line
+        ).split(" ")[-1]
+        return system_identifier, None
+
+    def create_data_backup_tarball(self) -> str:
+        """Store the current data folder in a tar.gz file and return its name."""
+        filename = (
+            f"{self.paths.data.parent}-"
+            f"{str(datetime.now()).replace(' ', '-').replace(':', '-')}.tar.gz"
+        )
+        # Input is hardcoded
+        subprocess.check_call(f"tar -zcf {filename} {self.paths.data}".split())  # noqa: S603
+        return filename
+
+    def clear_data_directories(self) -> None:
+        """Remove the contents of the data directories to initialise a new cluster."""
+        paths = [
+            self.paths.archive,
+            self.paths.data,
+            self.paths.wal,
+            self.paths.temp,
+        ]
+        path = None
+        try:
+            for path in paths:
+                path_object = Path(str(path))
+                if path_object.exists() and path_object.is_dir():
+                    for item in os.listdir(path_object):
+                        item_path = os.path.join(path_object, item)
+                        if os.path.isfile(item_path) or os.path.islink(item_path):
+                            os.remove(item_path)
+                        elif os.path.isdir(item_path):
+                            shutil.rmtree(item_path)
+        except OSError as e:
+            raise Exception(f"Failed to remove contents from {path} with error: {e!s}") from e
+
+    def remove_raft_state(self) -> None:
+        """Remove previous cluster information to make it possible to initialise a new cluster."""
+        try:
+            path = Path(f"{self.paths.patroni_conf}/raft")
+            if path.exists() and path.is_dir():
+                shutil.rmtree(path)
+        except OSError as e:
+            raise Exception(
+                f"Failed to remove previous cluster information with error: {e!s}"
+            ) from e
 
     def get_workload_version(self) -> str:
         """Get the workload version."""


### PR DESCRIPTION
## Issue

Prepares the async-replication module migration (VM charm @ 03494fb7b7, K8s charm @ dec4b9602d, plus the DPE-10203 dead-datacenter recovery from canonical/postgresql-operator#1913) by adding the substrate seams the module needs. Part 1/8 of a stacked series; each slice stays under the 500-LOC review target.

## Solution

- `BaseWorkload`: abstract `get_system_identifier()`, `create_data_backup_tarball()` and `clear_data_directories()`.
- `VMWorkload`: `pg_controldata` run demoted to `_daemon_` (as the VM charm module did), the tar backup of the data dir, content-clearing of the archive/data/logs/temp dirs, and the VM-only `remove_raft_state()`.
- `K8sWorkload`: container `exec` variants of the above, plus real `stop()`/`start_service()` pebble service control (previously no-op placeholders) and `postgresql_service_registered()`.
- Paths: `archive` on both substrates (versioned on VM, storage root on K8s) and `temp_storage` (`/var/lib/pg/temp` on K8s), matching the charms' constants exactly.
- `K8sManager.delete_patroni_cluster_resources()`: the lightkube Endpoints/Service deletion from the K8s module's `_remove_previous_cluster_information`.
- `PostgreSQLApplication.planned_units`: ModelError fallback to the count of currently known units — `goal-state` fails while a cross-model SAAS force-removed during a dead-DC teardown still lingers (DPE-10203, from #1913).

Deliberate divergences: none behaviorally; `remove_raft_state` is VM-only instead of a base no-op so the K8s substrate never imports VM paths.
