### PR TITLE
feat(charms): wire the async replication subsystem into the charm composition root (5/8)

### DIFF
--- a/single_kernel_postgresql/charms/abstract_charm.py
+++ b/single_kernel_postgresql/charms/abstract_charm.py
@@ -3,18 +3,21 @@
 """Skeleton for the abstract charm."""
 
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, cast
 
 from data_platform_helpers.advanced_statuses import StatusHandler
 from ops import StatusBase
 from ops.charm import CharmBase
 
 from single_kernel_postgresql.core.state import CharmState
+from single_kernel_postgresql.events.async_replication import PostgreSQLAsyncReplication
 from single_kernel_postgresql.events.database import DatabaseEventsHandler
 from single_kernel_postgresql.events.postgresql import PostgreSQLEventsHandler
 from single_kernel_postgresql.events.tls import TLS
 from single_kernel_postgresql.lib.charms.data_platform_libs.v0.data_interfaces import (
     DatabaseProvides,
 )
+from single_kernel_postgresql.managers.async_replication import AsyncReplicationManager
 from single_kernel_postgresql.managers.cluster import ClusterManager
 from single_kernel_postgresql.managers.config import ConfigManager
 from single_kernel_postgresql.managers.database import DatabaseManager
@@ -25,6 +28,9 @@ from single_kernel_postgresql.workload.base import BaseWorkload, ResourceProvide
 from ..config.enums import Substrates
 from ..config.literals import DATABASE
 from ..utils.postgresql import PostgreSQL
+
+if TYPE_CHECKING:
+    from single_kernel_postgresql.workload.k8s import K8sWorkload
 
 
 class AbstractPostgreSQLCharm(CharmBase, ABC):
@@ -49,6 +55,36 @@ class AbstractPostgreSQLCharm(CharmBase, ABC):
         )
         self.patroni_manager = PatroniManager(state=self.state, workload=self.workload)
         self.cluster_manager = ClusterManager(state=self.state, workload=self.workload)
+
+        # Substrate-only K8s API seam, injected into the handlers that need it; built
+        # here so the async-replication handler (below) can consume it.
+        if self.substrate == Substrates.K8S:
+            from single_kernel_postgresql.managers.k8s import K8sManager
+
+            # The K8s substrate asserts a K8sWorkload in PostgreSQLK8sCharm.
+            self.k8s_manager: K8sManager | None = K8sManager(
+                self.state,
+                cast("K8sWorkload", self.workload),
+            )
+        else:
+            self.k8s_manager = None
+
+        # Async-replication subsystem: the manager owns the data plane (counters,
+        # endpoints, secrets); the handler owns the observers and the standby lifecycle.
+        self.async_replication_manager = AsyncReplicationManager(
+            state=self.state,
+            workload=self.workload,
+            patroni_manager=self.patroni_manager,
+            update_config=self.update_config,
+        )
+        self.async_replication = PostgreSQLAsyncReplication(
+            self,
+            self.state,
+            self.async_replication_manager,
+            self.patroni_manager,
+            self.workload,
+            k8s_manager=self.k8s_manager,
+        )
 
         # Client-relation subsystem: the charm is the composition root, as with the
         # other managers; the handler owns only the observers and guard/defer decisions.
@@ -133,6 +169,16 @@ class AbstractPostgreSQLCharm(CharmBase, ABC):
     @abstractmethod
     def restart_services(self) -> None:
         """Restart the monitoring and LDAP-sync sidecar services."""
+        pass
+
+    @abstractmethod
+    def set_app_status(self, status: StatusBase) -> None:
+        """Set the application status through the charm's own status gates."""
+        pass
+
+    @abstractmethod
+    def set_primary_status_message(self) -> None:
+        """Recompute the unit's primary/standby status message."""
         pass
 
     @abstractmethod

--- a/single_kernel_postgresql/charms/k8s_charm.py
+++ b/single_kernel_postgresql/charms/k8s_charm.py
@@ -27,7 +27,8 @@ class PostgreSQLK8sCharm(AbstractPostgreSQLCharm):
         assert isinstance(self.workload, K8sWorkload), (  # noqa: S101
             "Workload must be an instance of K8sWorkload"
         )
-        self.k8s_manager = K8sManager(self.state, self.workload)
+
+        # The abstract charm builds self.k8s_manager and the async-replication handler.
 
     @property
     def postgresql(self) -> PostgreSQL:
@@ -72,6 +73,7 @@ class PostgreSQLK8sCharm(AbstractPostgreSQLCharm):
     # config re-render), so they are minimal here.
     def get_resource_provider(self) -> K8sManager:
         """Return the substrate's (cpu_cores, memory_bytes) introspector."""
+        assert self.k8s_manager is not None  # noqa: S101
         return self.k8s_manager
 
     def request_restart(self) -> None:
@@ -87,6 +89,20 @@ class PostgreSQLK8sCharm(AbstractPostgreSQLCharm):
     def update_config(self) -> bool:
         """Re-render the Patroni configuration and apply it."""
         return self.config_manager.update_config(self.postgresql)
+
+    def set_app_status(self, status: StatusBase) -> None:
+        """Set the application status; the production charm gates this on its own state."""
+        self.app.status = status
+
+    def set_primary_status_message(self) -> None:
+        """Recompute the unit's primary/standby status message."""
+
+    def fix_leader_annotation(self) -> bool:
+        """Fix the leader annotation; the production charm owns the real implementation."""
+        return False
+
+    def create_pgdata(self) -> None:
+        """Create the PostgreSQL data directories; the production charm owns the real body."""
 
     @property
     def primary_endpoint(self) -> str | None:

--- a/single_kernel_postgresql/charms/vm_charm.py
+++ b/single_kernel_postgresql/charms/vm_charm.py
@@ -79,6 +79,13 @@ class PostgreSQLVMCharm(AbstractPostgreSQLCharm):
         """Re-render the Patroni configuration and apply it."""
         return self.config_manager.update_config(self.postgresql)
 
+    def set_app_status(self, status: StatusBase) -> None:
+        """Set the application status; the production charm gates this on its own state."""
+        self.app.status = status
+
+    def set_primary_status_message(self) -> None:
+        """Recompute the unit's primary/standby status message."""
+
     @property
     def primary_endpoint(self) -> str | None:
         """Address of the cluster primary, or None when there is not one."""

--- a/single_kernel_postgresql/events/postgresql.py
+++ b/single_kernel_postgresql/events/postgresql.py
@@ -152,7 +152,8 @@ class PostgreSQLEventsHandler(Object):
             self.tls_manager.configure_internal_peer_cert()
 
         # Start the database service
-        charm.k8s_manager.update_pebble_layers()
+        if charm.k8s_manager is not None:
+            charm.k8s_manager.update_pebble_layers()
 
         # Assert the member is up and running before marking it as initialised.
         if not self.patroni_manager.member_started:


### PR DESCRIPTION
## Issue

Connects the ported subsystem to the composition root, mirroring how the LDAP and database modules are wired.

## Solution

- `AbstractPostgreSQLCharm` constructs `K8sManager` (K8s substrate only, lazy import so the VM import graph never pulls lightkube), `AsyncReplicationManager` and `PostgreSQLAsyncReplication`; the `k8s_manager` construction moves out of `PostgreSQLK8sCharm`.
- New charm bridges: `set_app_status(status)` (the production charms keep their refresh-priority/`can_set_app_status` gates behind it) and `set_primary_status_message()` (the VM `_set_primary_status_message` / K8s `_set_active_status` equivalents); minimal implementations in the library's VM/K8s charms plus K8s-only `fix_leader_annotation`/`create_pgdata` stubs.
- `events/postgresql.py` guards the pre-existing `charm.k8s_manager.update_pebble_layers()` call against the now-Optional manager.
