### PR TITLE
chore: bump library patch version to 16.3.13 (8/8)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "postgresql-charms-single-kernel"
 description = "Shared and reusable code for PostgreSQL-related charms"
-version = "16.3.7"
+version = "16.3.13"
 readme = "README.md"
 license = {file = "LICENSE"}
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1156,7 +1156,7 @@ wheels = [
 
 [[package]]
 name = "postgresql-charms-single-kernel"
-version = "16.3.7"
+version = "16.3.13"
 source = { editable = "." }
 dependencies = [
     { name = "ops", version = "2.23.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Issue

Final slice of the async-replication migration stack; the charm adoption PRs pin an archive URL of this stack's head, so the library needs its new patch version.

## Solution

Bumps the library version to 16.3.13.
